### PR TITLE
improve: チャンネル一覧タイムスタンプ表示のレイアウト調整 (#170)

### DIFF
--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -10,32 +10,38 @@
 
     <div class="px-2 sm:px-6 py-2 sm:py-6" x-data="archiveListComponent">
         <div class="p-2">
-            <h2 class="text-gray-500 items-center justify-center gap-4 hidden sm:flex">
-                <img :src="escapeHTML(channel.thumbnail || '')" alt="アイコン" class="w-20 h-20 rounded-full">
-                <span class="text-lg font-bold" x-text="channel.title || '未設定'"></span>
-                <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')" target="_blank" rel="noopener noreferrer" class="hover:opacity-80">
-                    Youtubeチャンネルはこちら
-                </a>
-                <!-- デスクトップ用切り替えボタン -->
-                <div class="flex gap-2 ml-auto hidden sm:flex">
-                    <button @click="activeTab = 'timestamps'"
-                            :class="activeTab === 'timestamps' ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
-                            :aria-pressed="activeTab === 'timestamps'"
-                            role="tab"
-                            aria-label="タイムスタンプタブに切り替え"
-                            class="px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
-                        タイムスタンプ
-                    </button>
-                    <button @click="activeTab = 'archives'"
-                            :class="activeTab === 'archives' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
-                            :aria-pressed="activeTab === 'archives'"
-                            role="tab"
-                            aria-label="アーカイブタブに切り替え"
-                            class="px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
-                        アーカイブ
-                    </button>
+            <!-- デスクトップ表示: 全体を中央寄せ -->
+            <div class="flex justify-center">
+                <div class="text-gray-500 flex items-center gap-4 hidden sm:flex">
+                    <img :src="escapeHTML(channel.thumbnail || '')" alt="アイコン" class="w-20 h-20 rounded-full">
+                    <span class="text-lg font-bold" x-text="channel.title || '未設定'"></span>
+                    <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')" target="_blank" rel="noopener noreferrer" class="hover:opacity-80">
+                        Youtubeチャンネルはこちら
+                    </a>
+                    <!-- 区切り線 -->
+                    <div class="h-8 w-px bg-gray-300 dark:bg-gray-600 mx-2"></div>
+                    <!-- デスクトップ用切り替えボタン -->
+                    <div class="flex gap-2">
+                        <button @click="activeTab = 'timestamps'"
+                                :class="activeTab === 'timestamps' ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
+                                :aria-pressed="activeTab === 'timestamps'"
+                                role="tab"
+                                aria-label="タイムスタンプタブに切り替え"
+                                class="px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
+                            タイムスタンプ
+                        </button>
+                        <button @click="activeTab = 'archives'"
+                                :class="activeTab === 'archives' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
+                                :aria-pressed="activeTab === 'archives'"
+                                role="tab"
+                                aria-label="アーカイブタブに切り替え"
+                                class="px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
+                            アーカイブ
+                        </button>
+                    </div>
                 </div>
-            </h2>
+            </div>
+            <!-- モバイル表示: 変更なし -->
             <h2 class="text-gray-500 justify-self-center sm:hidden">
                 <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')" target="_blank" rel="noopener noreferrer" class="flex items-center gap-4 hover:opacity-80">
                     <img :src="escapeHTML(channel.thumbnail || '')" alt="アイコン" class="w-20 h-20 rounded-full">
@@ -106,7 +112,7 @@
                             <button
                                 type="button"
                                 @click="searchQuery = ''"
-                                class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600">
+                                class="bg-gray-500 text-white px-6 py-2 rounded hover:bg-gray-600">
                                 クリア
                             </button>
                             <button


### PR DESCRIPTION
## 概要
Issue #170 の対応として、チャンネル一覧画面のタイムスタンプ表示におけるレイアウト問題を修正し、視覚的なバランスを改善しました。

## 変更内容

### 1. クリアボタンの改行を防ぐ（優先度: 高）⭐

**問題点**:
- タイムスタンプタブの検索エリアにある「クリア」ボタンの横幅が狭く、文字が2行になってしまっていた
- ボタンが不自然に縦長になる

**対応**:
`resources/views/channels/show.blade.php` Line 109
```blade
<!-- 変更前 -->
class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600">

<!-- 変更後 -->
class="bg-gray-500 text-white px-6 py-2 rounded hover:bg-gray-600">
```

**効果**:
- ボタンの横幅が広がり、「クリア」が1行で表示される
- 検索ボタンとのバランスが改善

### 2. ヘッダー部分の配置を中央寄せに改善（優先度: 中）

**問題点**:
- チャンネル情報（アイコン・チャンネル名・YouTubeリンク）と切り替えボタンが`ml-auto`で右端に配置され、間延びして見える
- 他のコンテンツエリア（`max-w-5xl`）との統一感が欠けていた

**対応**:
`resources/views/channels/show.blade.php` Lines 12-43

主な変更:
1. 外側に`<div class="flex justify-center">`を追加して全体を中央寄せ
2. `h2`を`div`に変更（セマンティック的により適切）
3. `ml-auto`を削除して、すべての要素を自然な順序で配置
4. 区切り線（`<div class="h-8 w-px bg-gray-300 dark:bg-gray-600 mx-2"></div>`）を追加してグループを視覚的に分離

**効果**:
- チャンネル情報と切り替えボタンが中央に集まる
- 画面全体のバランスが改善される
- 他のコンテンツエリア（`max-w-5xl`）との統一感が向上

**改善後のレイアウト**:
```
        ┌─────────────────────────────────────────────┐
        │   [Icon] チャンネル名 YouTube | [TS] [AR]   │
        └─────────────────────────────────────────────┘
                     ↑ 中央に集約
```

## テスト結果
```
OK (39 tests, 94 assertions)
✅ 全テストが正常に通過
```

## 影響範囲
- アーカイブ一覧画面（`/channels/{id}`）のみ
- デスクトップ表示が主な対象
- モバイル表示には影響なし

## ダークモード対応
区切り線は以下のクラスでダークモードに対応：
- ライトモード: `bg-gray-300`
- ダークモード: `bg-gray-600`

## 関連Issue
Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)