### PR TITLE
feat: タイムスタンプ一覧のUIをシンプル化し、レイアウトを改善 (#120)

### DIFF
--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -191,21 +191,10 @@
                     </template>
 
                     <template x-for="ts in (timestamps.data || [])" :key="ts.id">
-                        <div class="p-2 border rounded hover:bg-gray-50 dark:hover:bg-gray-700 active:bg-gray-100 dark:active:bg-gray-600 dark:border-gray-600 transition-colors"
-                             :class="{'bg-green-50 dark:bg-green-900/20': ts.mapping?.song}">
-                            <div class="flex items-center gap-2 sm:gap-3">
-                                <!-- ステータスアイコン -->
-                                <div class="flex-shrink-0 text-xs sm:text-base">
-                                    <template x-if="ts.mapping?.song">
-                                        <span class="text-green-600 dark:text-green-400" title="楽曲紐づけ済み">✓</span>
-                                    </template>
-                                    <template x-if="!ts.mapping">
-                                        <span class="text-gray-400" title="未紐づけ">○</span>
-                                    </template>
-                                </div>
-
-                                <!-- 楽曲情報: モバイル30%, タブレット以上40% -->
-                                <div class="truncate flex-shrink-0 w-[30%] sm:w-[40%]"
+                        <div class="p-2 border rounded hover:bg-gray-50 dark:hover:bg-gray-700 active:bg-gray-100 dark:active:bg-gray-600 dark:border-gray-600 transition-colors">
+                            <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
+                                <!-- 楽曲情報 -->
+                                <div class="truncate flex-shrink-0 w-full sm:w-[300px]"
                                      :title="ts.mapping?.song ? `${ts.mapping.song.title} / ${ts.mapping.song.artist}` : ts.text">
                                     <template x-if="ts.mapping?.song">
                                         <span>


### PR DESCRIPTION
## 概要
Issue #120で報告されたタイムスタンプ一覧のUI改善を実装しました。

## 変更内容

### 1. ステータス表示の削除
- **楽曲紐づけ済みタイムスタンプの緑背景を削除**
- **ステータスアイコン(✓、○)を削除**
- 視覚的ノイズを減らし、すっきりとしたUIを実現

### 2. レイアウトの改善

#### デスクトップ(≥640px)
- 楽曲名を300px固定幅に変更
- アーカイブ名の開始位置が統一され、一覧性が大幅に向上

**Before**:
```
[○] [楽曲名(可変)     ] [アーカイブ名(残り)]  [1:23:45 ↗]
[✓] [楽曲名が長い場合] [アーカイブ名]        [2:34:56 ↗]
```
→ アーカイブ名の開始位置がバラバラ

**After**:
```
[楽曲名(300px固定)     ] [アーカイブ名(残り)] [1:23:45 ↗]
[楽曲名が長い場合は... ] [アーカイブ名]       [2:34:56 ↗]
```
→ アーカイブ名の開始位置が統一

#### モバイル(<640px)
- 縦並びレイアウトを採用
- 各要素が全幅を使用し、見やすく表示

```
[楽曲名(全幅)                    ]
[アーカイブ名(全幅)              ]
[1:23:45 ↗                       ]
```

## 実装の詳細

**ファイル**: `resources/views/channels/show.blade.php` (行193-198)

1. 背景色の条件分岐を削除
2. ステータスアイコンのdiv全体を削除(11行削除)
3. モバイル対応クラスを追加(`flex-col sm:flex-row`)
4. 楽曲名幅を変更(`w-[30%] sm:w-[40%]` → `w-full sm:w-[300px]`)

## 期待される効果

- ✅ すっきりとしたUIで情報が見やすく
- ✅ アーカイブ名の位置が揃い、一覧性が大幅に向上
- ✅ 不要な視覚的ノイズが減少
- ✅ モバイルでも快適に閲覧可能

## テスト観点

### デスクトップ表示
- [ ] 楽曲名が300pxの固定幅で表示される
- [ ] 楽曲名が長い場合、省略(...)される
- [ ] ホバーで全文が表示される(title属性)
- [ ] アーカイブ名の開始位置が全行で揃っている
- [ ] 動画リンクが右端に表示される
- [ ] ホバー時に背景色が変化する(グレー)
- [ ] 緑背景やアイコンが表示されない

### モバイル表示
- [ ] 楽曲名、アーカイブ名、動画リンクが縦並びになる
- [ ] 各要素が全幅を使用して見やすく表示される
- [ ] タッチ操作が快適に動作する

### 共通
- [ ] 楽曲紐づけ済みと未紐づけの両方が正しく表示される
- [ ] ダークモードで正しく表示される
- [ ] 既存の機能(ページネーション、検索等)が正常に動作する

## 関連Issue
Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)