### PR TITLE
fix: ボタンのテキスト折り返しを防ぐためにwhitespace-nowrapを追加

### DIFF
--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -112,13 +112,13 @@
                             <button
                                 type="button"
                                 @click="searchQuery = ''"
-                                class="bg-gray-500 text-white px-6 py-2 rounded hover:bg-gray-600">
+                                class="bg-gray-500 text-white px-6 py-2 rounded hover:bg-gray-600 whitespace-nowrap">
                                 クリア
                             </button>
                             <button
                                 type="button"
                                 @click="downloadTimestamps()"
-                                class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 flex items-center gap-1">
+                                class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 flex items-center gap-1 whitespace-nowrap">
                                 📥 ダウンロード
                             </button>
                         </div>


### PR DESCRIPTION
## 概要
タイムスタンプタブの検索エリアにあるボタンのテキスト折り返しを防ぐため、`whitespace-nowrap`クラスを追加しました。

## 変更内容

### 1. 「クリア」ボタンに`whitespace-nowrap`を追加
- resources/views/channels/show.blade.php:115
- モバイル表示時に「クリア」が2行表示される問題を解決

### 2. 「📥 ダウンロード」ボタンに`whitespace-nowrap`を追加
- resources/views/channels/show.blade.php:121
- 絵文字とテキストが別々の行に分かれるのを予防

## 背景
Issue #170で`px-6`への変更が実施されましたが、根本的な原因である「テキストの折り返し」を防ぐ設定がなかったため、モバイル表示時に依然として問題が発生していました。

`whitespace-nowrap`（CSS: `white-space: nowrap`）を追加することで、画面サイズに関係なくテキストの折り返しを完全に防ぎます。

## 効果
- どの画面サイズでもボタンのテキストが1行で表示される
- ボタンが不自然に縦長にならない
- レスポンシブ対応が改善される

## Test plan
- [x] 全テストがパス（42 tests, 100 assertions）
- [x] コードスタイルチェック通過
- [x] フロントエンドビルド成功
- [x] デスクトップ表示で正常に表示されることを確認
- [x] モバイル表示でテキストが折り返さないことを確認

Fixes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)