### PR TITLE
Improve: ページネーション時に一覧を先頭へ自動スクロール

### DIFF
--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -301,7 +301,11 @@ class TimestampNormalization {
             btn.disabled = !isEnabled;
 
             if (isEnabled) {
-                btn.addEventListener('click', () => this.loadTimestamps(targetPage, this.currentSearchQuery));
+                btn.addEventListener('click', () => {
+                    this.loadTimestamps(targetPage, this.currentSearchQuery);
+                    // ページ切り替え時に一覧の先頭へスクロール
+                    document.getElementById('timestampsList').scrollTop = 0;
+                });
             }
 
             return btn;


### PR DESCRIPTION
## 概要
タイムスタンプ正規化画面のページネーションボタンをクリックした際に、一覧コンテナが自動的に先頭へスクロールするように改善しました。

## 変更内容
- `resources/js/songs/normalize.js`の`displayPagination()`メソッドを修正
- `createButton()`ヘルパー関数内のイベントリスナーにスクロール処理を追加

## 実装詳細
```javascript
btn.addEventListener('click', () => {
    this.loadTimestamps(targetPage, this.currentSearchQuery);
    // ページ切り替え時に一覧の先頭へスクロール
    document.getElementById('timestampsList').scrollTop = 0;
});
```

## 対象ボタン
以下の全てのページネーションボタンに適用:
- 「最初」ボタン
- 「前へ」ボタン
- 「次へ」ボタン  
- 「最後」ボタン
- 「-10」ボタン
- 「-5」ボタン
- 「+5」ボタン
- 「+10」ボタン

## 期待される効果
- ページ切り替え時に常に一覧の先頭が表示される
- ユーザーが手動でスクロールする必要がなくなる
- channels/show画面と一貫したUX

## 影響範囲
- タイムスタンプ正規化画面(`/songs/normalize`)のみ
- 既存機能への影響なし

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)