### PR TITLE
Improve: タイムスタンプ正規化画面のヘッダを削除して画面領域を拡大

### DIFF
--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -1,10 +1,4 @@
 <x-app-layout>
-    <x-slot name="header">
-        <h2 class="font-semibold sm:text-xl text-gray-800 dark:text-gray-200 leading-tight">
-            {{ __('タイムスタンプ正規化') }}
-        </h2>
-    </x-slot>
-
     <div class="py-2">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <!-- 検索エリア -->


### PR DESCRIPTION
## 概要
タイムスタンプ正規化画面のヘッダ部分（「タイムスタンプ正規化」の見出し）を削除し、画面の縦方向領域を増やしました。

## 変更内容

### 修正前
```html
<x-app-layout>
    <x-slot name="header">
        <h2 class="font-semibold sm:text-xl text-gray-800 dark:text-gray-200 leading-tight">
            {{ __('タイムスタンプ正規化') }}
        </h2>
    </x-slot>

    <div class="py-2">
        ...
    </div>
</x-app-layout>
```

### 修正後
```html
<x-app-layout>
    <div class="py-2">
        ...
    </div>
</x-app-layout>
```

## 効果
- ✅ **縦方向の表示領域拡大**: ヘッダ分のスペースが作業領域に
- ✅ **一覧性向上**: より多くのタイムスタンプや楽曲を一度に表示可能
- ✅ **作業効率向上**: スクロール回数が減少

## 影響範囲
- ファイル: `resources/views/songs/index.blade.php`
- 画面: タイムスタンプ正規化画面のみ
- 既存機能への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)