### PR TITLE
Improve: タイムスタンプ正規化画面のページネーション機能を強化

### DIFF
--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -13,6 +13,7 @@ class TimestampNormalization {
         this.selectedSong = null;
         this.selectedSpotifyTrack = null; // Spotify選択楽曲情報
         this.currentPage = 1;
+        this.currentSearchQuery = ''; // 検索条件を保持
         this.searchTimeout = null;
         this.unlinkedOnly = false;
 
@@ -39,8 +40,9 @@ class TimestampNormalization {
         // タイムスタンプ検索
         document.getElementById('timestampSearch').addEventListener('input', (e) => {
             clearTimeout(this.searchTimeout);
+            this.currentSearchQuery = e.target.value;
             this.searchTimeout = setTimeout(() => {
-                this.loadTimestamps(1, e.target.value);
+                this.loadTimestamps(1, this.currentSearchQuery);
             }, 500);
         });
 
@@ -55,7 +57,7 @@ class TimestampNormalization {
                 btn.classList.remove('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
                 btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
             }
-            this.loadTimestamps(1);
+            this.loadTimestamps(1, this.currentSearchQuery);
         });
 
         // 全選択・全選択解除
@@ -87,7 +89,7 @@ class TimestampNormalization {
 
         // 更新ボタン
         document.getElementById('refreshTimestampsBtn').addEventListener('click', () => {
-            this.loadTimestamps(this.currentPage);
+            this.loadTimestamps(this.currentPage, this.currentSearchQuery);
         });
 
         // 楽曲マスタ一覧表示
@@ -152,7 +154,8 @@ class TimestampNormalization {
                 }
             });
 
