### PR TITLE
Fix: updateOrCreate使用時のID再生成問題を修正

### DIFF
--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -378,16 +378,27 @@ class SongController extends Controller
         ]);
 
         DB::transaction(function () use ($validated) {
-            TimestampSongMapping::updateOrCreate(
-                ['normalized_text' => $validated['normalized_text']],
-                [
-                    'id' => Str::ulid(),
+            $mapping = TimestampSongMapping::where('normalized_text', $validated['normalized_text'])->first();
+
+            if ($mapping) {
+                // 既存レコードを更新（IDは変更しない）
+                $mapping->update([
                     'song_id' => $validated['song_id'],
                     'is_not_song' => false,
                     'is_manual' => true,
                     'confidence' => 1.0,
-                ]
-            );
+                ]);
+            } else {
+                // 新規レコードを作成
+                TimestampSongMapping::create([
+                    'id' => Str::ulid(),
+                    'normalized_text' => $validated['normalized_text'],
+                    'song_id' => $validated['song_id'],
+                    'is_not_song' => false,
+                    'is_manual' => true,
+                    'confidence' => 1.0,
+                ]);
+            }
         });
 
         return response()->json(['message' => 'タイムスタンプと楽曲を紐づけました。']);
@@ -403,16 +414,27 @@ class SongController extends Controller
         ]);
 
         DB::transaction(function () use ($validated) {
-            TimestampSongMapping::updateOrCreate(
-                ['normalized_text' => $validated['normalized_text']],
-                [
-                    'id' => Str::ulid(),
+            $mapping = TimestampSongMapping::where('normalized_text', $validated['normalized_text'])->first();
+
+            if ($mapping) {
+                // 既存レコードを更新（IDは変更しない）
+                $mapping->update([
                     'song_id' => null,
                     'is_not_song' => true,
                     'is_manual' => true,
                     'confidence' => 1.0,
-                ]
-            );
+                ]);
+            } else {
+                // 新規レコードを作成
+                TimestampSongMapping::create([
+                    'id' => Str::ulid(),
+                    'normalized_text' => $validated['normalized_text'],
+                    'song_id' => null,
+                    'is_not_song' => true,
+                    'is_manual' => true,
+                    'confidence' => 1.0,
+                ]);
+            }
         });
 
         return response()->json(['message' => '楽曲ではないとマークしました。']);


### PR DESCRIPTION
## 問題の概要
`TimestampSongMapping::updateOrCreate()`で既存レコード更新時にもULIDが再生成され、外部キー参照が壊れる可能性がありました。

## 修正内容

### 変更箇所
`app/Http/Controllers/SongController.php` の2箇所:
1. **linkTimestampメソッド** (行380-402)
2. **markAsNotSongメソッド** (行416-438)

### 修正方法
`updateOrCreate()`を廃止し、明示的に既存レコードの有無を確認してから処理を分岐:

**修正前:**
```php
TimestampSongMapping::updateOrCreate(
    ['normalized_text' => $validated['normalized_text']],
    [
        'id' => Str::ulid(),  // ❌ 更新時にもIDが再生成される
        'song_id' => $validated['song_id'],
        // ...
    ]
);
```

**修正後:**
```php
$mapping = TimestampSongMapping::where('normalized_text', $validated['normalized_text'])->first();

if ($mapping) {
    // 既存レコードを更新（IDは変更しない）
    $mapping->update([
        'song_id' => $validated['song_id'],
        // ...
    ]);
} else {
    // 新規レコードを作成
    TimestampSongMapping::create([
        'id' => Str::ulid(),
        'normalized_text' => $validated['normalized_text'],
        // ...
    ]);
}
```

## 修正による効果
- ✅ 既存レコード更新時にIDが保持される
- ✅ 外部キー参照の整合性が維持される
- ✅ データ破損リスクが排除される

## Test plan
- [ ] タイムスタンプと楽曲の紐づけ（linkTimestamp）を複数回実行
  - 初回: 新規レコードが作成されることを確認
  - 2回目以降: 同じIDで更新されることを確認
- [ ] 「楽曲ではない」マーク（markAsNotSong）を複数回実行
  - 初回: 新規レコードが作成されることを確認
  - 2回目以降: 同じIDで更新されることを確認
- [ ] 外部キー参照が壊れていないことを確認

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)