### PR TITLE
Fix: TsItemモデルの動的アクセサN+1問題を解決

### DIFF
--- a/app/Models/TsItem.php
+++ b/app/Models/TsItem.php
@@ -48,24 +48,4 @@ class TsItem extends Model
     {
         return \App\Helpers\TextNormalizer::normalize($this->text);
     }
-
-    /**
-     * マッピングを通じて楽曲を取得
-     */
-    public function getSongAttribute()
-    {
-        $mapping = TimestampSongMapping::where('normalized_text', $this->normalized_text)->first();
-
-        return $mapping ? $mapping->song : null;
-    }
-
-    /**
-     * マッピングを通じて is_not_song フラグを取得
-     */
-    public function getIsNotSongAttribute()
-    {
-        $mapping = TimestampSongMapping::where('normalized_text', $this->normalized_text)->first();
-
-        return $mapping ? $mapping->is_not_song : false;
-    }
 }


### PR DESCRIPTION
## 概要
TsItemモデルの動的アクセサ`getSongAttribute()`と`getIsNotSongAttribute()`を削除し、N+1問題を解決しました。

## 変更内容
- `app/Models/TsItem.php`から以下のメソッドを削除:
  - `getSongAttribute()` (55-60行目)
  - `getIsNotSongAttribute()` (65-70行目)

## 問題点
これらの動的アクセサは、参照されるたびに`TimestampSongMapping::where('normalized_text', ...)->first()`クエリを実行するため、ループ内で使用するとN+1問題が発生していました。

## 解決方法
- PR #102 (Issue #89対応)で既にコントローラー側を効率的な実装に置き換え済み
- コントローラー側では事前に全マッピングを一括取得し、`keyBy()`でキャッシュ化
- これらのアクセサは使用されていないため、安全に削除可能

## テスト
- 既存コードでこれらのアクセサを使用している箇所がないことを確認
- `$mapping->song`や`$mapping->is_not_song`は`TimestampSongMapping`モデルのもので影響なし

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)