### PR TITLE
improve: タイムスタンプダウンロードボタンの配置を最適化 (#186)

### DIFF
--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -108,20 +108,12 @@
                         </button>
                     </template>
                     <template x-if="activeTab === 'timestamps'">
-                        <div class="flex gap-2">
-                            <button
-                                type="button"
-                                @click="searchQuery = ''"
-                                class="bg-gray-500 text-white px-6 py-2 rounded hover:bg-gray-600 whitespace-nowrap">
-                                クリア
-                            </button>
-                            <button
-                                type="button"
-                                @click="downloadTimestamps()"
-                                class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 hidden sm:flex items-center gap-1 whitespace-nowrap">
-                                📥 ダウンロード
-                            </button>
-                        </div>
+                        <button
+                            type="button"
+                            @click="searchQuery = ''"
+                            class="bg-gray-500 text-white px-6 py-2 rounded hover:bg-gray-600 whitespace-nowrap">
+                            クリア
+                        </button>
                     </template>
                 </form>
             </div>
@@ -208,12 +200,21 @@
 
             <!-- タイムスタンプタブ -->
             <div x-show="activeTab === 'timestamps'">
-                <!-- 検索結果 -->
-                <div class="mb-4">
+                <!-- 検索結果とダウンロードボタン -->
+                <div class="mb-4 flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
                     <div class="text-sm text-gray-600 dark:text-gray-400">
                         <span x-show="searchQuery">検索結果: </span>
                         <span x-text="timestamps.total !== undefined ? `${timestamps.total}件` : ''"></span>
                     </div>
+                    <button
+                        type="button"
+                        @click="downloadTimestamps()"
+                        :disabled="loading || !timestamps.total"
+                        :class="loading || !timestamps.total ? 'opacity-50 cursor-not-allowed' : ''"
+                        class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 hidden sm:flex items-center gap-1 whitespace-nowrap text-sm"
+                        title="全タイムスタンプをテキストファイルとしてダウンロード">
+                        📥 ダウンロード
+                    </button>
                 </div>
 
                 <!-- ページネーション（上） -->


### PR DESCRIPTION
## Summary
ダウンロードボタンを検索エリアから検索結果表示エリアに移動し、UIの論理性とユーザビリティを向上しました。

## 変更内容

### 1. 検索エリアからダウンロードボタンを削除
- 検索エリアには「クリア」ボタンのみを配置
- 検索機能（フィルタリング）とエクスポート機能（全体操作）を分離

### 2. 検索結果表示エリアにダウンロードボタンを追加
- 「検索結果: 123件」の右側にダウンロードボタンを配置
- レスポンシブ対応:
  - モバイル（640px未満）: 縦並び（ただしボタンは非表示）
  - デスクトップ（640px以上）: 横並び
- ボタンの無効化条件を追加:
  - ローディング中（loading=true）
  - データなし（!timestamps.total）
- ツールチップ追加: "全タイムスタンプをテキストファイルとしてダウンロード"

### 3. スタイル調整
- text-smで検索結果テキストと統一
- hidden sm:flexでモバイル非表示を維持（Issue #184で対応済み）

## メリット

1. **論理的な配置**:
   - 「タイムスタンプ一覧全体に対する操作」として、一覧上部に配置
   - 検索機能とエクスポート機能が明確に分離

2. **発見性の向上**:
   - 件数表示の近くにあり、「これらをダウンロードできる」と直感的に理解可能
   - 検索エリアから独立し、異なる機能として明確に区別

3. **検索エリアのシンプル化**:
   - クリアボタンのみで視覚的にスッキリ
   - 主要操作（検索、クリア）に集中

4. **視覚的なバランス**:
   - 件数表示との横並びで自然な配置
   - 右端配置でボタンが目立つ

## レイアウトイメージ

### Before（Issue #184の状態）
```
デスクトップ:
┌─────────────────────────────────────────────────────────┐
│ [検索ボックス          ] [クリア] [📥 ダウンロード]    │
└─────────────────────────────────────────────────────────┘
↑ 検索エリアにダウンロードボタンがあり、窮屈

モバイル:
┌─────────────────────────────────┐
│ [検索ボックス           ]       │
│ [クリア]                        │
└─────────────────────────────────┘
↑ ダウンロードボタンは非表示
```

### After（本PR）
```
デスクトップ:
┌─────────────────────────────────────────────────────────┐
│ [検索ボックス          ] [クリア]                       │
└─────────────────────────────────────────────────────────┘
↓ 検索エリアがスッキリ

┌─────────────────────────────────────────────────────────┐
│ 検索結果: 123件              [📥 ダウンロード]          │
├─────────────────────────────────────────────────────────┤
│ [最初] [前へ] 5 / 10 [次へ] [最後]                      │
└─────────────────────────────────────────────────────────┘
↑ 件数表示の横にダウンロードボタン、論理的で発見しやすい

モバイル:
┌─────────────────────────────────┐
│ [検索ボックス           ]       │
│ [クリア]                        │
└─────────────────────────────────┘
┌─────────────────────────────────┐
│ 検索結果: 123件                 │
│ （ダウンロードボタンは非表示）  │
└─────────────────────────────────┘
↑ モバイルでの表示は変わらず
```

## Changes
- resources/views/channels/show.blade.php (2箇所)
  - Line 110-117: ダウンロードボタンを削除
  - Line 203-218: 検索結果表示エリアにダウンロードボタンを追加

## Test plan
- [x] 66件のテストがすべて成功
- [x] Pint（コードスタイル）チェック通過
- [x] フロントエンドビルド成功

## 関連Issue
- Issue #184: モバイル表示で不要な要素を非表示化（マージ済み）
- Issue #169: タイムスタンプダウンロード機能（マージ済み）
- Issue #178: ダウンロードファイル名にhandle追加（マージ済み）

Fixes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)