### PR TITLE
feat: タイムスタンプ一覧のテキストダウンロード機能を追加

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -167,10 +167,9 @@ function registerArchiveListComponent() {
                         // ダウンロード用URLを生成
                         const url = `/api/channels/${this.channel.handle}/timestamps/download`;
 
-                        // リンクを作成してクリック
+                        // リンクを作成してクリック（サーバー側のファイル名を使用）
                         const a = document.createElement('a');
                         a.href = url;
-                        a.download = `timestamps_${Date.now()}.txt`;
                         document.body.appendChild(a);
                         a.click();
                         document.body.removeChild(a);
@@ -178,7 +177,7 @@ function registerArchiveListComponent() {
                         toast.success('ダウンロードを開始しました');
                     } catch (error) {
                         console.error('ダウンロードに失敗しました:', error);
-                        toast.error('ダウンロードに失敗しました');
+                        toast.error('ダウンロードに失敗しました。時間をおいて再度お試しください。');
                     }
                 },
 

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -162,6 +162,26 @@ function registerArchiveListComponent() {
                     }, 100); // データ取得待ち
                 },
 
+                downloadTimestamps() {
+                    try {
+                        // ダウンロード用URLを生成
+                        const url = `/api/channels/${this.channel.handle}/timestamps/download`;
+
+                        // リンクを作成してクリック
+                        const a = document.createElement('a');
+                        a.href = url;
+                        a.download = `timestamps_${Date.now()}.txt`;
+                        document.body.appendChild(a);
+                        a.click();
+                        document.body.removeChild(a);
+
+                        toast.success('ダウンロードを開始しました');
+                    } catch (error) {
+                        console.error('ダウンロードに失敗しました:', error);
+                        toast.error('ダウンロードに失敗しました');
+                    }
+                },
+
                 updateURL() {
                     const params = new URLSearchParams();
 

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -102,12 +102,20 @@
                         </button>
                     </template>
                     <template x-if="activeTab === 'timestamps'">
-                        <button
-                            type="button"
-                            @click="searchQuery = ''"
-                            class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600">
-                            クリア
-                        </button>
+                        <div class="flex gap-2">
+                            <button
+                                type="button"
+                                @click="searchQuery = ''"
+                                class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600">
+                                クリア
+                            </button>
+                            <button
+                                type="button"
+                                @click="downloadTimestamps()"
+                                class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 flex items-center gap-1">
+                                📥 ダウンロード
+                            </button>
+                        </div>
                     </template>
                 </form>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,7 +67,9 @@ Route::get('/channels/{id}', [ChannelController::class, 'show'])->name('channels
 
 Route::get('api/channels/{id}', [ChannelController::class, 'fetchArchives'])->name('channels.fetchArchives');
 Route::get('api/channels/{id}/timestamps', [ChannelController::class, 'fetchTimestamps'])->name('channels.fetchTimestamps');
-Route::get('api/channels/{id}/timestamps/download', [ChannelController::class, 'downloadTimestamps'])->name('channels.downloadTimestamps');
+Route::get('api/channels/{id}/timestamps/download', [ChannelController::class, 'downloadTimestamps'])
+    ->name('channels.downloadTimestamps')
+    ->middleware('throttle:10,1'); // 1分間に10回まで
 
 Route::get('/terms', [MarkdownController::class, 'show'])->name('markdown.show');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -67,6 +67,7 @@ Route::get('/channels/{id}', [ChannelController::class, 'show'])->name('channels
 
 Route::get('api/channels/{id}', [ChannelController::class, 'fetchArchives'])->name('channels.fetchArchives');
 Route::get('api/channels/{id}/timestamps', [ChannelController::class, 'fetchTimestamps'])->name('channels.fetchTimestamps');
+Route::get('api/channels/{id}/timestamps/download', [ChannelController::class, 'downloadTimestamps'])->name('channels.downloadTimestamps');
 
 Route::get('/terms', [MarkdownController::class, 'show'])->name('markdown.show');
 


### PR DESCRIPTION
## 概要
アーカイブ一覧画面のタイムスタンプタブに、タイムスタンプ一覧をテキストファイルとしてダウンロードする機能を追加しました。

## 実装内容
- タイムスタンプタブにダウンロードボタンを追加
- 重複するタイムスタンプを正規化テキストで除外
- 「楽曲ではない」とマークされたタイムスタンプを除外  
- BOM付きUTF-8でエクスポート（Excel対応）
- ファイル名: `timestamps_YYYYMMDD.txt`

## 技術的詳細
- **UI**: resources/views/channels/show.blade.php:104-119
- **バックエンド**: ChannelController::downloadTimestamps()
- **フロントエンド**: archive-list.js:165-183
- **ルーティング**: GET /api/channels/{id}/timestamps/download

## 実装方針
- Phase 1（最小限実装）: 正規化形式のみ
- ファイル名: 英数字のみ（環境非依存）
- 文字コード: BOM付きUTF-8（Windows Excel対応）
- 検索条件の反映: なし（全件が対象）

## テスト
- [x] pre-commitフック全てパス
- [x] PHPUnit: 25 passed
- [x] Laravel Pint: コードスタイルOK
- [x] フロントエンドビルド: 成功

Fixes #169