### PR TITLE
improve: モバイル表示でタイムスタンプ一覧の不要な要素を非表示化 (#184)

### DIFF
--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -118,7 +118,7 @@
                             <button
                                 type="button"
                                 @click="downloadTimestamps()"
-                                class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 flex items-center gap-1 whitespace-nowrap">
+                                class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 hidden sm:flex items-center gap-1 whitespace-nowrap">
                                 📥 ダウンロード
                             </button>
                         </div>
@@ -246,7 +246,7 @@
                 </div>
 
                 <!-- 頭文字ジャンプナビゲーション（楽曲名ソート時のみ表示） -->
-                <div x-show="timestampSort === 'song_asc' && timestamps.available_indexes && timestamps.available_indexes.length > 0" class="mb-4 border-b border-gray-200 dark:border-gray-700 pb-4">
+                <div x-show="timestampSort === 'song_asc' && timestamps.available_indexes && timestamps.available_indexes.length > 0" class="mb-4 border-b border-gray-200 dark:border-gray-700 pb-4 hidden sm:block">
                     <div class="text-xs text-gray-600 dark:text-gray-400 mb-2">頭文字でジャンプ:</div>
 
                     <!-- アルファベット -->


### PR DESCRIPTION
## Summary
モバイルユーザビリティを向上させるため、640px未満の画面で不要な要素を非表示化：

1. **頭文字ジャンプナビゲーションを非表示**
   - `hidden sm:block`を追加して、640px以上のみ表示
   - モバイルでは38個の小さいボタンが複数行に折り返され、約200pxのスペースを占有していた
   - ページネーション（最初/前へ/次へ/最後）で代替可能

2. **ダウンロードボタンを非表示**
   - `flex`を`hidden sm:flex`に変更して、640px以上のみ表示
   - モバイルユーザーは主に閲覧がメインで、ダウンロード機能はPCユーザー向け
   - 検索エリアがスッキリし、クリアボタンのみで直感的に

## Changes
- resources/views/channels/show.blade.php
  - Line 249: 頭文字ジャンプナビゲーションに`hidden sm:block`を追加
  - Line 121: ダウンロードボタンの`flex`を`hidden sm:flex`に変更

## Test plan
- [x] 54件のテストがすべて成功
- [x] Pint（コードスタイル）チェック通過
- [x] フロントエンドビルド成功

## 効果
- モバイルのスクロール量が約200px削減
- 検索エリアが視覚的にシンプルに
- タッチ操作の誤タップが減少
- デスクトップ表示には影響なし

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)