### PR TITLE
fix: タイムスタンプタブのページネーション文字列連結バグを修正

### DIFF
--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -336,7 +336,16 @@
                         const response = await fetch(`/api/channels/${this.channel.handle}/timestamps?${params}`);
                         if (!response.ok) throw new Error('タイムスタンプの取得に失敗しました');
 
-                        this.timestamps = await response.json();
+                        const data = await response.json();
+
+                        // ページ番号を数値として保存（文字列連結バグの防止）
+                        const parsedPage = parseInt(data.current_page, 10);
+                        data.current_page = Number.isNaN(parsedPage) ? 1 : parsedPage;
+
+                        const parsedLastPage = parseInt(data.last_page, 10);
+                        data.last_page = Number.isNaN(parsedLastPage) ? 1 : parsedLastPage;
+
+                        this.timestamps = data;
                         this.currentTimestampPage = page;
                         this.updateURL();
                     } catch (error) {


### PR DESCRIPTION
## 概要
Issue #116の対応として、タイムスタンプタブのページネーション不具合を修正しました。

## 問題

### 現象
- 1ページ目で「次へ」をクリック → 11ページ目に移動
- 11ページ目で「次へ」をクリック → 111ページ目に移動
- ページネーションが使用不可能

### 原因
JavaScriptの型変換の罠により文字列連結が発生:
```javascript
// APIから返されるcurrent_pageは文字列 "1"
timestamps.current_page = "1"

// "次へ"ボタンで +1 すると...
"1" + 1 = "11"  // 文字列連結になる
"11" + 1 = "111" // さらに連結
```

## 修正内容

### fetchTimestamps()メソッドの修正 (`resources/views/channels/show.blade.php:339-346`)

```javascript
const data = await response.json();

// ページ番号を数値として保存（文字列連結バグの防止）
const parsedPage = parseInt(data.current_page, 10);
data.current_page = Number.isNaN(parsedPage) ? 1 : parsedPage;

const parsedLastPage = parseInt(data.last_page, 10);
data.last_page = Number.isNaN(parsedLastPage) ? 1 : parsedLastPage;

this.timestamps = data;
```

### 修正のポイント
1. `parseInt(value, 10)`で明示的に数値変換
2. `Number.isNaN()`でバリデーション
3. 不正な値の場合はデフォルト値（1）を使用

## 参考実装

この修正は**PR #96**（タイムスタンプ正規化画面）で既に実施済みの同じパターンを適用しています:
- PR #96: `resources/js/songs/normalize.js` (158-159行目)

```javascript
const parsedPage = parseInt(response.data.current_page, 10);
this.currentPage = Number.isNaN(parsedPage) ? 1 : parsedPage;
```

## 動作確認

- [x] 「次へ」ボタンで2ページ目に正しく移動する（11ページではない）
- [x] 「前へ」ボタンで1ページ目に戻る
- [x] 「最初」「最後」ボタンが正常に動作する
- [x] 検索後のページネーションも正常に動作する
- [x] ソート後のページネーションも正常に動作する

## 影響範囲

- アーカイブ一覧画面 - タイムスタンプタブのページネーション
- Phase3で追加されたソート機能・検索機能との組み合わせ

## 関連

- Closes #116
- PR #96 - 同じ問題の修正パターン
- PR #117 - Phase3でタイムスタンプタブの機能を拡張

🤖 Generated with [Claude Code](https://claude.com/claude-code)