### PR TITLE
アーカイブ一覧の初期表示とUI改善

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -12,7 +12,7 @@ function registerArchiveListComponent() {
                 channel: window.channel || {},
                 archives: window.archives || {},
                 timestamps: {},
-                activeTab: 'archives',
+                activeTab: 'timestamps',
                 searchQuery: '',
                 archiveQuery: '',
                 tsFlg: '',
@@ -145,7 +145,7 @@ function registerArchiveListComponent() {
                 updateURL() {
                     const params = new URLSearchParams();
 
-                    if (this.activeTab !== 'archives') {
+                    if (this.activeTab !== 'timestamps') {
                         params.set('view', this.activeTab);
                     }
 
@@ -199,13 +199,8 @@ function registerArchiveListComponent() {
                     const sort = params.get('sort');
                     const page = parseInt(params.get('page')) || 1;
 
-                    if (view === 'timestamps') {
-                        this.activeTab = 'timestamps';
-                        this.searchQuery = search || '';
-                        this.timestampSort = sort || 'song_asc';
-                        this.currentTimestampPage = page;
-                        this.fetchTimestamps(page, this.searchQuery);
-                    } else {
+                    if (view === 'archives') {
+                        this.activeTab = 'archives';
                         // アーカイブタブの状態を復元
                         const archiveQuery = params.get('baramutsu') || '';
                         const tsFlg = params.get('ts') || '';
@@ -217,6 +212,13 @@ function registerArchiveListComponent() {
                         } else {
                             this.fetchData(this.firstUrl());
                         }
+                    } else {
+                        // タイムスタンプタブの状態を復元（デフォルト）
+                        this.activeTab = 'timestamps';
+                        this.searchQuery = search || '';
+                        this.timestampSort = sort || 'song_asc';
+                        this.currentTimestampPage = page;
+                        this.fetchTimestamps(page, this.searchQuery);
                     }
 
                     const paginationButtons = document.querySelectorAll('#paginationButtons button');
@@ -247,14 +249,9 @@ function registerArchiveListComponent() {
                         const sort = params.get('sort');
                         const page = parseInt(params.get('page')) || 1;
 
-                        this.activeTab = view || 'archives';
+                        this.activeTab = view || 'timestamps';
 
-                        if (view === 'timestamps') {
-                            this.searchQuery = search || '';
-                            this.timestampSort = sort || 'song_asc';
-                            this.currentTimestampPage = page;
-                            this.fetchTimestamps(page, search || '');
-                        } else {
+                        if (view === 'archives') {
                             // アーカイブタブの状態を復元
                             const archiveQuery = params.get('baramutsu') || '';
                             const tsFlg = params.get('ts') || '';
@@ -266,6 +263,12 @@ function registerArchiveListComponent() {
                             } else {
                                 this.fetchData(this.firstUrl());
                             }
+                        } else {
+                            // タイムスタンプタブの状態を復元（デフォルト）
+                            this.searchQuery = search || '';
+                            this.timestampSort = sort || 'song_asc';
+                            this.currentTimestampPage = page;
+                            this.fetchTimestamps(page, search || '');
                         }
                     });
                 }

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -145,6 +145,7 @@ function registerArchiveListComponent() {
                 updateURL() {
                     const params = new URLSearchParams();
 
+                    // Only add 'view' parameter when not on default tab (timestamps)
                     if (this.activeTab !== 'timestamps') {
                         params.set('view', this.activeTab);
                     }
@@ -192,8 +193,7 @@ function registerArchiveListComponent() {
                     window.scroll({top: 0, behavior: 'auto'});
                 },
 
-                init() {
-                    const params = new URLSearchParams(window.location.search);
+                restoreStateFromURL(params) {
                     const view = params.get('view');
                     const search = params.get('search');
                     const sort = params.get('sort');
@@ -201,7 +201,6 @@ function registerArchiveListComponent() {
 
                     if (view === 'archives') {
                         this.activeTab = 'archives';
-                        // アーカイブタブの状態を復元
                         const archiveQuery = params.get('baramutsu') || '';
                         const tsFlg = params.get('ts') || '';
                         this.archiveQuery = archiveQuery;
@@ -220,6 +219,11 @@ function registerArchiveListComponent() {
                         this.currentTimestampPage = page;
                         this.fetchTimestamps(page, this.searchQuery);
                     }
+                },
+
+                init() {
+                    const params = new URLSearchParams(window.location.search);
+                    this.restoreStateFromURL(params);
 
                     const paginationButtons = document.querySelectorAll('#paginationButtons button');
                     paginationButtons.forEach(button => {
@@ -244,32 +248,7 @@ function registerArchiveListComponent() {
 
                     window.addEventListener('popstate', () => {
                         const params = new URLSearchParams(window.location.search);
-                        const view = params.get('view');
-                        const search = params.get('search');
-                        const sort = params.get('sort');
-                        const page = parseInt(params.get('page')) || 1;
-
-                        this.activeTab = view || 'timestamps';
-
-                        if (view === 'archives') {
-                            // アーカイブタブの状態を復元
-                            const archiveQuery = params.get('baramutsu') || '';
-                            const tsFlg = params.get('ts') || '';
-                            this.archiveQuery = archiveQuery;
-                            this.tsFlg = tsFlg;
-
-                            if (archiveQuery || tsFlg) {
-                                this.archiveSearch();
-                            } else {
-                                this.fetchData(this.firstUrl());
-                            }
-                        } else {
-                            // タイムスタンプタブの状態を復元（デフォルト）
-                            this.searchQuery = search || '';
-                            this.timestampSort = sort || 'song_asc';
-                            this.currentTimestampPage = page;
-                            this.fetchTimestamps(page, search || '');
-                        }
+                        this.restoreStateFromURL(params);
                     });
                 }
             };

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -17,14 +17,20 @@
                     Youtubeチャンネルはこちら
                 </a>
                 <!-- デスクトップ用切り替えボタン -->
-                <div class="flex gap-2 ml-auto">
+                <div class="flex gap-2 ml-auto hidden sm:flex">
                     <button @click="activeTab = 'timestamps'"
                             :class="activeTab === 'timestamps' ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
+                            :aria-pressed="activeTab === 'timestamps'"
+                            role="tab"
+                            aria-label="タイムスタンプタブに切り替え"
                             class="px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
                         タイムスタンプ
                     </button>
                     <button @click="activeTab = 'archives'"
                             :class="activeTab === 'archives' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
+                            :aria-pressed="activeTab === 'archives'"
+                            role="tab"
+                            aria-label="アーカイブタブに切り替え"
                             class="px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
                         アーカイブ
                     </button>

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -16,6 +16,19 @@
                 <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')" target="_blank" rel="noopener noreferrer" class="hover:opacity-80">
                     Youtubeチャンネルはこちら
                 </a>
+                <!-- デスクトップ用切り替えボタン -->
+                <div class="flex gap-2 ml-auto">
+                    <button @click="activeTab = 'timestamps'"
+                            :class="activeTab === 'timestamps' ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
+                            class="px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
+                        タイムスタンプ
+                    </button>
+                    <button @click="activeTab = 'archives'"
+                            :class="activeTab === 'archives' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
+                            class="px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
+                        アーカイブ
+                    </button>
+                </div>
             </h2>
             <h2 class="text-gray-500 justify-self-center sm:hidden">
                 <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')" target="_blank" rel="noopener noreferrer" class="flex items-center gap-4 hover:opacity-80">
@@ -26,18 +39,18 @@
         </div>
 
         <div class="p-2 flex flex-col justify-self-center w-[100%] max-w-5xl gap-2">
-            <!-- タブUI -->
-            <div class="mb-4">
+            <!-- タブUI（モバイル専用） -->
+            <div class="mb-4 sm:hidden">
                 <nav class="flex space-x-4 border-b border-gray-200 dark:border-gray-700">
-                    <button @click="activeTab = 'archives'"
-                            :class="activeTab === 'archives' ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 dark:text-gray-400'"
-                            class="px-3 py-2 text-sm font-medium border-b-2 -mb-px hover:text-gray-700 dark:hover:text-gray-300">
-                        アーカイブ
-                    </button>
                     <button @click="activeTab = 'timestamps'"
                             :class="activeTab === 'timestamps' ? 'border-green-500 text-green-600 dark:text-green-400' : 'border-transparent text-gray-500 dark:text-gray-400'"
                             class="px-3 py-2 text-sm font-medium border-b-2 -mb-px hover:text-gray-700 dark:hover:text-gray-300">
                         タイムスタンプ
+                    </button>
+                    <button @click="activeTab = 'archives'"
+                            :class="activeTab === 'archives' ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 dark:text-gray-400'"
+                            class="px-3 py-2 text-sm font-medium border-b-2 -mb-px hover:text-gray-700 dark:hover:text-gray-300">
+                        アーカイブ
                     </button>
                 </nav>
             </div>


### PR DESCRIPTION
## 概要
Issue #156 の対応として、アーカイブ一覧の初期表示をタイムスタンプに変更し、切り替えUIを改善しました。

## 変更内容

### 1. JavaScript (resources/js/channels/archive-list.js)
- activeTab の初期値を 'timestamps' に変更
- updateURL、init、popstate ハンドラでデフォルトをタイムスタンプに変更
- 重複コード削減のため restoreStateFromURL() メソッドを追加
- URL状態管理ロジックにコメントを追加

### 2. Blade (resources/views/channels/show.blade.php)
- デスクトップ: ヘッダー右側にボタン型の切り替えUIを追加
  - rounded-lg、背景色、ホバー効果付き
  - アクセシビリティ対応 (aria-pressed, role="tab", aria-label)
- モバイル: 既存のタブUIを維持（sm:hiddenで制御）
- タブの順序をタイムスタンプ優先に変更

### 3. コードレビュー指摘事項の反映
- init()とpopstateハンドラの重複ロジックを統合
- デスクトップボタンにARIA属性を追加
- URL状態管理の意図を明確化するコメントを追加

## 期待される効果
- ユーザーが最もよく使用する機能（タイムスタンプ）を初期表示に
- デスクトップでのUI改善により、より直感的な操作が可能に
- モバイルでの使いやすさを維持
- コードの保守性向上（重複コード削減）
- アクセシビリティの向上

## UI/UX設計
- **デスクトップ**: ヘッダー右側にボタン型トグル（縦スペース節約）
- **モバイル**: 従来のタブUI（モバイルユーザーに馴染みのあるパターン）
- **カラーコーディング**: タイムスタンプ=緑、アーカイブ=青

## 注意事項
本修正は暫定対応として実装。UIの配置やデザインについては今後さらなる改善が可能。

Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)