### PR TITLE
test: SpotifyServiceの包括的なテストを追加 (#144 Phase 2)

### DIFF
--- a/tests/Unit/Services/SpotifyServiceTest.php
+++ b/tests/Unit/Services/SpotifyServiceTest.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\SpotifyService;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SpotifyServiceTest extends TestCase
+{
+    protected SpotifyService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new SpotifyService;
+    }
+
+    /**
+     * 認証成功のテスト
+     */
+    public function test_authenticate_success(): void
+    {
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_access_token_123',
+                'token_type' => 'Bearer',
+                'expires_in' => 3600,
+            ], 200),
+        ]);
+
+        $result = $this->service->authenticate('test_client_id', 'test_client_secret');
+
+        $this->assertTrue($result);
+
+        // 認証後にAPIが使えることを確認
+        Http::fake([
+            'https://api.spotify.com/v1/search*' => Http::response([
+                'tracks' => [
+                    'items' => [
+                        [
+                            'id' => 'track123',
+                            'name' => 'Test Track',
+                            'artists' => [['name' => 'Test Artist']],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $tracks = $this->service->searchTracks('test query');
+        $this->assertCount(1, $tracks);
+    }
+
+    /**
+     * 認証失敗のテスト
+     */
+    public function test_authenticate_failure(): void
+    {
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'error' => 'invalid_client',
+                'error_description' => 'Invalid client credentials',
+            ], 401),
+        ]);
+
+        $result = $this->service->authenticate('invalid_client_id', 'invalid_secret');
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * 楽曲検索成功のテスト
+     */
+    public function test_search_tracks_success(): void
+    {
+        // 認証をモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+        ]);
+
+        $this->service->authenticate('client_id', 'client_secret');
+
+        // 検索APIをモック
+        Http::fake([
+            'https://api.spotify.com/v1/search*' => Http::response([
+                'tracks' => [
+                    'items' => [
+                        [
+                            'id' => 'track1',
+                            'name' => 'Song A',
+                            'artists' => [['name' => 'Artist A']],
+                            'album' => ['name' => 'Album A'],
+                        ],
+                        [
+                            'id' => 'track2',
+                            'name' => 'Song B',
+                            'artists' => [['name' => 'Artist B']],
+                            'album' => ['name' => 'Album B'],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        $tracks = $this->service->searchTracks('test query', 2);
+
+        $this->assertCount(2, $tracks);
+        $this->assertEquals('track1', $tracks[0]['id']);
+        $this->assertEquals('Song A', $tracks[0]['name']);
+        $this->assertEquals('Artist A', $tracks[0]['artists'][0]['name']);
+    }
+
+    /**
+     * 未認証時の楽曲検索エラーテスト
+     */
+    public function test_search_tracks_without_authentication(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Spotify API is not authenticated.');
+
+        $this->service->searchTracks('test query');
+    }
+
+    /**
+     * 楽曲検索失敗のテスト（API エラー）
+     */
+    public function test_search_tracks_api_error(): void
+    {
+        // 認証をモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+        ]);
+
+        $this->service->authenticate('client_id', 'client_secret');
+
+        // 検索APIをエラーレスポンスでモック
+        Http::fake([
+            'https://api.spotify.com/v1/search*' => Http::response([
+                'error' => [
+                    'status' => 400,
+                    'message' => 'Bad Request',
+                ],
+            ], 400),
+        ]);
+
+        $tracks = $this->service->searchTracks('invalid query');
+
+        $this->assertEmpty($tracks);
+    }
+
+    /**
+     * 楽曲検索結果が空のテスト
+     */
+    public function test_search_tracks_no_results(): void
+    {
+        // 認証をモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+        ]);
+
+        $this->service->authenticate('client_id', 'client_secret');
+
+        // 検索APIを空結果でモック
+        Http::fake([
+            'https://api.spotify.com/v1/search*' => Http::response([
+                'tracks' => [
+                    'items' => [],
+                ],
+            ], 200),
+        ]);
+
+        $tracks = $this->service->searchTracks('nonexistent song');
+
+        $this->assertEmpty($tracks);
+    }
+
+    /**
+     * トラック情報取得成功のテスト
+     */
+    public function test_get_track_success(): void
+    {
+        // 認証をモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+        ]);
+
+        $this->service->authenticate('client_id', 'client_secret');
+
+        // トラック取得APIをモック
+        Http::fake([
+            'https://api.spotify.com/v1/tracks/track123' => Http::response([
+                'id' => 'track123',
+                'name' => 'Test Track',
+                'artists' => [
+                    ['name' => 'Test Artist', 'id' => 'artist123'],
+                ],
+                'album' => [
+                    'name' => 'Test Album',
+                    'release_date' => '2024-01-01',
+                ],
+                'duration_ms' => 180000,
+                'external_urls' => [
+                    'spotify' => 'https://open.spotify.com/track/track123',
+                ],
+            ], 200),
+        ]);
+
+        $track = $this->service->getTrack('track123');
+
+        $this->assertNotNull($track);
+        $this->assertEquals('track123', $track['id']);
+        $this->assertEquals('Test Track', $track['name']);
+        $this->assertEquals('Test Artist', $track['artists'][0]['name']);
+    }
+
+    /**
+     * 未認証時のトラック取得エラーテスト
+     */
+    public function test_get_track_without_authentication(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Spotify API is not authenticated.');
+
+        $this->service->getTrack('track123');
+    }
+
+    /**
+     * トラック取得失敗のテスト（存在しないトラックID）
+     */
+    public function test_get_track_not_found(): void
+    {
+        // 認証をモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+        ]);
+
+        $this->service->authenticate('client_id', 'client_secret');
+
+        // トラック取得APIを404でモック
+        Http::fake([
+            'https://api.spotify.com/v1/tracks/nonexistent' => Http::response([
+                'error' => [
+                    'status' => 404,
+                    'message' => 'Not found',
+                ],
+            ], 404),
+        ]);
+
+        $track = $this->service->getTrack('nonexistent');
+
+        $this->assertNull($track);
+    }
+
+    /**
+     * 検索時のlimitパラメータが正しく渡されるかのテスト
+     */
+    public function test_search_tracks_with_custom_limit(): void
+    {
+        // 認証と検索APIを同時にモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+            'https://api.spotify.com/v1/search*' => Http::response([
+                'tracks' => [
+                    'items' => array_fill(0, 20, [
+                        'id' => 'track',
+                        'name' => 'Song',
+                        'artists' => [['name' => 'Artist']],
+                    ]),
+                ],
+            ], 200),
+        ]);
+
+        $this->service->authenticate('client_id', 'client_secret');
+        $tracks = $this->service->searchTracks('query', 20);
+
+        // limitパラメータが正しく送信されたことを確認
+        Http::assertSent(function ($request) {
+            return str_starts_with($request->url(), 'https://api.spotify.com/v1/search')
+                && $request['limit'] === 20
+                && $request['q'] === 'query'
+                && $request['type'] === 'track';
+        });
+
+        $this->assertCount(20, $tracks);
+    }
+
+    /**
+     * 認証リクエストに正しいパラメータが送信されるかのテスト
+     */
+    public function test_authenticate_sends_correct_parameters(): void
+    {
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+        ]);
+
+        $this->service->authenticate('my_client_id', 'my_client_secret');
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://accounts.spotify.com/api/token'
+                && $request['grant_type'] === 'client_credentials'
+                && $request['client_id'] === 'my_client_id'
+                && $request['client_secret'] === 'my_client_secret';
+        });
+    }
+
+    /**
+     * トラック取得時に正しい認証ヘッダーが送信されるかのテスト
+     */
+    public function test_get_track_sends_correct_authorization_header(): void
+    {
+        // 認証をモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'my_access_token',
+            ], 200),
+        ]);
+
+        $this->service->authenticate('client_id', 'client_secret');
+
+        // トラック取得APIをモック
+        Http::fake([
+            'https://api.spotify.com/v1/tracks/*' => Http::response([
+                'id' => 'track123',
+                'name' => 'Track',
+            ], 200),
+        ]);
+
+        $this->service->getTrack('track123');
+
+        Http::assertSent(function ($request) {
+            return str_starts_with($request->url(), 'https://api.spotify.com/v1/tracks/')
+                && $request->hasHeader('Authorization', 'Bearer my_access_token');
+        });
+    }
+}

