### PR TITLE
Fix: 未紐づけフィルターが常にON状態として動作する問題を修正

### DIFF
--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -28,7 +28,7 @@ class SongController extends Controller
     {
         $perPage = $request->input('per_page', 50);
         $search = $request->input('search', '');
-        $unlinkedOnly = $request->input('unlinked_only', false);
+        $unlinkedOnly = $request->boolean('unlinked_only', false);
         $currentPage = $request->input('page', 1);
 
         $query = TsItem::with(['archive'])


### PR DESCRIPTION
## 問題の説明
タイムスタンプ正規化画面において、「未紐づけのみ表示」絞り込みボタンのON/OFFに関わらず、常に未紐づけのタイムスタンプのみが表示される問題がありました。

## 再現手順
1. タイムスタンプ正規化画面を開く
2. 未紐づけ絞り込みボタンをクリック（グレー→青、または青→グレーに変化）
3. APIリクエストパラメータは正しく変化する:
   - ON: `unlinked_only=true`
   - OFF: `unlinked_only=false`
4. しかし、表示結果は常に未紐づけのみ

## 根本原因
`app/Http/Controllers/SongController.php:31`で、HTTPパラメータを文字列として受け取っていました:

```php
$unlinkedOnly = $request->input('unlinked_only', false);
```

- フロントエンドから`unlinked_only=false`が送信される
- PHPは文字列`"false"`として受け取る
- PHPでは空でない文字列は全てtruthyなので、`"false"`もtruthyとして評価される
- 81行目の`if ($unlinkedOnly)`が常にtrueと評価される
- 結果として、常に未紐づけフィルターが適用される

## 修正内容
31行目を以下のように修正:

```php
// 修正前
$unlinkedOnly = $request->input('unlinked_only', false);

// 修正後
$unlinkedOnly = $request->boolean('unlinked_only', false);
```

Laravelの`$request->boolean()`メソッドを使用することで、HTTPパラメータを正しくboolean型に変換できます。

## 期待される動作（修正後）
- `unlinked_only=false`: 全てのタイムスタンプが表示される（紐づけ済み + 未紐づけ）
- `unlinked_only=true`: 未紐づけのタイムスタンプのみが表示される

## 影響範囲
- ファイル: `app/Http/Controllers/SongController.php`
- 行: 31
- メソッド: `fetchTimestamps()`

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)