-            this.currentPage = response.data.current_page;
+            const parsedPage = parseInt(response.data.current_page, 10);
+            this.currentPage = Number.isNaN(parsedPage) ? 1 : parsedPage;
             this.displayTimestamps(response.data.data);
             this.displayPagination(response.data);
         } catch (error) {
@@ -276,29 +279,67 @@ class TimestampNormalization {
 
         if (data.last_page <= 1) return;
 
-        // 前へボタン
-        if (data.current_page > 1) {
-            const prevBtn = document.createElement('button');
-            prevBtn.textContent = '前へ';
-            prevBtn.className = 'px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600';
-            prevBtn.addEventListener('click', () => this.loadTimestamps(data.current_page - 1));
-            container.appendChild(prevBtn);
+        const currentPage = parseInt(data.current_page, 10);
+        const lastPage = parseInt(data.last_page, 10);
+
+        // バリデーション
+        if (Number.isNaN(currentPage) || Number.isNaN(lastPage)) {
+            console.error('Invalid page numbers:', { currentPage, lastPage });
+            return;
         }
+
+        // ボタンのスタイル
+        const btnClass = 'px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 text-sm';
+        const disabledBtnClass = 'px-3 py-1 bg-gray-100 dark:bg-gray-800 rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed text-sm';
+
+        // ボタン作成ヘルパー関数
+        const createButton = (label, targetPage, isEnabled) => {
+            const btn = document.createElement('button');
+            btn.textContent = label;
+            btn.className = isEnabled ? btnClass : disabledBtnClass;
+            btn.disabled = !isEnabled;
+
+            if (isEnabled) {
+                btn.addEventListener('click', () => this.loadTimestamps(targetPage, this.currentSearchQuery));
+            }
+
+            return btn;
+        };
+
+        // ボタン定義
+        const buttons = [
+            { label: '最初', targetPage: 1, showCondition: true, enableCondition: currentPage > 1 },
+            { label: '-10', targetPage: currentPage - 10, showCondition: true, enableCondition: currentPage > 10 },
+            { label: '-5', targetPage: currentPage - 5, showCondition: true, enableCondition: currentPage > 5 },
+            { label: '前へ', targetPage: currentPage - 1, showCondition: true, enableCondition: currentPage > 1 },
+        ];
+
+        // ボタンを追加
+        buttons.forEach(({ label, targetPage, showCondition, enableCondition }) => {
+            if (showCondition) {
+                container.appendChild(createButton(label, targetPage, enableCondition));
+            }
+        });
 
         // ページ情報
         const pageInfo = document.createElement('span');
-        pageInfo.textContent = `${data.current_page} / ${data.last_page}`;
-        pageInfo.className = 'px-3 py-1 text-sm';
+        pageInfo.textContent = `${currentPage} / ${lastPage}`;
+        pageInfo.className = 'px-3 py-1 text-sm font-medium';
         container.appendChild(pageInfo);
 
-        // 次へボタン
-        if (data.current_page < data.last_page) {
-            const nextBtn = document.createElement('button');
-            nextBtn.textContent = '次へ';
-            nextBtn.className = 'px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600';
-            nextBtn.addEventListener('click', () => this.loadTimestamps(data.current_page + 1));
-            container.appendChild(nextBtn);
-        }
+        // 次へ系のボタン
+        const nextButtons = [
+            { label: '次へ', targetPage: currentPage + 1, showCondition: true, enableCondition: currentPage < lastPage },
+            { label: '+5', targetPage: currentPage + 5, showCondition: true, enableCondition: currentPage + 5 <= lastPage },
+            { label: '+10', targetPage: currentPage + 10, showCondition: true, enableCondition: currentPage + 10 <= lastPage },
+            { label: '最後', targetPage: lastPage, showCondition: true, enableCondition: currentPage < lastPage },
+        ];
+
+        nextButtons.forEach(({ label, targetPage, showCondition, enableCondition }) => {
+            if (showCondition) {
+                container.appendChild(createButton(label, targetPage, enableCondition));
+            }
+        });
     }
 
     toggleTimestampSelection(timestamp) {
@@ -311,7 +352,7 @@ class TimestampNormalization {
         }
 
         this.updateSelectionDisplay();
-        this.loadTimestamps(this.currentPage);
+        this.loadTimestamps(this.currentPage, this.currentSearchQuery);
 
         // 最初のタイムスタンプが選択された時、Spotify検索窓に反映
         if (this.selectedTimestamps.length === 1) {
@@ -333,7 +374,7 @@ class TimestampNormalization {
     deselectAll() {
         this.selectedTimestamps = [];
         this.updateSelectionDisplay();
-        this.loadTimestamps(this.currentPage);
+        this.loadTimestamps(this.currentPage, this.currentSearchQuery);
     }
 
     updateSelectionDisplay() {
@@ -408,7 +449,7 @@ class TimestampNormalization {
         this.selectedSong = null;
         this.selectedSpotifyTrack = null;
         this.updateSelectionDisplay();
-        this.loadTimestamps(this.currentPage);
+        this.loadTimestamps(this.currentPage, this.currentSearchQuery);
     }
 
     async searchSpotify() {
@@ -778,7 +819,7 @@ class TimestampNormalization {
             await axios.delete(`/api/songs/${songId}`);
             alert('楽曲マスタを削除しました。');
             await this.loadSongs();
-            await this.loadTimestamps(this.currentPage);
+            await this.loadTimestamps(this.currentPage, this.currentSearchQuery);
 
             if (this.selectedSong?.id === songId) {
                 this.selectedSong = null;
@@ -824,7 +865,7 @@ class TimestampNormalization {
                 btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
             }
 
-            await this.loadTimestamps(this.currentPage);
+            await this.loadTimestamps(this.currentPage, this.currentSearchQuery);
             this.updateSelectionDisplay();
         } catch (error) {
             console.error('紐づけに失敗しました:', error);
@@ -864,7 +905,7 @@ class TimestampNormalization {
                 btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
             }
 
-            await this.loadTimestamps(this.currentPage);
+            await this.loadTimestamps(this.currentPage, this.currentSearchQuery);
             this.updateSelectionDisplay();
         } catch (error) {
             console.error('マークに失敗しました:', error);
@@ -900,7 +941,7 @@ class TimestampNormalization {
             // 「未連携のみ」フィルタがオンでも表示される
             // （フィルタは維持）
 
-            await this.loadTimestamps(this.currentPage);
+            await this.loadTimestamps(this.currentPage, this.currentSearchQuery);
             this.updateSelectionDisplay();
         } catch (error) {
             console.error('解除に失敗しました:', error);


### PR DESCRIPTION
## 概要
タイムスタンプ正規化画面のページネーション機能を大幅に強化しました。現在50ページ以上存在し、1ページずつの移動が厳しいという課題に対応しています。

## 変更内容

### 1. ページネーションボタンの追加
- **最初のページへ移動**ボタン（「最初」）：1ページ目に直接移動
- **10ページ戻る**ボタン（「-10」）：10ページ分戻る
- **5ページ戻る**ボタン（「-5」）：5ページ分戻る
- **5ページ進む**ボタン（「+5」）：5ページ分進む
- **10ページ進む**ボタン（「+10」）：10ページ分進む
- **最後のページへ移動**ボタン（「最後」）：最終ページに直接移動

各ボタンは適切な状態（有効/無効）で表示されます。

### 2. コード品質の改善
- **コード重複の解消**：ボタン作成処理をヘルパー関数化し、保守性を向上
- **検索条件の保持**：ページ移動時に検索フィルタが失われる問題を修正
  - `currentSearchQuery`プロパティを追加
  - 全てのページ遷移で検索条件が保持されるように修正
- **ページ番号のバリデーション**：NaNチェックを追加し、エッジケースに対応

### 3. バグ修正
- ページ番号が文字列として扱われ、1 → 11 → 111 と連結される問題を修正
- ページ移動時に検索フィルタが失われる問題を修正

## 影響範囲
- `resources/js/songs/normalize.js`

## テスト
- ✅ PHPUnit全テストパス
- ✅ Laravel Pint（コードスタイル）チェックパス
- ✅ Viteビルド成功

## 関連Issue
- 50ページ以上のタイムスタンプページネーションの課題に対応

## チェックリスト
- [x] コードレビュー実施済み
- [x] 全てのテストがパス
- [x] コードスタイルチェックパス
- [x] ビルド成功
- [x] バグ修正とリファクタリング完了
- [x] 最新のdevelopから作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)