### PR TITLE
improve: タイムスタンプダウンロードのファイル名にチャンネル識別子を追加

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -439,7 +439,20 @@ class ChannelController extends Controller
 
         // BOM付きUTF-8でテキスト生成
         $content = "\xEF\xBB\xBF".implode("\n", $lines);
-        $filename = 'timestamps_'.date('Ymd').'.txt';
+
+        // ファイル名生成（安全な文字のみ使用、20文字まで）
+        $identifier = $channel->handle ?: $channel->channel_id;
+        $safeIdentifier = preg_replace('/[^A-Za-z0-9\-_]/', '', $identifier);
+
+        // 空の場合のフォールバック
+        if (empty($safeIdentifier)) {
+            $safeIdentifier = 'unknown';
+        }
+
+        // 識別子を20文字に制限
+        $safeIdentifier = substr($safeIdentifier, 0, 20);
+
+        $filename = 'timestamps_'.$safeIdentifier.'_'.date('Ymd').'.txt';
 
         return response($content, 200)
             ->header('Content-Type', 'text/plain; charset=UTF-8')


### PR DESCRIPTION
## 概要
タイムスタンプダウンロード機能のファイル名にチャンネル識別子を追加しました。

## 変更内容

### 1. ファイル名にチャンネル識別子を追加
- 形式: `timestamps_{identifier}_{date}.txt`
- 例: `timestamps_SoraCh_20250112.txt`

### 2. 安全なファイル名生成ロジック
- チャンネルhandleまたはchannel_idを使用
- 特殊文字を除外（A-Za-z0-9\-_のみ許可）
- 20文字に制限
- 空の場合は'unknown'を使用

### 3. テストケースを追加
- 特殊文字処理のテスト
- 長さ制限のテスト
- フォールバック処理のテスト

## 効果
複数チャンネルのタイムスタンプをダウンロードした際に、ファイル名で区別できるようになりました。

## Test plan
- [x] 既存テストが全てパス
- [x] 新規テストケース3件を追加
- [x] 特殊文字のフィルタリングが正しく動作
- [x] 長さ制限が正しく動作
- [x] フォールバック処理が正しく動作

Fixes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)