### PR TITLE
ローカル環境用の制御フラグを実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,13 @@ APP_KEY= # Run: php artisan key:generate
 APP_DEBUG=true
 APP_URL=http://localhost
 
+# ローカル環境制御
+# 注意: 以下の設定はAPP_ENV=localの場合のみ有効です
+# YouTube API呼び出し時のページあたりの取得件数（クォータ節約用）
+PAGINATE_NUM=50
+# ローカル環境での最大アーカイブ取得数の上限
+MAX_ARCHIVE_COUNT=100
+
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug

--- a/app/Services/YouTubeService.php
+++ b/app/Services/YouTubeService.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Exception;
 use Google\Client as Google_Client;
 use Google\Service\YouTube as Google_Service_YouTube;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Str;
@@ -101,7 +102,7 @@ class YouTubeService
         $playlist_id = 'UU'.substr($channel_id, 2);
 
         // nextPageTokenが取得できなくなるまでループ
-        $maxResults = config('app.debug') ? config('utils.page') : 50;
+        $maxResults = App::environment('local') ? config('utils.page') : 50;
         $response = null;
         $archives = [];
         do {
@@ -133,7 +134,7 @@ class YouTubeService
                     ];
                 }
             }
-            if (config('app.debug') && count($archives) >= config('utils.max_archive_count')) {
+            if (App::environment('local') && count($archives) >= config('utils.max_archive_count')) {
                 break;
             }
         } while ($response->getNextPageToken());


### PR DESCRIPTION
## 概要
Issue #152 の対応として、ローカル開発環境とプロダクション環境の動作を明確に分離する制御機能を実装しました。

## 変更内容

### 1. YouTubeService.php の改善
- `config('app.debug')` から `App::environment('local')` に変更
- より明示的な環境判定により、ローカル環境専用の動作を実現
- デバッグフラグに依存せず、環境設定（APP_ENV）による制御を可能に
- App facadeを使用してコードベースの他のfacade利用と統一

### 2. .env.example にドキュメント追加
- PAGINATE_NUM と MAX_ARCHIVE_COUNT の説明を追加
- APP_ENV=local の場合のみ有効であることを明記
- YouTube API クォータ節約の目的を説明
- 各変数の役割を明確化

## 効果
- ローカル開発環境でのYouTube API クォータ使用量を削減
- 本番環境では制限なしで動作し、パフォーマンスを維持
- 環境による動作の違いが明確化され、保守性が向上
- デバッグモードとローカル環境の概念を適切に分離

## 技術的な詳細
**環境判定の変更理由:**
- `config('app.debug')` は任意の環境でtrueにできるデバッグフラグ
- `App::environment('local')` はローカル開発環境を明示的に判定
- ステージング環境でデバッグを有効にしてもAPI制限が適用されない（意図した動作）

Fixes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)