### PR TITLE
タイムスタンプ表示に公開日と報告機能を追加（Phase 1）

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -1,4 +1,14 @@
 import { escapeHTML } from '../utils.js';
+import toast from '../utils/toast.js';
+
+// 報告タイプ定数
+const REPORT_TYPES = {
+    WRONG_SONG: 'wrong_song',
+    NOT_SONG: 'not_song',
+    NOT_TIMESTAMP: 'not_timestamp',
+    PROBLEM: 'problem',
+    OTHER: 'other'
+};
 
 /**
  * アーカイブ一覧とタイムスタンプ管理コンポーネント
@@ -268,8 +278,16 @@ function registerArchiveListComponent() {
 
                 // 報告を送信（暫定実装：コンソールに出力）
                 submitReport() {
+                    // reportTargetの存在確認
+                    if (!this.reportTarget) {
+                        console.error('No report target set');
+                        toast.error('報告対象が見つかりません');
+                        return;
+                    }
+
+                    // 報告タイプの検証
                     if (!this.reportType) {
-                        alert('報告の種類を選択してください');
+                        toast.error('報告の種類を選択してください');
                         return;
                     }
 
@@ -284,17 +302,12 @@ function registerArchiveListComponent() {
                     };
 
                     // 暫定実装：コンソールに出力
-                    console.log('=== タイムスタンプ報告 ===');
-                    console.log('タイムスタンプID:', reportData.timestamp_id);
-                    console.log('動画ID:', reportData.video_id);
-                    console.log('タイムスタンプテキスト:', reportData.timestamp_text);
-                    console.log('タイムスタンプ時刻:', reportData.timestamp_time);
-                    console.log('報告種別:', reportData.report_type);
-                    console.log('詳細:', reportData.comment);
-                    console.log('報告日時:', reportData.reported_at);
-                    console.log('========================');
+                    console.log('=== タイムスタンプ報告 ===', reportData);
 
                     // TODO: 将来的にはAPIエンドポイントに送信
+                    // Expected endpoint: POST /api/timestamp-reports
+                    // Expected response: { success: boolean, message: string }
+                    // Required headers: CSRF token
                     // await fetch('/api/timestamp-reports', {
                     //     method: 'POST',
                     //     headers: {
@@ -304,7 +317,7 @@ function registerArchiveListComponent() {
                     //     body: JSON.stringify(reportData),
                     // });
 
-                    alert('報告を受け付けました。（現在は暫定実装のため、コンソールに出力されています）');
+                    toast.success('報告を受け付けました。（現在は暫定実装のため、コンソールに出力されています）');
                     this.showReportModal = false;
                 }
             };

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -23,6 +23,12 @@ function registerArchiveListComponent() {
                 error: null,
                 isFiltered: false,
 
+                // 報告機能の状態管理
+                showReportModal: false,
+                reportTarget: null,
+                reportType: '',
+                reportComment: '',
+
                 // computed property
                 get maxPage() {
                     if (!this.archives.total || !this.archives.per_page) return 1;
@@ -250,6 +256,56 @@ function registerArchiveListComponent() {
                         const params = new URLSearchParams(window.location.search);
                         this.restoreStateFromURL(params);
                     });
+                },
+
+                // 報告モーダルを開く
+                openReportModal(timestamp) {
+                    this.reportTarget = timestamp;
+                    this.reportType = '';
+                    this.reportComment = '';
+                    this.showReportModal = true;
+                },
+
+                // 報告を送信（暫定実装：コンソールに出力）
+                submitReport() {
+                    if (!this.reportType) {
+                        alert('報告の種類を選択してください');
+                        return;
+                    }
+
+                    const reportData = {
+                        timestamp_id: this.reportTarget.id,
+                        video_id: this.reportTarget.video_id,
+                        timestamp_text: this.reportTarget.text,
+                        timestamp_time: this.reportTarget.ts_text,
+                        report_type: this.reportType,
+                        comment: this.reportComment,
+                        reported_at: new Date().toISOString(),
+                    };
+
+                    // 暫定実装：コンソールに出力
+                    console.log('=== タイムスタンプ報告 ===');
+                    console.log('タイムスタンプID:', reportData.timestamp_id);
+                    console.log('動画ID:', reportData.video_id);
+                    console.log('タイムスタンプテキスト:', reportData.timestamp_text);
+                    console.log('タイムスタンプ時刻:', reportData.timestamp_time);
+                    console.log('報告種別:', reportData.report_type);
+                    console.log('詳細:', reportData.comment);
+                    console.log('報告日時:', reportData.reported_at);
+                    console.log('========================');
+
+                    // TODO: 将来的にはAPIエンドポイントに送信
+                    // await fetch('/api/timestamp-reports', {
+                    //     method: 'POST',
+                    //     headers: {
+                    //         'Content-Type': 'application/json',
+                    //         'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                    //     },
+                    //     body: JSON.stringify(reportData),
+                    // });
+
+                    alert('報告を受け付けました。（現在は暫定実装のため、コンソールに出力されています）');
+                    this.showReportModal = false;
                 }
             };
         });

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -362,7 +362,11 @@
         <div x-show="showReportModal"
              x-cloak
              class="fixed inset-0 z-50 overflow-y-auto"
-             @click.self="showReportModal = false">
+             role="dialog"
+             aria-modal="true"
+             aria-labelledby="report-modal-title"
+             @click.self="showReportModal = false"
+             @keydown.escape.window="showReportModal = false">
             <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
                 <!-- 背景オーバーレイ -->
                 <div x-show="showReportModal"
@@ -386,7 +390,7 @@
                      class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
 
                     <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-                        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+                        <h3 id="report-modal-title" class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
                             タイムスタンプの報告
                         </h3>
 

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -298,10 +298,15 @@
                                     </template>
                                 </div>
 
-                                <!-- アーカイブタイトル: モバイルでは非表示 -->
-                                <div class="hidden sm:block text-sm text-gray-600 dark:text-gray-400 truncate flex-1"
-                                     :title="ts.archive.title"
-                                     x-text="ts.archive.title">
+                                <!-- アーカイブタイトル & 公開日: モバイルでは非表示 -->
+                                <div class="hidden sm:block text-sm truncate flex-1">
+                                    <div class="text-gray-600 dark:text-gray-400 truncate"
+                                         :title="ts.archive.title"
+                                         x-text="ts.archive.title">
+                                    </div>
+                                    <div class="text-xs text-gray-500 dark:text-gray-500 mt-0.5"
+                                         x-text="'公開日: ' + (ts.archive.published_at ? new Date(ts.archive.published_at).toLocaleDateString() : '不明')">
+                                    </div>
                                 </div>
 
                                 <!-- 動画リンク: モバイルではコンパクト -->
@@ -310,6 +315,13 @@
                                    target="_blank"
                                    x-text="ts.ts_text + ' ↗'">
                                 </a>
+
+                                <!-- 報告ボタン -->
+                                <button @click="openReportModal(ts)"
+                                        class="text-gray-500 hover:text-red-500 dark:text-gray-400 dark:hover:text-red-400 text-xs px-2 py-1 border border-gray-300 dark:border-gray-600 rounded hover:border-red-500 dark:hover:border-red-400 transition-colors whitespace-nowrap"
+                                        title="問題を報告">
+                                    報告
+                                </button>
                             </div>
                         </div>
                     </template>
@@ -342,6 +354,85 @@
                             class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded text-sm">
                         最後
                     </button>
+                </div>
+            </div>
+        </div>
+
+        <!-- 報告モーダル -->
+        <div x-show="showReportModal"
+             x-cloak
+             class="fixed inset-0 z-50 overflow-y-auto"
+             @click.self="showReportModal = false">
+            <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
+                <!-- 背景オーバーレイ -->
+                <div x-show="showReportModal"
+                     x-transition:enter="ease-out duration-300"
+                     x-transition:enter-start="opacity-0"
+                     x-transition:enter-end="opacity-100"
+                     x-transition:leave="ease-in duration-200"
+                     x-transition:leave-start="opacity-100"
+                     x-transition:leave-end="opacity-0"
+                     class="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-75"
+                     @click="showReportModal = false"></div>
+
+                <!-- モーダルコンテンツ -->
+                <div x-show="showReportModal"
+                     x-transition:enter="ease-out duration-300"
+                     x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                     x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+                     x-transition:leave="ease-in duration-200"
+                     x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+                     x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+                     class="inline-block align-bottom bg-white dark:bg-gray-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+
+                    <div class="bg-white dark:bg-gray-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                        <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">
+                            タイムスタンプの報告
+                        </h3>
+
+                        <div class="mb-4 p-3 bg-gray-50 dark:bg-gray-700 rounded text-sm">
+                            <div class="text-gray-700 dark:text-gray-300" x-text="reportTarget?.text || ''"></div>
+                            <div class="text-xs text-gray-500 dark:text-gray-400 mt-1" x-text="reportTarget?.ts_text || ''"></div>
+                        </div>
+
+                        <div class="mb-4">
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                報告の種類を選択してください
+                            </label>
+                            <select x-model="reportType"
+                                    class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-gray-300">
+                                <option value="">選択してください</option>
+                                <option value="wrong_song">表示される楽曲名が違う</option>
+                                <option value="not_song">楽曲ではない</option>
+                                <option value="not_timestamp">タイムスタンプではない</option>
+                                <option value="problem">問題がある</option>
+                                <option value="other">その他</option>
+                            </select>
+                        </div>
+
+                        <div class="mb-4">
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                詳細（任意）
+                            </label>
+                            <textarea x-model="reportComment"
+                                      rows="3"
+                                      class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-gray-300"
+                                      placeholder="詳細な情報があれば記入してください"></textarea>
+                        </div>
+                    </div>
+
+                    <div class="bg-gray-50 dark:bg-gray-700 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse gap-2">
+                        <button @click="submitReport()"
+                                :disabled="!reportType"
+                                :class="!reportType ? 'opacity-50 cursor-not-allowed' : 'hover:bg-red-700'"
+                                class="w-full sm:w-auto px-4 py-2 bg-red-600 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">
+                            報告する
+                        </button>
+                        <button @click="showReportModal = false"
+                                class="w-full sm:w-auto mt-3 sm:mt-0 px-4 py-2 bg-white dark:bg-gray-600 text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-gray-500 rounded-md hover:bg-gray-50 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">
+                            キャンセル
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## 概要
Issue #159 の対応として、タイムスタンプタブに公開日表示と報告機能を追加しました（Phase 1: UI実装）。

## 変更内容

### 1. タイムスタンプ一覧にアーカイブの公開日を表示
- タイムスタンプタブのアーカイブタイトル下に公開日を追加表示
- 既存のAPIレスポンス（archive.published_at）を利用
- デスクトップ表示のみ（モバイルでは非表示）

### 2. タイムスタンプの報告機能UI（暫定実装）
- 各タイムスタンプに「報告」ボタンを追加
- 報告モーダルで以下の種別を選択可能：
  - 表示される楽曲名が違う
  - 楽曲ではない
  - タイムスタンプではない
  - 問題がある
  - その他
- 詳細コメント入力欄を追加
- 現在は暫定実装として、コンソールへの出力のみ

### 3. コードレビュー指摘事項の反映
- **alert()をtoast通知システムに置き換え**
  - プロジェクト方針（ycs-replace-alert-with-message）に準拠
- **バリデーション強化**
  - reportTargetの存在確認を追加
  - エラーハンドリングの改善
- **レポートタイプを定数化**
  - REPORT_TYPES定数を追加
  - フロントエンド・バックエンド連携の準備
- **アクセシビリティ改善**
  - role="dialog"とaria-modal="true"を追加
  - Escapeキーでモーダルを閉じる機能を追加

## 対応方針

### 公開日表示
- バックエンド変更なし（既存データを活用）
- フロントエンドのみの対応で実装完了

### 報告機能
- **Phase 1（本PR）**：UIとクライアント側処理を実装
- **Phase 2（今後）**：バックエンドAPI実装
  - データベース設計（timestamp_reportsテーブル作成）
  - APIエンドポイント実装（POST /api/timestamp-reports）
  - 管理画面での報告確認機能
  - 報告に基づく自動/手動処理フロー

## 変更ファイル
- `resources/views/channels/show.blade.php`
  - 公開日表示を追加
  - 報告ボタンと報告モーダルUIを追加
  - アクセシビリティ属性を追加
- `resources/js/channels/archive-list.js`
  - toast.jsのインポート
  - レポートタイプ定数を追加
  - 報告機能の状態管理を追加
  - openReportModal()とsubmitReport()メソッドを追加
  - バリデーションとエラーハンドリングを改善

## 期待される効果
- ユーザーがタイムスタンプの公開日を確認できる
- ユーザーが誤ったタイムスタンプ情報を報告できる仕組みの基盤
- データ品質向上への第一歩
- ユーザーエクスペリエンスの向上（toast通知）
- アクセシビリティの向上

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)