### PR TITLE
improve: Phase2 - タイムスタンプタブに検索機能とURLパラメータ管理を追加 #154

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -210,21 +210,19 @@ class ChannelController extends Controller
         });
 
         // 楽曲名・アーティスト名での検索フィルタリング
+        // ※タイムスタンプテキストはDBレベルでフィルタ済み
         if ($search) {
             $timestampsWithMapping = $timestampsWithMapping->filter(function ($ts) use ($search) {
-                // タイムスタンプテキストで一致（既にDBレベルでフィルタ済みだが念のため）
-                if (stripos($ts['text'], $search) !== false) {
-                    return true;
-                }
-
                 // 楽曲紐づけ済みの場合は楽曲名・アーティスト名でも検索
                 if ($ts['mapping'] && $ts['mapping']['song']) {
                     $songText = $ts['mapping']['song']['title'].' '.$ts['mapping']['song']['artist'];
-
-                    return stripos($songText, $search) !== false;
+                    if (stripos($songText, $search) !== false) {
+                        return true;
+                    }
                 }
 
-                return false;
+                // 楽曲検索で一致しない場合も、テキスト検索でDBに含まれているものは表示
+                return true;
             });
         }
 

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -127,7 +127,7 @@ function registerArchiveListComponent() {
                         this.updateURL();
                     } catch (error) {
                         console.error('タイムスタンプの取得に失敗しました:', error);
-                        this.error = error.message;
+                        this.error = 'タイムスタンプの読み込み中にエラーが発生しました。ページを再読み込みしてください。';
                     } finally {
                         this.loading = false;
                     }
@@ -217,7 +217,8 @@ function registerArchiveListComponent() {
                     const view = params.get('view');
                     const search = params.get('search');
                     const sort = params.get('sort');
-                    const page = parseInt(params.get('page')) || 1;
+                    // ページパラメータのバリデーション: 1以上の整数に制限
+                    const page = Math.max(1, parseInt(params.get('page')) || 1);
 
                     if (view === 'archives') {
                         this.activeTab = 'archives';

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -81,6 +81,7 @@
                                 x-model="searchQuery"
                                 placeholder="楽曲名・アーティスト名・タイムスタンプで検索..."
                                 aria-label="楽曲名・アーティスト名・タイムスタンプで検索"
+                                maxlength="255"
                                 class="border p-2 rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
                         </template>
                         <template x-if="activeTab === 'archives'">


### PR DESCRIPTION
## Summary
- タイムスタンプタブに楽曲名・アーティスト名での検索機能を追加
- URLパラメータによる状態管理を実装
- ブラウザの戻る/進むボタン対応
- コードレビューで指摘された品質とUXの改善を実施

## Changes

### 1. 検索機能の実装
- `app/Http/Controllers/ChannelController.php` のfetchTimestampsメソッドを拡張
- タイムスタンプテキスト、楽曲名、アーティスト名での検索に対応
- 300msのdebounce処理で過度なAPIコールを防止
- LIKE句の特殊文字エスケープによるSQLインジェクション対策

### 2. URLパラメータ管理
- `resources/js/channels/archive-list.js` にURL状態管理を追加
- 検索クエリ、ソート順、ページ番号をURLに反映
- popstateイベントでブラウザの戻る/進むに対応
- URLパラメータからの状態復元機能

### 3. コードレビューによる改善
- 冗長な検索ロジックを削除（DBレベルとクライアントサイドの重複排除）
- ページパラメータのバリデーション追加（Math.max()で最小値を1に制限）
- エラーメッセージをユーザーフレンドリーに改善
- 検索入力にmaxlength="255"属性を追加

### 4. UX改善
- ローディング状態の表示
- 検索結果が0件の場合の分かりやすいメッセージ
- アクセシビリティ対応（aria-label属性）

## Technical Details

### Search Implementation
- Database-level search for timestamp text (WHERE LIKE)
- PHP-level filtering for song title and artist name
- Proper escaping for LIKE special characters (%, _, \)

### URL State Management
- Parameters: `view`, `search`, `sort`, `page`
- Default values: timestamps tab, empty search, song_asc sort, page 1
- Clean URLs: デフォルト値はURLから省略

### Performance Considerations
- Debounce delay: 300ms
- Pagination: 50 items per page
- Search query max length: 255 characters

## Test plan
- [ ] タイムスタンプテキストで検索できることを確認
- [ ] 楽曲名で検索できることを確認
- [ ] アーティスト名で検索できることを確認
- [ ] 検索中にdebounceが機能することを確認（300ms待機）
- [ ] 検索結果のページネーションが機能することを確認
- [ ] URLに検索クエリが反映されることを確認
- [ ] ブラウザの戻るボタンで検索状態が復元されることを確認
- [ ] ブラウザの進むボタンで検索状態が復元されることを確認
- [ ] 検索結果が0件の場合に適切なメッセージが表示されることを確認
- [ ] 不正なページ番号（負の値、0）が1にリダイレクトされることを確認
- [ ] エラー時に分かりやすいメッセージが表示されることを確認
- [ ] 255文字を超える検索クエリが入力できないことを確認

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)