### PR TITLE
fix: TsItemモデルのcomment_idをfillableに追加 (#187)

### DIFF
--- a/app/Models/TsItem.php
+++ b/app/Models/TsItem.php
@@ -20,6 +20,7 @@ class TsItem extends Model
         'ts_text',
         'ts_num',
         'text',
+        'comment_id',
         'is_display',
     ];
 


### PR DESCRIPTION
## Summary
- TsItemモデルの$fillable配列にcomment_idフィールドを追加
- これにより、comment_idのmass assignment保護が適切に設定される

## Changes
- app/Models/TsItem.php: $fillable配列に'comment_id'を追加

## Test plan
- [x] 既存テスト54件がすべて成功することを確認
- [x] Pint（コードスタイル）チェック通過
- [x] フロントエンドビルド成功

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)