### PR TITLE
Improve: 楽曲表示を1行形式に統一（楽曲名 / アーティスト名）

### DIFF
--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -439,8 +439,21 @@ class TimestampNormalization {
         const spotifySelectedDiv = document.getElementById('spotifySelected');
         if (this.selectedSpotifyTrack) {
             spotifySelectedDiv.classList.remove('hidden');
-            document.getElementById('spotifySelectedTitle').textContent = this.selectedSpotifyTrack.name;
-            document.getElementById('spotifySelectedArtist').textContent = this.selectedSpotifyTrack.artists.map(a => a.name).join(', ');
+            const spotifyInfoDiv = document.getElementById('spotifySelectedInfo');
+            spotifyInfoDiv.textContent = '';  // クリア
+
+            const titleSpan = document.createElement('span');
+            titleSpan.className = 'font-medium';
+            titleSpan.textContent = this.selectedSpotifyTrack.name;
+
+            const artistNames = this.selectedSpotifyTrack.artists.map(a => a.name).join(', ');
+            const separatorSpan = document.createElement('span');
+            separatorSpan.className = 'text-gray-500 dark:text-gray-400';
+            separatorSpan.textContent = ' / ' + artistNames;
+
+            spotifyInfoDiv.appendChild(titleSpan);
+            spotifyInfoDiv.appendChild(separatorSpan);
+            spotifyInfoDiv.title = `${this.selectedSpotifyTrack.name} / ${artistNames}`;
         } else {
             spotifySelectedDiv.classList.add('hidden');
         }
@@ -489,16 +502,23 @@ class TimestampNormalization {
                         : 'border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
                 }`;
 
-                const title = document.createElement('div');
-                title.className = 'font-medium text-sm';
-                title.textContent = track.name;
+                const songInfo = document.createElement('div');
+                songInfo.className = 'text-sm truncate';
 
-                const artist = document.createElement('div');
-                artist.className = 'text-xs text-gray-500 dark:text-gray-400';
-                artist.textContent = track.artists.map(a => a.name).join(', ');
+                const titleSpan = document.createElement('span');
+                titleSpan.className = 'font-medium';
+                titleSpan.textContent = track.name;
 
-                div.appendChild(title);
-                div.appendChild(artist);
+                const artistNames = track.artists.map(a => a.name).join(', ');
+                const separatorSpan = document.createElement('span');
+                separatorSpan.className = 'text-gray-500 dark:text-gray-400';
+                separatorSpan.textContent = ' / ' + artistNames;
+
+                songInfo.appendChild(titleSpan);
+                songInfo.appendChild(separatorSpan);
+                songInfo.title = `${track.name} / ${artistNames}`;
+
+                div.appendChild(songInfo);
 
                 div.addEventListener('click', () => {
                     this.selectSpotifyTrack(track);
@@ -783,16 +803,22 @@ class TimestampNormalization {
             const contentDiv = document.createElement('div');
             contentDiv.className = 'flex-1';
 
-            const title = document.createElement('div');
-            title.className = 'font-medium text-sm';
-            title.textContent = song.title;
+            const songInfo = document.createElement('div');
+            songInfo.className = 'text-sm truncate';
 
-            const artist = document.createElement('div');
-            artist.className = 'text-xs text-gray-500 dark:text-gray-400';
-            artist.textContent = song.artist;
+            const titleSpan = document.createElement('span');
+            titleSpan.className = 'font-medium';
+            titleSpan.textContent = song.title;
 
-            contentDiv.appendChild(title);
-            contentDiv.appendChild(artist);
+            const separatorSpan = document.createElement('span');
+            separatorSpan.className = 'text-gray-500 dark:text-gray-400';
+            separatorSpan.textContent = ' / ' + song.artist;
+
+            songInfo.appendChild(titleSpan);
+            songInfo.appendChild(separatorSpan);
+            songInfo.title = `${song.title} / ${song.artist}`;
+
+            contentDiv.appendChild(songInfo);
 
             // 削除ボタン
             const deleteBtn = document.createElement('button');

--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -102,8 +102,7 @@
                         <!-- Spotify選択楽曲情報表示 -->
                         <div id="spotifySelected" class="mb-3 p-3 bg-green-50 dark:bg-gray-700 rounded hidden">
                             <div class="text-sm text-gray-600 dark:text-gray-400 mb-1">Spotify選択楽曲</div>
-                            <div id="spotifySelectedTitle" class="font-medium"></div>
-                            <div id="spotifySelectedArtist" class="text-xs text-gray-500 dark:text-gray-400 mt-1"></div>
+                            <div id="spotifySelectedInfo" class="text-sm truncate" title=""></div>
                         </div>
 
                         <!-- タブ -->


### PR DESCRIPTION
## 概要
タイムスタンプ正規化画面において、楽曲表示を2行形式から1行形式（楽曲名 / アーティスト名）に統一しました。

## 現状の問題
以下の3箇所で楽曲情報が2行表示されていました:
- Spotify検索結果
- 楽曲マスタ一覧
- Spotify選択楽曲情報

```
楽曲名（1行目）
アーティスト名（2行目、グレー文字）
```

## 変更内容

### 1. Spotify検索結果 (`resources/js/songs/normalize.js:492-508`)
2行表示を1行にまとめ、「楽曲名 / アーティスト名」形式に変更

**修正前**:
```javascript
const title = document.createElement('div');
title.className = 'font-medium text-sm';
title.textContent = track.name;

const artist = document.createElement('div');
artist.className = 'text-xs text-gray-500 dark:text-gray-400';
artist.textContent = track.artists.map(a => a.name).join(', ');
```

**修正後**:
```javascript
const songInfo = document.createElement('div');
songInfo.className = 'text-sm truncate';

const titleSpan = document.createElement('span');
titleSpan.className = 'font-medium';
titleSpan.textContent = track.name;

const artistNames = track.artists.map(a => a.name).join(', ');
const separatorSpan = document.createElement('span');
separatorSpan.className = 'text-gray-500 dark:text-gray-400';
separatorSpan.textContent = ' / ' + artistNames;

songInfo.appendChild(titleSpan);
songInfo.appendChild(separatorSpan);
songInfo.title = `${track.name} / ${artistNames}`;
```

### 2. 楽曲マスタ一覧 (`resources/js/songs/normalize.js:793-808`)
Spotify検索結果と同様の1行形式に変更

### 3. Spotify選択楽曲情報
- **HTML構造変更** (`resources/views/songs/index.blade.php:103-106`)
  - 2つのdiv要素（title/artist）を1つに統合
- **JavaScript更新処理変更** (`resources/js/songs/normalize.js:438-459`)
  - DOM操作で1行形式を動的生成

## 実装の特徴

### UI/UX
- **`truncate`クラス**: 長い楽曲名を自動省略
- **`title`属性**: ホバー時に全文表示
- **スタイル**: 楽曲名は太字、アーティスト名はグレー文字

### セキュリティ
- DOM操作による自動エスケープでXSS対策済み
- `innerHTML`は使用せず、`textContent`と`appendChild`を使用

## 期待される効果
- ✅ **縦スペース削減**: 各楽曲アイテムが2行→1行になり、表示効率が約50%向上
- ✅ **一覧性向上**: スクロールなしでより多くの楽曲を一度に確認可能
- ✅ **統一感**: タイムスタンプステータス表示と形式が統一される
- ✅ **可読性**: 「楽曲名 / アーティスト名」の形式は一般的で理解しやすい

## 表示例
```
Let It Be / The Beatles
Bohemian Rhapsody / Queen
Hotel California / Eagles
```

Fixes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)