### PR TITLE
perf: timestamp_song_mappingsのnormalized_textにインデックスを追加

### DIFF
--- a/database/migrations/2025_11_12_111442_add_index_to_normalized_text_in_timestamp_song_mappings.php
+++ b/database/migrations/2025_11_12_111442_add_index_to_normalized_text_in_timestamp_song_mappings.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('timestamp_song_mappings', function (Blueprint $table) {
+            $table->index('normalized_text');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('timestamp_song_mappings', function (Blueprint $table) {
+            $table->dropIndex(['normalized_text']);
+        });
+    }
+};


### PR DESCRIPTION
## 概要
`timestamp_song_mappings`テーブルの`normalized_text`カラムにインデックスを追加し、クエリパフォーマンスを改善しました。

## 変更内容
- マイグレーションファイルを追加: `add_index_to_normalized_text_in_timestamp_song_mappings`
- `normalized_text`カラムにインデックスを設定

## パフォーマンス改善
以下のメソッドで`whereIn('normalized_text', ...)`クエリが高速化されます:
- `ChannelController::fetchTimestamps()`
- `ChannelController::downloadTimestamps()`
- `SongController`の各種メソッド

## テスト
- [x] PHPUnit: 全テストパス
- [x] Laravel Pint: コードスタイルOK

Fixes #172