### PR TITLE
Fix PHPUnit test failures caused by config cache

### DIFF
--- a/.env.testing.example
+++ b/.env.testing.example
@@ -1,6 +1,6 @@
 APP_NAME=歌枠履歴er:D
 APP_ENV=testing
-APP_KEY=
+APP_KEY= # Run: php artisan key:generate --show
 APP_DEBUG=true
 APP_URL=http://localhost
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,7 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
-        <env name="APP_KEY" value="base64:2VGAFrqZRNuRJu8BmPsRXYdBmULmEJ7pHFKnF8U3v0Q="/>
+        <env name="APP_KEY" value="base64:sg2ERaVrvPZq1uApES4n4XCDDlV5XvyWFCxKMxxvT7E="/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>


### PR DESCRIPTION
## Problem
All PHPUnit tests were failing with 419 errors (CSRF token mismatch) and authentication failures.
- 25 tests total: **14 failed, 11 passed**
- Main issues: CSRF verification, session management, authentication

## Root Cause
The configuration cache (created by `php artisan config:cache`) hardcoded `APP_ENV` to 'local' from .env file. When tests ran, Laravel didn't recognize the test environment, causing:
- ✗ CSRF verification to be enforced (should be skipped in tests)
- ✗ Session management issues
- ✗ Authentication failures

## Solution
1. **Clear config cache**: `php artisan config:clear`
2. Update phpunit.xml with new test-only APP_KEY
3. Add helpful comment to .env.testing.example for future developers

## Changes
- **phpunit.xml**: Updated APP_KEY to new test-specific key
- **.env.testing.example**: Added comment: `# Run: php artisan key:generate --show`

## Verification
✅ All 25 tests now pass successfully:
```
Tests:    25 passed (61 assertions)
Duration: 1.34s
```

✅ Pre-commit checks: All passed
- PHPUnit tests: ✓
- Laravel Pint (code style): ✓
- Frontend build (Vite): ✓

## Notes
- The APP_KEY change in phpunit.xml is test-only and does not affect production
- SESSION_DRIVER remains as `array` (tested and confirmed working)
- Other developers may need to run `php artisan config:clear` if they encounter similar issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)