### PR TITLE
fix: テスト環境のAPP_KEY未設定によるテスト失敗を修正

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:2VGAFrqZRNuRJu8BmPsRXYdBmULmEJ7pHFKnF8U3v0Q="/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>


### PR DESCRIPTION
## 概要
Issue #121の対応として、テスト環境のAPP_KEY未設定問題を修正しました。

## 問題

### エラー詳細
```
MissingAppKeyException
No application encryption key has been specified.
```

### 影響
- pre-commitフックでPHPUnitテストを実行すると全Featureテストが失敗
- Laravelの暗号化サービスが初期化できない
- テストの継続的な実行が不可能

## 修正内容

### phpunit.xmlにAPP_KEYを追加 (`phpunit.xml:22`)

```xml
<php>
    <env name="APP_ENV" value="testing"/>
    <env name="APP_KEY" value="base64:2VGAFrqZRNuRJu8BmPsRXYdBmULmEJ7pHFKnF8U3v0Q="/>
    <!-- 他の環境変数 -->
</php>
```

### 採用したアプローチ
Issue #121で提案された修正案のうち、以下を選択:
- **方法2**: `phpunit.xml`でAPP_KEYを環境変数として設定

### 理由
1. `.env.testing`ファイルを作成する必要がない（シンプル）
2. テスト専用の固定値で問題ない（本番環境とは無関係）
3. 他のテスト環境変数と同じ場所で管理できる

## セキュリティ上の考慮

### このAPP_KEYは安全か？
- **YES**: テスト専用の値で、本番環境の鍵とは完全に別物
- テストは`:memory:`のSQLiteで実行され、データは永続化されない
- テストデータに機密情報は含まれない

### 本番環境への影響
- **なし**: `phpunit.xml`は本番環境では使用されない
- `.env`ファイルの値が本番環境で使用される

## 動作確認

### 修正前
```bash
vendor/bin/phpunit
# MissingAppKeyException エラーが発生
```

### 修正後
```bash
vendor/bin/phpunit tests/Unit/ExampleTest.php
# OK (1 test, 1 assertion) ✓
```

## 注意事項

### 残存する問題
Featureテストでは別のエラーが発生します:
```
Vite manifest not found at: public/build/manifest.json
```

これはIssue #121の範囲外の問題です（Viteビルドの設定）。APP_KEY問題は解決されています。

## 関連

- Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)