### PR TITLE
improve: アーカイブ一覧・タイムスタンプに配信リンク（Spotify）を追加 #155

### DIFF
--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -167,6 +167,8 @@
                                                 <a :href="`https://open.spotify.com/track/${tsItem.song.spotify_track_id}`"
                                                    target="_blank"
                                                    rel="noopener noreferrer"
+                                                   :aria-label="`Spotifyで「${tsItem.text}」を聴く`"
+                                                   :title="`Spotifyで「${tsItem.song.title} / ${tsItem.song.artist}」を聴く`"
                                                    class="inline-flex items-center gap-1 text-xs text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300 hover:underline ml-2">
                                                     <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
                                                         <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
@@ -333,6 +335,8 @@
                                             <a :href="`https://open.spotify.com/track/${ts.mapping.song.spotify_track_id}`"
                                                target="_blank"
                                                rel="noopener noreferrer"
+                                               :aria-label="`Spotifyで「${ts.mapping.song.title}」を聴く`"
+                                               :title="`Spotifyで「${ts.mapping.song.title} / ${ts.mapping.song.artist}」を聴く`"
                                                class="inline-flex items-center gap-1 text-xs text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300 hover:underline">
                                                 <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
                                                     <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -154,10 +154,27 @@
                             <div class="timestamps flex flex-col gap-2 sm:gap-0">
                                 <template x-for="tsItem in archive.ts_items_display" :key="tsItem.id">
                                     <div class="timestamp text-sm text-gray-700">
-                                        <a :href="getArchiveUrl(tsItem.video_id, tsItem.ts_num)"
-                                            target="_blank" rel="noopener noreferrer" class="text-blue-500 tabular-nums hover:underline"
-                                            x-text="tsItem.ts_text || '0:00:00'">
-                                        </a> <span class="ml-2" x-text="tsItem.text || ''"></span>
+                                        <div class="flex flex-col sm:flex-row sm:items-center gap-1">
+                                            <div class="flex items-baseline gap-2">
+                                                <a :href="getArchiveUrl(tsItem.video_id, tsItem.ts_num)"
+                                                    target="_blank" rel="noopener noreferrer" class="text-blue-500 tabular-nums hover:underline"
+                                                    x-text="tsItem.ts_text || '0:00:00'">
+                                                </a>
+                                                <span x-text="tsItem.text || ''"></span>
+                                            </div>
+                                            <!-- 配信リンク -->
+                                            <template x-if="tsItem.song?.spotify_track_id">
+                                                <a :href="`https://open.spotify.com/track/${tsItem.song.spotify_track_id}`"
+                                                   target="_blank"
+                                                   rel="noopener noreferrer"
+                                                   class="inline-flex items-center gap-1 text-xs text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300 hover:underline ml-2">
+                                                    <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
+                                                        <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
+                                                    </svg>
+                                                    <span>Spotify</span>
+                                                </a>
+                                            </template>
+                                        </div>
                                     </div>
                                 </template>
                             </div>
@@ -297,17 +314,32 @@
                         <div class="p-2 border rounded hover:bg-gray-50 dark:hover:bg-gray-700 active:bg-gray-100 dark:active:bg-gray-600 dark:border-gray-600 transition-colors">
                             <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
                                 <!-- 楽曲情報 -->
