### PR TITLE
improve: アーカイブ一覧画面のUI/UX改善

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -80,7 +80,7 @@ class ChannelController extends Controller
         $perPage = $validated['per_page'] ?? 50;
         $currentPage = $validated['page'] ?? 1;
         $search = $validated['search'] ?? '';
-        $sort = $validated['sort'] ?? 'time_desc';
+        $sort = $validated['sort'] ?? 'song_asc';
 
         // タイムスタンプ取得（チャンネルフィルタ付き）
         $query = TsItem::with(['archive'])

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -18,7 +18,7 @@ function registerArchiveListComponent() {
                 tsFlg: '',
                 searchTimeout: null,
                 currentTimestampPage: 1,
-                timestampSort: 'time_desc',
+                timestampSort: 'song_asc',
                 loading: false,
                 error: null,
                 isFiltered: false,
@@ -155,7 +155,7 @@ function registerArchiveListComponent() {
                             params.set('search', this.searchQuery);
                         }
 
-                        if (this.timestampSort && this.timestampSort !== 'time_desc') {
+                        if (this.timestampSort && this.timestampSort !== 'song_asc') {
                             params.set('sort', this.timestampSort);
                         }
 
@@ -202,7 +202,7 @@ function registerArchiveListComponent() {
                     if (view === 'timestamps') {
                         this.activeTab = 'timestamps';
                         this.searchQuery = search || '';
-                        this.timestampSort = sort || 'time_desc';
+                        this.timestampSort = sort || 'song_asc';
                         this.currentTimestampPage = page;
                         this.fetchTimestamps(page, this.searchQuery);
                     } else {
@@ -251,7 +251,7 @@ function registerArchiveListComponent() {
 
                         if (view === 'timestamps') {
                             this.searchQuery = search || '';
-                            this.timestampSort = sort || 'time_desc';
+                            this.timestampSort = sort || 'song_asc';
                             this.currentTimestampPage = page;
                             this.fetchTimestamps(page, search || '');
                         } else {

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -7,13 +7,8 @@
         </script>
         @vite('resources/js/channels/archive-list.js')
     </x-slot>
-    <x-slot name="header">
-        <h2 class="font-semibold sm:text-xl text-gray-800 dark:text-gray-200 leading-tight">
-            {{ __('アーカイブ一覧') }}
-        </h2>
-    </x-slot>
 
-    <div class="px-2 sm:px-6 py-4 sm:py-12" x-data="archiveListComponent">
+    <div class="px-2 sm:px-6 py-2 sm:py-6" x-data="archiveListComponent">
         <div class="p-2">
             <h2 class="text-gray-500 items-center justify-center gap-4 hidden sm:flex">
                 <img :src="escapeHTML(channel.thumbnail || '')" alt="アイコン" class="w-20 h-20 rounded-full">
@@ -31,6 +26,22 @@
         </div>
 
         <div class="p-2 flex flex-col justify-self-center w-[100%] max-w-5xl gap-2">
+            <!-- タブUI -->
+            <div class="mb-4">
+                <nav class="flex space-x-4 border-b border-gray-200 dark:border-gray-700">
+                    <button @click="activeTab = 'archives'"
+                            :class="activeTab === 'archives' ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 dark:text-gray-400'"
+                            class="px-3 py-2 text-sm font-medium border-b-2 -mb-px hover:text-gray-700 dark:hover:text-gray-300">
+                        アーカイブ
+                    </button>
+                    <button @click="activeTab = 'timestamps'"
+                            :class="activeTab === 'timestamps' ? 'border-green-500 text-green-600 dark:text-green-400' : 'border-transparent text-gray-500 dark:text-gray-400'"
+                            class="px-3 py-2 text-sm font-medium border-b-2 -mb-px hover:text-gray-700 dark:hover:text-gray-300">
+                        タイムスタンプ
+                    </button>
+                </nav>
+            </div>
+
             <!-- 統一検索ボックス -->
             <div class="search-unified">
                 <form @submit.prevent="activeTab === 'archives' ? archiveSearch() : searchTimestamps()" class="flex items-stretch sm:items-center gap-2 max-w-7lg">
@@ -79,22 +90,6 @@
                         </button>
                     </template>
                 </form>
-            </div>
-
-            <!-- タブUI -->
-            <div class="mb-4">
-                <nav class="flex space-x-4 border-b border-gray-200 dark:border-gray-700">
-                    <button @click="activeTab = 'archives'"
-                            :class="activeTab === 'archives' ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 dark:text-gray-400'"
-                            class="px-3 py-2 text-sm font-medium border-b-2 -mb-px hover:text-gray-700 dark:hover:text-gray-300">
-                        アーカイブ
-                    </button>
-                    <button @click="activeTab = 'timestamps'"
-                            :class="activeTab === 'timestamps' ? 'border-green-500 text-green-600 dark:text-green-400' : 'border-transparent text-gray-500 dark:text-gray-400'"
-                            class="px-3 py-2 text-sm font-medium border-b-2 -mb-px hover:text-gray-700 dark:hover:text-gray-300">
-                        タイムスタンプ
-                    </button>
-                </nav>
             </div>
 
             <!-- アーカイブタブ -->
@@ -147,24 +142,11 @@
 
             <!-- タイムスタンプタブ -->
             <div x-show="activeTab === 'timestamps'">
-                <!-- 検索結果とソート -->
+                <!-- 検索結果 -->
                 <div class="mb-4">
-                    <div class="flex justify-between items-center">
-                        <div class="text-sm text-gray-600 dark:text-gray-400">
-                            <span x-show="searchQuery">検索結果: </span>
-                            <span x-text="timestamps.total !== undefined ? `${timestamps.total}件` : ''"></span>
-                        </div>
-                        <div class="flex gap-2 items-center">
-                            <label class="text-xs sm:text-sm text-gray-600 dark:text-gray-400">並び替え:</label>
-                            <select x-model="timestampSort"
-                                    @change="fetchTimestamps(1, searchQuery)"
-                                    class="px-2 py-1 sm:px-3 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
-                                <option value="time_desc">時刻↓</option>
-                                <option value="time_asc">時刻↑</option>
-                                <option value="song_asc">楽曲名</option>
-                                <option value="archive_desc">公開日</option>
-                            </select>
-                        </div>
+                    <div class="text-sm text-gray-600 dark:text-gray-400">
+                        <span x-show="searchQuery">検索結果: </span>
+                        <span x-text="timestamps.total !== undefined ? `${timestamps.total}件` : ''"></span>
                     </div>
                 </div>
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,7 +15,7 @@
                     <x-nav-link :href="route('top')">
                         {{ config('app.name') }}
                     </x-nav-link>
-                    <x-nav-link :href="route('channels.index')" :active="request()->routeIs('channels.index')">
+                    <x-nav-link :href="route('channels.index')" :active="request()->routeIs('channels.*')">
                         {{ __('チャンネル一覧') }}
                     </x-nav-link>
                     @if (Auth::check())
@@ -104,7 +104,7 @@
                 <x-responsive-nav-link :href="route('songs.index')" :active="request()->routeIs('songs.index')">
                     {{ __('タイムスタンプ正規化') }}
                 </x-responsive-nav-link>
-                <x-responsive-nav-link :href="route('channels.index')" :active="request()->routeIs('channels.index')">
+                <x-responsive-nav-link :href="route('channels.index')" :active="request()->routeIs('channels.*')">
                     {{ __('チャンネル一覧') }}
                 </x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('markdown.show')" :active="request()->routeIs('markdown.show')">
@@ -153,7 +153,7 @@
                     </x-responsive-nav-link>
                 </div>
                 <div class="pt-2 pb-3 space-y-1">
-                    <x-responsive-nav-link :href="route('channels.index')" :active="request()->routeIs('channels.index')">
+                    <x-responsive-nav-link :href="route('channels.index')" :active="request()->routeIs('channels.*')">
                         {{ __('チャンネル一覧') }}
                     </x-responsive-nav-link>
                     <x-responsive-nav-link :href="route('markdown.show')" :active="request()->routeIs('markdown.show')">


### PR DESCRIPTION
## Summary
アーカイブ一覧画面のUI/UX改善を実施。5つの改善により、コンテンツ表示領域の拡大、ナビゲーションの明確化、UIのシンプル化を実現。

## 変更内容

### 1. ヘッダーの「アーカイブ一覧」テキストを削除
- コンテンツ表示領域を拡大
- チャンネル名が既に画面に表示されているため冗長性を解消

### 2. ナビゲーションバーのアクティブ状態表示を改善
- `channels.index` → `channels.*`に変更
- チャンネル一覧とチャンネル詳細ページの両方で「チャンネル一覧」が強調表示されるように

**変更ファイル**: `resources/views/layouts/navigation.blade.php`

### 3. 画面上部の余白を削減
- `py-4 sm:py-12` → `py-2 sm:py-6`
- モバイルとデスクトップの両方で余白を50%削減
- コンテンツがより上部に表示され、一覧性が向上

### 4. タブの表示位置を検索ボックスの上に移動
- タブが最上部に表示され、画面構成が直感的に
- 検索ボックスはタブ配下に配置され、階層構造が明確に
- タブとコンテンツの関係性が分かりやすく

### 5. タイムスタンプの並び替えオプションを削減
- セレクトボックスを削除してUIをシンプル化
- デフォルトを楽曲名順（`song_asc`）に固定
- フロントエンドとバックエンドの両方でデフォルトを統一
- 頭文字ジャンプ機能が最初から使える

**変更ファイル**:
- `resources/views/channels/show.blade.php`
- `resources/js/channels/archive-list.js`
- `app/Http/Controllers/ChannelController.php`

## Test plan
- [x] 全てのPHPUnitテストがパス
- [x] フロントエンドビルドが成功
- [x] コードレビューで指摘された重要事項（バックエンドデフォルトソート）を修正
- [x] pre-commit-checkが正常に完了

## 参考
- Issue #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)