### PR TITLE
feat: Phase1 - アーカイブ一覧画面にタイムスタンプ表示機能を追加

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -2,7 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\TextNormalizer;
 use App\Models\Channel;
+use App\Models\TimestampSongMapping;
+use App\Models\TsItem;
 use App\Services\GetArchiveService;
 use Illuminate\Http\Request;
 
@@ -56,5 +59,85 @@ class ChannelController extends Controller
             ->appends($request->query());
 
         return response()->json($archives);
+    }
+
+    /**
+     * チャンネルに紐づくタイムスタンプを取得（マッピング情報付き）
+     */
+    public function fetchTimestamps(string $id, Request $request)
+    {
+        // チャンネル取得
+        $channel = Channel::where('handle', $id)->firstOrFail();
+
+        $perPage = $request->input('per_page', 50);
+        $currentPage = $request->input('page', 1);
+
+        // タイムスタンプ取得（チャンネルフィルタ付き）
+        $query = TsItem::with(['archive'])
+            ->whereHas('archive', function ($q) use ($channel) {
+                $q->where('channel_id', $channel->channel_id)
+                    ->where('is_display', 1);
+            })
+            ->whereNotNull('text')
+            ->where('text', '!=', '')
+            ->where('is_display', 1);
+
+        // 全件取得（ページネーション前）
+        $allTimestamps = $query->get();
+
+        // N+1クエリ問題を回避: 全タイムスタンプの正規化テキストを事前に取得
+        $normalizedTexts = $allTimestamps->map(function ($item) {
+            return TextNormalizer::normalize($item->text);
+        })->unique()->values()->toArray();
+
+        // 一度にすべてのマッピングを取得
+        $mappings = TimestampSongMapping::whereIn('normalized_text', $normalizedTexts)
+            ->with('song')
+            ->get()
+            ->keyBy('normalized_text');
+
+        // 各タイムスタンプにマッピング情報を追加
+        $timestampsWithMapping = $allTimestamps->map(function ($item) use ($mappings) {
+            $normalizedText = TextNormalizer::normalize($item->text);
+            $mapping = $mappings->get($normalizedText);
+
+            return [
+                'id' => $item->id,
+                'ts_text' => $item->ts_text,
+                'ts_num' => $item->ts_num,
+                'text' => $item->text,
+                'video_id' => $item->video_id,
+                'archive' => [
+                    'title' => $item->archive->title,
+                    'published_at' => $item->archive->published_at,
+                ],
+                'mapping' => $mapping ? [
+                    'song' => $mapping->song ? [
+                        'title' => $mapping->song->title,
+                        'artist' => $mapping->song->artist,
+                    ] : null,
+                    'is_not_song' => $mapping->is_not_song,
+                ] : null,
+            ];
+        });
+
+        // 「楽曲ではない」タイムスタンプを除外
+        $timestampsWithMapping = $timestampsWithMapping->filter(function ($ts) {
+            return ! ($ts['mapping'] && $ts['mapping']['is_not_song']);
+        })->values();
+
+        // 手動でページネーション
+        $total = $timestampsWithMapping->count();
+        $lastPage = (int) ceil($total / $perPage);
+        $offset = ($currentPage - 1) * $perPage;
+        $items = $timestampsWithMapping->slice($offset, $perPage)->values();
+
+        return response()->json([
+            'data' => $items,
+            'current_page' => $currentPage,
+            'last_page' => $lastPage,
+            'per_page' => $perPage,
+            'total' => $total,
+        ]);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -66,6 +66,7 @@ Route::get('/channels', [ChannelController::class, 'index'])->name('channels.ind
 Route::get('/channels/{id}', [ChannelController::class, 'show'])->name('channels.show');
 
 Route::get('api/channels/{id}', [ChannelController::class, 'fetchArchives'])->name('channels.fetchArchives');
+Route::get('api/channels/{id}/timestamps', [ChannelController::class, 'fetchTimestamps'])->name('channels.fetchTimestamps');
 
 Route::get('/terms', [MarkdownController::class, 'show'])->name('markdown.show');
 


### PR DESCRIPTION
## 概要
アーカイブ一覧画面（`/channels/{handle}`）にタブUIを追加し、タイムスタンプ一覧を表示する基本機能を実装しました（Phase1）。

## 変更内容

### 1. 新規APIエンドポイント (`routes/web.php`, `app/Http/Controllers/ChannelController.php`)

**エンドポイント**: `GET /api/channels/{id}/timestamps`

**処理内容**:
- チャンネルに紐づくタイムスタンプを取得
- Eager Loadingでアーカイブ情報を一括取得（N+1対策）
- 楽曲マッピング情報を一括取得して付与
- **「楽曲ではない」タイムスタンプを除外**
- ページネーション処理（1ページ50件）

### 2. タブUI追加 (`resources/views/channels/show.blade.php`)

```html
<nav class="flex space-x-4 border-b">
    <button @click="activeTab = 'archives'">アーカイブ</button>
    <button @click="activeTab = 'timestamps'">タイムスタンプ</button>
</nav>
```

- Alpine.jsで切り替え制御
- アーカイブタブ: 青色
- タイムスタンプタブ: 緑色

### 3. タイムスタンプ一覧表示

**表示項目**:
- ✓/○ ステータスアイコン（紐づけ済み/未紐づけ）
- 楽曲情報: 「楽曲名 / アーティスト名」（紐づけ済み）または元テキスト（未紐づけ）
- アーカイブタイトル
- YouTubeリンク（タイムスタンプ付き）

**スタイル**:
- 楽曲紐づけ済み: 緑背景 (`bg-green-50`)
- 未紐づけ: 白背景
- 長文は`truncate`で省略、`title`属性でホバー時に全文表示
- 1行形式で表示効率向上

### 4. ページネーション

- 上下に配置
- ボタン: 最初/前へ/次へ/最後
- クリック時に画面先頭へ自動スクロール

### 5. Alpine.jsロジック

```javascript
// タイムスタンプ取得
async fetchTimestamps(page = 1) {
    const response = await fetch(`/api/channels/${this.channel.handle}/timestamps?page=${page}&per_page=50`);
    this.timestamps = await response.json();
}

// タブ切り替え監視
this.$watch('activeTab', (newTab) => {
    if (newTab === 'timestamps' && !this.timestamps.data) {
        this.fetchTimestamps();
    }
});
```

## 技術的ポイント

### N+1クエリ対策
```php
// アーカイブ情報をEager Loading
TsItem::with(['archive'])
    ->whereHas('archive', function($q) use ($channel) {
        $q->where('channel_id', $channel->channel_id);
    })

// 楽曲マッピング情報を一括取得
$normalizedTexts = $allTimestamps->map(...)->unique()->toArray();
TimestampSongMapping::whereIn('normalized_text', $normalizedTexts)
    ->with('song')
    ->get()
    ->keyBy('normalized_text');
```

### 「楽曲ではない」タイムスタンプの除外
```php
$timestampsWithMapping = $timestampsWithMapping->filter(function ($ts) {
    return ! ($ts['mapping'] && $ts['mapping']['is_not_song']);
})->values();
```

### YouTubeリンク生成
```
https://youtube.com/watch?v={video_id}&t={ts_num}s
```

## 表示例

### 楽曲紐づけ済み
```
✓ Let It Be / The Beatles  | 【歌枠】朝活 | 0:12:34 ↗
```
（緑背景）

### 未紐づけ
```
○ めちゃくちゃいい曲 | 【歌枠】夜活 | 1:23:45 ↗
```
（白背景）

## 期待される効果
- ✅ タイムスタンプ一覧を効率的に閲覧可能
- ✅ 楽曲紐づけ状況が一目で分かる
- ✅ 「楽曲ではない」が除外され、関連性の高い情報のみ表示
- ✅ YouTubeへの直接アクセスが容易
- ✅ 1行形式で表示効率が向上

## 次のフェーズ

Phase2では以下の機能を追加予定:
- 検索機能の統合
- ステータス表示の改善
- URLパラメータでの状態管理

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)