--- a/tests/Unit/Services/SpotifyServiceTest.php
+++ b/tests/Unit/Services/SpotifyServiceTest.php
@@ -32,24 +32,6 @@ class SpotifyServiceTest extends TestCase
         $result = $this->service->authenticate('test_client_id', 'test_client_secret');
 
         $this->assertTrue($result);
-
-        // 認証後にAPIが使えることを確認
-        Http::fake([
-            'https://api.spotify.com/v1/search*' => Http::response([
-                'tracks' => [
-                    'items' => [
-                        [
-                            'id' => 'track123',
-                            'name' => 'Test Track',
-                            'artists' => [['name' => 'Test Artist']],
-                        ],
-                    ],
-                ],
-            ], 200),
-        ]);
-
-        $tracks = $this->service->searchTracks('test query');
-        $this->assertCount(1, $tracks);
     }
 
     /**


### PR DESCRIPTION
## Summary
SpotifyServiceの全メソッドをカバーする12件のテストを実装しました。

## テストカバレッジ

### 1. authenticate()メソッド（3テスト）
- ✅ 認証成功のテスト
- ✅ 認証失敗のテスト（無効な資格情報）
- ✅ 正しいパラメータ送信の確認

### 2. searchTracks()メソッド（5テスト）
- ✅ 楽曲検索成功のテスト
- ✅ 未認証時のエラーテスト
- ✅ APIエラー時の空配列返却テスト
- ✅ 検索結果が空の場合のテスト
- ✅ カスタムlimitパラメータのテスト

### 3. getTrack()メソッド（4テスト）
- ✅ トラック情報取得成功のテスト
- ✅ 未認証時のエラーテスト
- ✅ 存在しないトラックIDの404エラーテスト
- ✅ 正しい認証ヘッダー送信の確認

## 実装の詳細
- **Http::fake()を使用**: 外部API呼び出しをモック化し、実際のSpotify APIを呼ばずにテスト
- **正常系と異常系を網羅**: 各メソッドの成功ケースとエラーケースを両方カバー
- **HTTPリクエスト検証**: パラメータとヘッダーが正しく送信されることを確認

## Changes
- tests/Unit/Services/SpotifyServiceTest.php（新規作成、350行）

## Test plan
- [x] 12件の新規テストがすべて成功
- [x] 既存の54件のテストもすべて成功
- [x] Pint（コードスタイル）チェック通過
- [x] フロントエンドビルド成功

## テスト結果
```
テスト件数: 54 → 66件（+12件）
アサーション数: 128 → 150（+22）
すべてのテストが成功 ✓
```

Part of #144 Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)