-                                <div class="truncate flex-shrink-0 w-full sm:w-[300px]"
-                                     :title="ts.mapping?.song ? `${ts.mapping.song.title} / ${ts.mapping.song.artist}` : ts.text">
-                                    <template x-if="ts.mapping?.song">
-                                        <span>
-                                            <span class="font-medium text-xs sm:text-sm" x-text="ts.mapping.song.title"></span>
-                                            <span class="text-gray-500 dark:text-gray-400 text-xs sm:text-sm"> / </span>
-                                            <span class="text-gray-500 dark:text-gray-400 text-xs sm:text-sm" x-text="ts.mapping.song.artist"></span>
-                                        </span>
-                                    </template>
-                                    <template x-if="!ts.mapping?.song">
-                                        <span class="text-xs sm:text-sm text-gray-700 dark:text-gray-300" x-text="ts.text"></span>
+                                <div class="flex-shrink-0 w-full sm:w-[300px]">
+                                    <div class="truncate" :title="ts.mapping?.song ? `${ts.mapping.song.title} / ${ts.mapping.song.artist}` : ts.text">
+                                        <template x-if="ts.mapping?.song">
+                                            <span>
+                                                <span class="font-medium text-xs sm:text-sm" x-text="ts.mapping.song.title"></span>
+                                                <span class="text-gray-500 dark:text-gray-400 text-xs sm:text-sm"> / </span>
+                                                <span class="text-gray-500 dark:text-gray-400 text-xs sm:text-sm" x-text="ts.mapping.song.artist"></span>
+                                            </span>
+                                        </template>
+                                        <template x-if="!ts.mapping?.song">
+                                            <span class="text-xs sm:text-sm text-gray-700 dark:text-gray-300" x-text="ts.text"></span>
+                                        </template>
+                                    </div>
+                                    <!-- 配信リンク -->
+                                    <template x-if="ts.mapping?.song?.spotify_track_id">
+                                        <div class="mt-1">
+                                            <a :href="`https://open.spotify.com/track/${ts.mapping.song.spotify_track_id}`"
+                                               target="_blank"
+                                               rel="noopener noreferrer"
+                                               class="inline-flex items-center gap-1 text-xs text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300 hover:underline">
+                                                <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
+                                                    <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
+                                                </svg>
+                                                <span>Spotify</span>
+                                            </a>
+                                        </div>
                                     </template>
                                 </div>
 


### PR DESCRIPTION
## Summary
- アーカイブ一覧とタイムスタンプ表示にSpotifyリンクを追加
- N+1クエリ問題を回避した効率的な実装
- セキュリティとアクセシビリティを考慮した改善を実施

## Changes

### 1. アーカイブ一覧へのSpotifyリンク追加
- `app/Http/Controllers/ChannelController.php` でfetchArchivesメソッドを拡張
- タイムスタンプ表示（ts_items_display）に楽曲情報を付与
- N+1問題を回避するため一括でマッピング情報を取得
- `resources/views/channels/show.blade.php` にSpotifyリンクUI追加

### 2. タイムスタンプタブへのSpotifyリンク追加
- fetchTimestampsメソッドで楽曲マッピング情報を付与
- is_not_songフラグを考慮した適切な判定
- タイムスタンプタブにもSpotifyリンクUIを追加

### 3. セキュリティ強化
- validateSpotifyTrackId()メソッドを実装
- Track IDフォーマット検証（22文字の英数字）
- 不正データによる潜在的なXSS脆弱性を防止

### 4. エラーハンドリング追加
- データベースクエリのtry-catchブロック実装
- エラー時は空のコレクションを返して処理を継続
- エラーログを記録して問題追跡を容易に

### 5. パフォーマンス改善
- タイムスタンプがない場合の早期リターン
- 不要なデータベースクエリを回避

### 6. アクセシビリティ向上
- aria-label属性で楽曲情報をスクリーンリーダーに提供
- title属性でホバー時の詳細情報表示
- 適切な外部リンク属性（target="_blank", rel="noopener noreferrer"）

## UI Features
- Spotifyの公式緑色（text-green-600）でブランド識別
- SVGアイコンによる視覚的な識別
- ホバー時のアニメーション（hover:underline, hover:text-green-700）
- レスポンシブ対応

## Test plan
- [ ] アーカイブ一覧で楽曲マッピング済みタイムスタンプにSpotifyリンクが表示されることを確認
- [ ] タイムスタンプタブで楽曲マッピング済みアイテムにSpotifyリンクが表示されることを確認
- [ ] Spotifyリンクをクリックして正しい楽曲ページが新しいタブで開くことを確認
- [ ] 楽曲マッピングがないタイムスタンプではリンクが表示されないことを確認
- [ ] is_not_songフラグが立っているタイムスタンプではリンクが表示されないことを確認
- [ ] aria-label属性が正しく設定されていることをスクリーンリーダーで確認
- [ ] ホバー時のtitle属性で楽曲情報が表示されることを確認
- [ ] 不正なSpotify Track IDが適切にフィルタリングされることを確認
- [ ] データベースエラー時もアプリケーションが正常動作することを確認

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)