### PR TITLE
improve: 長い動画タイトル表示の改善（トグル機能追加） #157

### DIFF
--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -1043,6 +1043,11 @@ class TimestampNormalization {
 
         videoTitle.textContent = title;
         videoTitle.title = title;
+        // 初期状態でtruncateクラスを適用
+        if (!videoTitle.classList.contains('truncate')) {
+            videoTitle.classList.add('truncate');
+            videoTitle.style.maxWidth = '300px';
+        }
         videoLinkBtn.disabled = !enabled;
         videoLinkBtn.setAttribute('aria-disabled', enabled ? 'false' : 'true');
 

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -1043,11 +1043,9 @@ class TimestampNormalization {
 
         videoTitle.textContent = title;
         videoTitle.title = title;
-        // 初期状態でtruncateクラスを適用
-        if (!videoTitle.classList.contains('truncate')) {
-            videoTitle.classList.add('truncate');
-            videoTitle.style.maxWidth = '300px';
-        }
+        // 初期状態でtruncateクラスを適用（必ず初期化）
+        videoTitle.classList.add('truncate');
+        videoTitle.style.maxWidth = '300px';
         videoLinkBtn.disabled = !enabled;
         videoLinkBtn.setAttribute('aria-disabled', enabled ? 'false' : 'true');
 

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -131,7 +131,13 @@
                                         class="rounded-md object-cover flex flex-shrink-0"/>
                                 </a>
                                 <div :class="isFiltered ? 'w-3/4' : ''">
-                                    <h4 class="font-semibold text-gray-800 line-clamp-2" x-text="archive.title || ''"></h4>
+                                    <h4 class="font-semibold text-gray-800 cursor-pointer hover:text-blue-600 transition-colors"
+                                        x-data="{ expanded: false }"
+                                        :class="expanded ? '' : 'truncate'"
+                                        :title="archive.title || ''"
+                                        @click="expanded = !expanded"
+                                        x-text="archive.title || ''">
+                                    </h4>
                                     <p class="text-sm text-gray-600"
                                         :title="'元の値: ' + (archive.published_at || '')"
                                         x-text="'公開日: ' + formatPublishedDate(archive.published_at)"></p>

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -131,11 +131,17 @@
                                         class="rounded-md object-cover flex flex-shrink-0"/>
                                 </a>
                                 <div :class="isFiltered ? 'w-3/4' : ''">
-                                    <h4 class="font-semibold text-gray-800 cursor-pointer hover:text-blue-600 transition-colors"
+                                    <h4 class="font-semibold text-gray-800 cursor-pointer hover:text-blue-600 transition-colors transition-all duration-200 ease-in-out"
                                         x-data="{ expanded: false }"
                                         :class="expanded ? '' : 'truncate'"
                                         :title="archive.title || ''"
                                         @click="expanded = !expanded"
+                                        role="button"
+                                        tabindex="0"
+                                        :aria-expanded="expanded"
+                                        aria-label="タイトルを展開/折りたたみ"
+                                        @keydown.enter="expanded = !expanded"
+                                        @keydown.space.prevent="expanded = !expanded"
                                         x-text="archive.title || ''">
                                     </h4>
                                     <p class="text-sm text-gray-600"

--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -57,7 +57,11 @@
 
                             <!-- 動画情報表示エリア -->
                             <div id="videoInfoArea" class="flex-1 flex items-center justify-end gap-2">
-                                <div class="text-xs text-gray-600 dark:text-gray-400 truncate max-w-[200px]" id="videoTitle" title="">
+                                <div class="text-xs text-gray-600 dark:text-gray-400 cursor-pointer hover:text-blue-600 transition-colors"
+                                     id="videoTitle"
+                                     title=""
+                                     style="max-width: 300px;"
+                                     onclick="this.classList.toggle('truncate'); if(!this.classList.contains('truncate')) { this.style.maxWidth = 'none'; } else { this.style.maxWidth = '300px'; }">
                                 </div>
                                 <button id="videoLinkBtn" class="px-3 py-1 text-white text-xs rounded flex-shrink-0 flex items-center gap-1 transition-colors bg-gray-400 cursor-not-allowed" disabled aria-label="動画を開く" aria-disabled="true">
                                     ▶ 動画を開く

--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -57,11 +57,19 @@
 
                             <!-- 動画情報表示エリア -->
                             <div id="videoInfoArea" class="flex-1 flex items-center justify-end gap-2">
-                                <div class="text-xs text-gray-600 dark:text-gray-400 cursor-pointer hover:text-blue-600 transition-colors"
+                                <div class="text-xs text-gray-600 dark:text-gray-400 cursor-pointer hover:text-blue-600 transition-colors transition-all duration-200 ease-in-out max-w-[300px]"
                                      id="videoTitle"
                                      title=""
-                                     style="max-width: 300px;"
-                                     onclick="this.classList.toggle('truncate'); if(!this.classList.contains('truncate')) { this.style.maxWidth = 'none'; } else { this.style.maxWidth = '300px'; }">
+                                     x-data="{ expanded: false }"
+                                     :class="expanded ? '' : 'truncate'"
+                                     :style="expanded ? 'max-width: none;' : ''"
+                                     @click="expanded = !expanded"
+                                     role="button"
+                                     tabindex="0"
+                                     :aria-expanded="expanded"
+                                     aria-label="タイトルを展開/折りたたみ"
+                                     @keydown.enter="expanded = !expanded"
+                                     @keydown.space.prevent="expanded = !expanded">
                                 </div>
                                 <button id="videoLinkBtn" class="px-3 py-1 text-white text-xs rounded flex-shrink-0 flex items-center gap-1 transition-colors bg-gray-400 cursor-not-allowed" disabled aria-label="動画を開く" aria-disabled="true">
                                     ▶ 動画を開く


### PR DESCRIPTION
## Summary
- 長い動画タイトルを展開/折りたたみできるトグル機能を追加
- 実装パターンをAlpine.jsに統一してコードの保守性を向上
- アクセシビリティ属性を追加してキーボード操作とスクリーンリーダーに対応

## Changes

### 1. アーカイブ一覧のタイトルトグル機能
- `resources/views/channels/show.blade.php` でAlpine.jsを使用した展開/折りたたみ機能を実装
- クリックでタイトルの省略表示と全文表示を切り替え
- アクセシビリティ属性（role, tabindex, aria-expanded, aria-label）を追加
- キーボード操作（Enter, Space）をサポート
- スムーズなアニメーション（transition-all duration-200）を追加

### 2. 楽曲詳細画面のタイトルトグル機能を統一
- `resources/views/songs/index.blade.php` のインラインonclick処理をAlpine.jsに変更
- channels/show.blade.phpと同じパターンで実装
- インラインスタイルをTailwindクラス（max-w-[300px]）に置き換え
- アクセシビリティ対応を追加

### 3. 状態リセット問題の修正
- `resources/js/songs/normalize.js` で動画切り替え時に必ずtruncate状態にリセット
- 展開状態が次の動画に引き継がれる問題を解決

## Code Review Improvements Applied
- 状態管理の一貫性を確保（normalize.jsの条件分岐を削除）
- 実装パターンを統一（Alpine.jsに統一）
- アクセシビリティを向上（ARIA属性、キーボード操作）
- インラインスタイルを削除してTailwindクラスを使用

## Test plan
- [ ] アーカイブ一覧で長いタイトルをクリックして展開/折りたたみが機能することを確認
- [ ] 楽曲詳細画面で動画タイトルをクリックして展開/折りたたみが機能することを確認
- [ ] Enterキーとスペースキーでタイトルをトグルできることを確認
- [ ] 楽曲詳細画面で動画を切り替えた際にタイトルが折りたたみ状態にリセットされることを確認
- [ ] スクリーンリーダーでaria-expanded属性が適切に読み上げられることを確認
- [ ] ホバー時に色が変わることを確認（hover:text-blue-600）
- [ ] トグル時のアニメーションがスムーズであることを確認

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)