### PR TITLE
improve: pre-commit-check.shにconfig:clearを追加してテスト失敗の再発を防止

### DIFF
--- a/pre-commit-check.sh
+++ b/pre-commit-check.sh
@@ -5,8 +5,25 @@
 echo "🔍 Pre-commit checks starting..."
 echo ""
 
-# 1. PHPUnit テストを実行
-echo "1️⃣ Running PHPUnit tests..."
+# 1. 設定キャッシュをクリア
+# Note: config:cacheを実行した環境でテストを実行すると、
+# APP_ENVがhardcodeされテストが失敗する問題を防ぐため (Issue #141)
+echo "1️⃣ Clearing config cache..."
+OUTPUT=$(php artisan config:clear 2>&1)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "❌ Failed to clear config cache!"
+    echo "   Error details:"
+    echo "$OUTPUT"
+    echo "   Please check your Laravel installation."
+    exit 1
+fi
+echo "✅ Config cache cleared!"
+echo ""
+
+# 2. PHPUnit テストを実行
+echo "2️⃣ Running PHPUnit tests..."
 
 # .env.testingの存在チェック（警告のみ、ブロックはしない）
 if [ ! -f .env.testing ]; then
@@ -26,8 +43,8 @@ fi
 echo "✅ Tests passed!"
 echo ""
 
-# 2. Laravel Pint (コードスタイル) をチェック
-echo "2️⃣ Checking code style with Laravel Pint..."
+# 3. Laravel Pint (コードスタイル) をチェック
+echo "3️⃣ Checking code style with Laravel Pint..."
 ./vendor/bin/pint --test
 if [ $? -ne 0 ]; then
     echo "❌ Code style issues found! Run './vendor/bin/pint' to fix them."
@@ -36,8 +53,8 @@ fi
 echo "✅ Code style is good!"
 echo ""
 
-# 3. フロントエンドビルドをチェック
-echo "3️⃣ Building frontend assets..."
+# 4. フロントエンドビルドをチェック
+echo "4️⃣ Building frontend assets..."
 npm run build
 if [ $? -ne 0 ]; then
     echo "❌ Frontend build failed! Please fix before committing."

--- a/pre-commit-check.sh
+++ b/pre-commit-check.sh
@@ -9,14 +9,14 @@ echo ""
 # Note: config:cacheを実行した環境でテストを実行すると、
 # APP_ENVがhardcodeされテストが失敗する問題を防ぐため (Issue #141)
 echo "1️⃣ Clearing config cache..."
-OUTPUT=$(php artisan config:clear 2>&1)
+OUTPUT=$(php artisan config:clear --quiet 2>&1)
 EXIT_CODE=$?
 
 if [ $EXIT_CODE -ne 0 ]; then
     echo "❌ Failed to clear config cache!"
     echo "   Error details:"
     echo "$OUTPUT"
-    echo "   Please check your Laravel installation."
+    echo "   Please ensure Laravel is properly installed and bootstrap/cache is writable."
     exit 1
 fi
 echo "✅ Config cache cleared!"


### PR DESCRIPTION
## Summary
- pre-commit-check.shにconfig:clearステップを追加
- Issue #141で解決した問題の再発を防止
- エラーハンドリングを改善し、詳細なエラー情報を表示

## 変更内容
1. **config:clearステップの追加**
   - テスト実行前に設定キャッシュをクリア
   - config:cacheによるAPP_ENVのhardcode問題を防止
   - Issue #141への参照を追加したコメント

2. **エラーハンドリングの改善**
   - config:clear失敗時は詳細なエラー情報を表示
   - exit 1で確実にpre-commitを停止

3. **ステップ番号の整理**
   - 全てのステップ番号を再採番（1→2, 2→3, 3→4）

## Test plan
- [x] config:cacheを実行した環境でpre-commit-check.shが正常に動作することを確認
- [x] config:clearが失敗した場合、適切なエラーメッセージを表示して終了することを確認
- [x] 全てのチェック（config:clear, tests, pint, build）が正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)