### PR TITLE
improve: タイムスタンプの正規化表示とホバーでの元データ表示機能を実装 #158

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -1,4 +1,4 @@
-import { escapeHTML } from '../utils.js';
+import { escapeHTML, formatDate } from '../utils.js';
 import toast from '../utils/toast.js';
 
 // 報告タイプ定数
@@ -77,6 +77,10 @@ function registerArchiveListComponent() {
 
                 escapeHTML(str) {
                     return escapeHTML(str);
+                },
+
+                formatPublishedDate(dateStr) {
+                    return formatDate(dateStr);
                 },
 
                 archiveSearch() {

--- a/resources/js/manage/archives.js
+++ b/resources/js/manage/archives.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import DOMPurify from 'dompurify';
-import { escapeHTML, toggleButtonDisabled } from "../utils";
+import { escapeHTML, toggleButtonDisabled, formatDate } from "../utils";
 
 document.addEventListener('DOMContentLoaded', function () {
     const registerForm = document.getElementById('archiveRegisterForm');
@@ -58,8 +58,8 @@ document.addEventListener('DOMContentLoaded', function () {
                                         <h4 class="font-semibold ${archive.is_display ? 'text-gray-800' : 'text-gray-500'}">
                                             ${escapeHTML(archive.title || '')}
                                         </h4>
-                                        <p class="text-sm text-gray-600">
-                                            公開日: ${new Date(archive.published_at || 0).toLocaleString().split(' ')[0]}
+                                        <p class="text-sm text-gray-600" title="元の値: ${escapeHTML(archive.published_at || '')}">
+                                            公開日: ${formatDate(archive.published_at)}
                                         </p>
                                     </div>
                                     <div class="flex flex-col">

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -13,7 +13,11 @@ export function toggleButtonDisabled(target, flg) {
 /**
  * 日付を正規化してフォーマットする
  * @param {string|Date} dateStr - 日付文字列またはDateオブジェクト
- * @returns {string} - YYYY年MM月DD日 形式の文字列
+ * @returns {string} - YYYY年MM月DD日 形式の文字列。無効な入力の場合は空文字列を返す
+ * @example
+ * formatDate('2024-11-11') // '2024年11月11日'
+ * formatDate('') // ''
+ * formatDate(null) // ''
  */
 export function formatDate(dateStr) {
     if (!dateStr) return '';

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -9,3 +9,21 @@ export function toggleButtonDisabled(target, flg) {
     target.classList.toggle('opacity-50', flg);
     target.classList.toggle('cursor-not-allowed', flg);
 }
+
+/**
+ * 日付を正規化してフォーマットする
+ * @param {string|Date} dateStr - 日付文字列またはDateオブジェクト
+ * @returns {string} - YYYY年MM月DD日 形式の文字列
+ */
+export function formatDate(dateStr) {
+    if (!dateStr) return '';
+
+    const date = new Date(dateStr);
+    if (isNaN(date.getTime())) return '';
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+
+    return `${year}年${month}月${day}日`;
+}

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -133,7 +133,8 @@
                                 <div :class="isFiltered ? 'w-3/4' : ''">
                                     <h4 class="font-semibold text-gray-800 line-clamp-2" x-text="archive.title || ''"></h4>
                                     <p class="text-sm text-gray-600"
-                                        x-text="'公開日: ' + (new Date(archive.published_at || 0)).toLocaleString().split(' ')[0]"></p>
+                                        :title="'元の値: ' + (archive.published_at || '')"
+                                        x-text="'公開日: ' + formatPublishedDate(archive.published_at)"></p>
                                 </div>
                             </div>
                         </div>

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -306,7 +306,8 @@
                                          x-text="ts.archive.title">
                                     </div>
                                     <div class="text-xs text-gray-500 dark:text-gray-500 mt-0.5"
-                                         x-text="'公開日: ' + (ts.archive.published_at ? new Date(ts.archive.published_at).toLocaleDateString() : '不明')">
+                                         :title="'元の値: ' + (ts.archive.published_at || '')"
+                                         x-text="'公開日: ' + (ts.archive.published_at ? formatPublishedDate(ts.archive.published_at) : '不明')">
                                     </div>
                                 </div>
 


### PR DESCRIPTION
## Summary
- formatDate関数を追加して日付表示を「YYYY年MM月DD日」形式に統一
- ホバー時に元データを表示するtitle属性を追加
- アーカイブタブとタイムスタンプタブで一貫した日付表示を実現

## Changes

### 1. formatDate ユーティリティ関数の追加
- `resources/js/utils.js` に formatDate 関数を実装
- 日付文字列を「YYYY年MM月DD日」形式にフォーマット
- 無効な入力時は空文字列を返す
- JSDocに使用例を追加して利用方法を明確化

### 2. Alpine.jsコンポーネントの拡張
- `resources/js/channels/archive-list.js` に formatPublishedDate メソッドを追加
- formatDate関数をインポートして利用

### 3. ビューでの日付表示の統一
- `resources/views/channels/show.blade.php` で新しいフォーマット関数を使用
- アーカイブタブとタイムスタンプタブの両方で統一された日付表示
- title属性で元データを表示（「元の値: YYYY-MM-DD HH:MM:SS」）

### 4. 管理画面の日付表示も統一
- `resources/js/manage/archives.js` でも同様のフォーマットを適用

## Code Review Improvements
- タイムスタンプタブの日付表示をformatPublishedDate()に統一
- JSDocにエッジケースと使用例を追加
- 全ての日付表示にtitle属性を追加

## Test plan
- [ ] アーカイブタブで公開日が「YYYY年MM月DD日」形式で表示されることを確認
- [ ] タイムスタンプタブで公開日が同じ形式で表示されることを確認
- [ ] 日付にマウスをホバーすると元データが表示されることを確認
- [ ] 管理画面のアーカイブ一覧でも同じ形式で表示されることを確認
- [ ] 無効な日付データ（null、空文字列）が正しく処理されることを確認

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)