### PR TITLE
improve: アーカイブ一覧の検索ボックスを統一してUXを改善 (#138)

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -14,6 +14,8 @@ function registerArchiveListComponent() {
                 timestamps: {},
                 activeTab: 'archives',
                 searchQuery: '',
+                archiveQuery: '',
+                tsFlg: '',
                 searchTimeout: null,
                 currentTimestampPage: 1,
                 timestampSort: 'time_desc',
@@ -59,6 +61,19 @@ function registerArchiveListComponent() {
 
                 escapeHTML(str) {
                     return escapeHTML(str);
+                },
+
+                archiveSearch() {
+                    const params = new URLSearchParams();
+                    params.append('baramutsu', this.archiveQuery);
+                    params.append('visible', '');
+                    params.append('ts', this.tsFlg);
+
+                    const hasQuery = this.archiveQuery.length > 0;
+                    const filterEvent = new CustomEvent('filter-changed', { detail: hasQuery });
+                    window.dispatchEvent(filterEvent);
+
+                    this.fetchData(this.firstUrl(params.toString()));
                 },
 
                 async fetchTimestamps(page = 1, search = '') {
@@ -178,10 +193,6 @@ function registerArchiveListComponent() {
                     } else {
                         this.fetchData(this.firstUrl());
                     }
-
-                    this.$el.addEventListener('search-results', (e) => {
-                        this.fetchData(this.firstUrl(e.detail));
-                    });
 
                     const paginationButtons = document.querySelectorAll('#paginationButtons button');
                     paginationButtons.forEach(button => {

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -70,10 +70,10 @@ function registerArchiveListComponent() {
                     params.append('ts', this.tsFlg);
 
                     const hasQuery = this.archiveQuery.length > 0;
-                    const filterEvent = new CustomEvent('filter-changed', { detail: hasQuery });
-                    window.dispatchEvent(filterEvent);
+                    this.$dispatch('filter-changed', hasQuery);
 
                     this.fetchData(this.firstUrl(params.toString()));
+                    this.updateURL();
                 },
 
                 async fetchTimestamps(page = 1, search = '') {
@@ -149,17 +149,32 @@ function registerArchiveListComponent() {
                         params.set('view', this.activeTab);
                     }
 
-                    if (this.searchQuery) {
-                        params.set('search', this.searchQuery);
-                    }
+                    // タイムスタンプタブのパラメータ
+                    if (this.activeTab === 'timestamps') {
+                        if (this.searchQuery) {
+                            params.set('search', this.searchQuery);
+                        }
 
-                    if (this.timestampSort && this.timestampSort !== 'time_desc') {
-                        params.set('sort', this.timestampSort);
-                    }
+                        if (this.timestampSort && this.timestampSort !== 'time_desc') {
+                            params.set('sort', this.timestampSort);
+                        }
 
-                    const page = this.activeTab === 'timestamps' ? this.currentTimestampPage : this.archives.current_page;
-                    if (page && page > 1) {
-                        params.set('page', page);
+                        if (this.currentTimestampPage && this.currentTimestampPage > 1) {
+                            params.set('page', this.currentTimestampPage);
+                        }
+                    } else {
+                        // アーカイブタブのパラメータ
+                        if (this.archiveQuery) {
+                            params.set('baramutsu', this.archiveQuery);
+                        }
+
+                        if (this.tsFlg) {
+                            params.set('ts', this.tsFlg);
+                        }
+
+                        if (this.archives.current_page && this.archives.current_page > 1) {
+                            params.set('page', this.archives.current_page);
+                        }
                     }
 
                     const paramString = params.toString();
@@ -191,7 +206,17 @@ function registerArchiveListComponent() {
                         this.currentTimestampPage = page;
                         this.fetchTimestamps(page, this.searchQuery);
                     } else {
-                        this.fetchData(this.firstUrl());
+                        // アーカイブタブの状態を復元
+                        const archiveQuery = params.get('baramutsu') || '';
+                        const tsFlg = params.get('ts') || '';
+                        this.archiveQuery = archiveQuery;
+                        this.tsFlg = tsFlg;
+
+                        if (archiveQuery || tsFlg) {
+                            this.archiveSearch();
+                        } else {
+                            this.fetchData(this.firstUrl());
+                        }
                     }
 
                     const paginationButtons = document.querySelectorAll('#paginationButtons button');
@@ -229,6 +254,18 @@ function registerArchiveListComponent() {
                             this.timestampSort = sort || 'time_desc';
                             this.currentTimestampPage = page;
                             this.fetchTimestamps(page, search || '');
+                        } else {
+                            // アーカイブタブの状態を復元
+                            const archiveQuery = params.get('baramutsu') || '';
+                            const tsFlg = params.get('ts') || '';
+                            this.archiveQuery = archiveQuery;
+                            this.tsFlg = tsFlg;
+
+                            if (archiveQuery || tsFlg) {
+                                this.archiveSearch();
+                            } else {
+                                this.fetchData(this.firstUrl());
+                            }
                         }
                     });
                 }

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -31,13 +31,47 @@
         </div>
 
         <div class="p-2 flex flex-col justify-self-center w-[100%] max-w-5xl gap-2">
-            <x-search
-                :channel-id="$channel->handle"
-                placeholder="タイムスタンプを検索"
-                button-text="検索"
-                manage-flg=""
-                alpine-parent="archiveListComponent"
-            />
+            <!-- 統一検索ボックス -->
+            <div class="search-unified">
+                <form @submit.prevent="activeTab === 'archives' ? archiveSearch() : null" class="flex items-stretch sm:items-center gap-2 max-w-7lg">
+                    <div class="flex gap-2 w-full sm:flex-grow flex-col sm:flex-row">
+                        <!-- アーカイブタブ用の検索ボックス -->
+                        <input
+                            x-show="activeTab === 'archives'"
+                            type="text"
+                            x-model="archiveQuery"
+                            placeholder="タイムスタンプを検索"
+                            class="border p-2 rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
+                        <!-- タイムスタンプタブ用の検索ボックス -->
+                        <input
+                            x-show="activeTab === 'timestamps'"
+                            type="text"
+                            x-model="searchQuery"
+                            placeholder="楽曲名・アーティスト名・タイムスタンプで検索..."
+                            class="border p-2 rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
+                        <div class="flex flex-row gap-2" x-show="activeTab === 'archives'">
+                            <select x-model="tsFlg" class="border p-2 pr-8 rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100">
+                                <option value="">タイムスタンプ</option>
+                                <option value="1">有のみ</option>
+                                <option value="2">無のみ</option>
+                            </select>
+                        </div>
+                    </div>
+                    <button
+                        type="submit"
+                        x-show="activeTab === 'archives'"
+                        class="bg-blue-500 text-white px-4 py-2 rounded sm:min-w-[100px] hover:bg-blue-600">
+                        検索
+                    </button>
+                    <button
+                        type="button"
+                        x-show="activeTab === 'timestamps'"
+                        @click="searchQuery = ''"
+                        class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600">
+                        クリア
+                    </button>
+                </form>
+            </div>
 
             <!-- タブUI -->
             <div class="mb-4">
@@ -105,19 +139,9 @@
 
             <!-- タイムスタンプタブ -->
             <div x-show="activeTab === 'timestamps'">
-                <!-- 検索エリア -->
+                <!-- 検索結果とソート -->
                 <div class="mb-4">
-                    <div class="flex gap-2">
-                        <input type="text"
-                               x-model="searchQuery"
-                               placeholder="楽曲名・アーティスト名・タイムスタンプで検索..."
-                               class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm">
-                        <button @click="searchQuery = ''"
-                                class="px-3 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600 text-sm">
-                            クリア
-                        </button>
-                    </div>
-                    <div class="mt-2 flex justify-between items-center">
+                    <div class="flex justify-between items-center">
                         <div class="text-sm text-gray-600 dark:text-gray-400">
                             <span x-show="searchQuery">検索結果: </span>
                             <span x-text="timestamps.total !== undefined ? `${timestamps.total}件` : ''"></span>

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -33,43 +33,51 @@
         <div class="p-2 flex flex-col justify-self-center w-[100%] max-w-5xl gap-2">
             <!-- 統一検索ボックス -->
             <div class="search-unified">
-                <form @submit.prevent="activeTab === 'archives' ? archiveSearch() : null" class="flex items-stretch sm:items-center gap-2 max-w-7lg">
+                <form @submit.prevent="activeTab === 'archives' ? archiveSearch() : searchTimestamps()" class="flex items-stretch sm:items-center gap-2 max-w-7lg">
                     <div class="flex gap-2 w-full sm:flex-grow flex-col sm:flex-row">
                         <!-- アーカイブタブ用の検索ボックス -->
-                        <input
-                            x-show="activeTab === 'archives'"
-                            type="text"
-                            x-model="archiveQuery"
-                            placeholder="タイムスタンプを検索"
-                            class="border p-2 rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
+                        <template x-if="activeTab === 'archives'">
+                            <input
+                                type="text"
+                                x-model="archiveQuery"
+                                placeholder="タイムスタンプを検索"
+                                aria-label="タイムスタンプを検索"
+                                class="border p-2 rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
+                        </template>
                         <!-- タイムスタンプタブ用の検索ボックス -->
-                        <input
-                            x-show="activeTab === 'timestamps'"
-                            type="text"
-                            x-model="searchQuery"
-                            placeholder="楽曲名・アーティスト名・タイムスタンプで検索..."
-                            class="border p-2 rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
-                        <div class="flex flex-row gap-2" x-show="activeTab === 'archives'">
-                            <select x-model="tsFlg" class="border p-2 pr-8 rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100">
-                                <option value="">タイムスタンプ</option>
-                                <option value="1">有のみ</option>
-                                <option value="2">無のみ</option>
-                            </select>
-                        </div>
+                        <template x-if="activeTab === 'timestamps'">
+                            <input
+                                type="text"
+                                x-model="searchQuery"
+                                placeholder="楽曲名・アーティスト名・タイムスタンプで検索..."
+                                aria-label="楽曲名・アーティスト名・タイムスタンプで検索"
+                                class="border p-2 rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
+                        </template>
+                        <template x-if="activeTab === 'archives'">
+                            <div class="flex flex-row gap-2">
+                                <select x-model="tsFlg" aria-label="タイムスタンプフィルター" class="border p-2 pr-8 rounded dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100">
+                                    <option value="">タイムスタンプ</option>
+                                    <option value="1">有のみ</option>
+                                    <option value="2">無のみ</option>
+                                </select>
+                            </div>
+                        </template>
                     </div>
-                    <button
-                        type="submit"
-                        x-show="activeTab === 'archives'"
-                        class="bg-blue-500 text-white px-4 py-2 rounded sm:min-w-[100px] hover:bg-blue-600">
-                        検索
-                    </button>
-                    <button
-                        type="button"
-                        x-show="activeTab === 'timestamps'"
-                        @click="searchQuery = ''"
-                        class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600">
-                        クリア
-                    </button>
+                    <template x-if="activeTab === 'archives'">
+                        <button
+                            type="submit"
+                            class="bg-blue-500 text-white px-4 py-2 rounded sm:min-w-[100px] hover:bg-blue-600">
+                            検索
+                        </button>
+                    </template>
+                    <template x-if="activeTab === 'timestamps'">
+                        <button
+                            type="button"
+                            @click="searchQuery = ''"
+                            class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600">
+                            クリア
+                        </button>
+                    </template>
                 </form>
             </div>
 


### PR DESCRIPTION
## Summary
タイムスタンプタブ表示時に2つの検索ボックスが表示される問題を解決。
単一の統一検索ボックスに変更し、アクティブなタブに応じて動作を切り替えるよう改善しました。

Fixes #138

## 変更内容

### 機能改善
- x-searchコンポーネントを削除し、統一検索ボックスを実装
- タイムスタンプタブ内の重複検索ボックスを削除
- activeTabに基づいて検索ボックスとボタンの表示を切り替え
- archiveSearch()メソッドを追加してアーカイブ検索を処理

### コードレビュー対応
- x-showをx-ifに変更してDOM要素を適切に管理
- すべての入力要素にaria-label属性を追加（アクセシビリティ向上）
- タイムスタンプ検索でEnterキー送信に対応
- アーカイブ検索のURL状態管理を実装
- ブラウザの戻る/進むでアーカイブ検索状態を復元
- AlpineのdispatchメソッドをCustomEventの代わりに使用

## Test plan
- [ ] アーカイブタブで検索ボックスが表示されることを確認
- [ ] タイムスタンプタブで検索ボックスが表示されることを確認
- [ ] タイムスタンプタブで検索ボックスが1つだけ表示されることを確認
- [ ] アーカイブタブで検索実行後、URLにパラメータが反映されることを確認
- [ ] タイムスタンプタブで検索実行後、URLにパラメータが反映されることを確認
- [ ] ブラウザの戻る/進むで検索状態が復元されることを確認
- [ ] タイムスタンプ検索でEnterキーが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)