### PR TITLE
test: チャンネル管理機能のテストを追加 (Issue #183 Phase 2)

### DIFF
--- a/tests/Feature/ManageControllerTest.php
+++ b/tests/Feature/ManageControllerTest.php
@@ -1,0 +1,347 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Archive;
+use App\Models\ChangeList;
+use App\Models\Channel;
+use App\Models\TsItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ManageControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['email_verified_at' => now()]);
+    }
+
+    /**
+     * チャンネル一覧を取得できる
+     */
+    public function test_fetch_channel_returns_all_channels(): void
+    {
+        $channels = Channel::factory()->count(3)->create();
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/manage/channels');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3)
+            ->assertJsonFragment(['handle' => $channels[0]->handle])
+            ->assertJsonFragment(['handle' => $channels[1]->handle])
+            ->assertJsonFragment(['handle' => $channels[2]->handle]);
+    }
+
+    /**
+     * チャンネル一覧が空の場合も正常に動作する
+     */
+    public function test_fetch_channel_returns_empty_array_when_no_channels(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/manage/channels');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(0);
+    }
+
+    /**
+     * アーカイブの表示切り替えができる（表示→非表示）
+     */
+    public function test_toggle_display_from_visible_to_hidden(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create([
+            'channel_id' => $channel->channel_id,
+            'is_display' => 1,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/toggle-display', [
+                'id' => $archive->id,
+                'is_display' => '1',
+            ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals('"0"', $response->getContent());
+
+        $this->assertDatabaseHas('archives', [
+            'id' => $archive->id,
+            'is_display' => 0,
+        ]);
+
+        $this->assertDatabaseHas('change_list', [
+            'channel_id' => $archive->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => null,
+            'is_display' => 0,
+        ]);
+    }
+
+    /**
+     * アーカイブの表示切り替えができる（非表示→表示）
+     */
+    public function test_toggle_display_from_hidden_to_visible(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create([
+            'channel_id' => $channel->channel_id,
+            'is_display' => 0,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/toggle-display', [
+                'id' => $archive->id,
+                'is_display' => '0',
+            ]);
+
+        $response->assertStatus(200);
+        $this->assertEquals('"1"', $response->getContent());
+
+        $this->assertDatabaseHas('archives', [
+            'id' => $archive->id,
+            'is_display' => 1,
+        ]);
+
+        $this->assertDatabaseHas('change_list', [
+            'channel_id' => $archive->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => null,
+            'is_display' => 1,
+        ]);
+    }
+
+    /**
+     * 存在しないアーカイブIDでエラーが発生する
+     */
+    public function test_toggle_display_fails_with_invalid_archive_id(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/toggle-display', [
+                'id' => 'non-existent-id',
+                'is_display' => '1',
+            ]);
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * バリデーションエラー: idが必須
+     */
+    public function test_toggle_display_validation_id_required(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/toggle-display', [
+                'is_display' => '1',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['id']);
+    }
+
+    /**
+     * バリデーションエラー: is_displayが必須
+     */
+    public function test_toggle_display_validation_is_display_required(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/toggle-display', [
+                'id' => $archive->id,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['is_display']);
+    }
+
+    /**
+     * バリデーションエラー: is_displayは0または1のみ
+     */
+    public function test_toggle_display_validation_is_display_must_be_0_or_1(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/toggle-display', [
+                'id' => $archive->id,
+                'is_display' => '2',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['is_display']);
+    }
+
+    /**
+     * タイムスタンプの編集ができる
+     */
+    public function test_edit_timestamps_updates_display_status(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+        $tsItems = TsItem::factory()->count(3)->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-123',
+            'is_display' => 1,
+        ]);
+
+        $requestData = $tsItems->map(fn ($item) => [
+            'id' => $item->id,
+            'comment_id' => $item->comment_id,
+            'is_display' => false,
+        ])->toArray();
+
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/edit-timestamps', $requestData);
+
+        $response->assertStatus(200)
+            ->assertJson(['message' => 'タイムスタンプの編集が完了しました']);
+
+        foreach ($tsItems as $item) {
+            $this->assertDatabaseHas('ts_items', [
+                'id' => $item->id,
+                'is_display' => 0,
+            ]);
+        }
+
+        $this->assertDatabaseHas('change_list', [
+            'channel_id' => $archive->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-123',
+            'is_display' => 0,
+        ]);
+    }
+
+    /**
+     * タイムスタンプ編集時に既存の変更リストが削除される
+     */
+    public function test_edit_timestamps_deletes_old_change_lists(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 既存の変更リストを作成
+        ChangeList::create([
+            'channel_id' => $archive->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'old-comment',
+            'is_display' => 0,
+        ]);
+
+        // 動画の変更リスト（comment_id=null）は削除されない
+        ChangeList::create([
+            'channel_id' => $archive->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => null,
+            'is_display' => 0,
+        ]);
+
+        $tsItems = TsItem::factory()->count(2)->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'new-comment',
+            'is_display' => 1,
+        ]);
+
+        $requestData = $tsItems->map(fn ($item) => [
+            'id' => $item->id,
+            'comment_id' => $item->comment_id,
+            'is_display' => true,
+        ])->toArray();
+
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/edit-timestamps', $requestData);
+
+        $response->assertStatus(200);
+
+        // 古い変更リスト（comment_id='old-comment'）が削除されている
+        $this->assertDatabaseMissing('change_list', [
+            'video_id' => $archive->video_id,
+            'comment_id' => 'old-comment',
+        ]);
+
+        // 動画の変更リスト（comment_id=null）は残っている
+        $this->assertDatabaseHas('change_list', [
+            'video_id' => $archive->video_id,
+            'comment_id' => null,
+        ]);
+
+        // 新しい変更リストが作成されている
+        $this->assertDatabaseHas('change_list', [
+            'video_id' => $archive->video_id,
+            'comment_id' => 'new-comment',
+        ]);
+    }
+
+    /**
+     * バリデーションエラー: タイムスタンプIDが必須
+     */
+    public function test_edit_timestamps_validation_id_required(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/edit-timestamps', [
+                [
+                    'comment_id' => 'comment-123',
+                    'is_display' => true,
+                ],
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['0.id']);
+    }
+
+    /**
+     * バリデーションエラー: comment_idが必須
+     */
+    public function test_edit_timestamps_validation_comment_id_required(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+        $tsItem = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-123',
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/edit-timestamps', [
+                [
+                    'id' => $tsItem->id,
+                    'is_display' => true,
+                ],
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['0.comment_id']);
+    }
+
+    /**
+     * バリデーションエラー: is_displayが必須
+     */
+    public function test_edit_timestamps_validation_is_display_required(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+        $tsItem = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-123',
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/edit-timestamps', [
+                [
+                    'id' => $tsItem->id,
+                    'comment_id' => $tsItem->comment_id,
+                ],
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['0.is_display']);
+    }
+}


### PR DESCRIPTION
## 概要
Issue #183 のPhase 2として、チャンネル管理機能（ManageController）の包括的なテストを追加しました。

## 変更内容
- `tests/Feature/ManageControllerTest.php` を新規作成
- 13のテストケース、44のアサーションを追加
- 主要なチャンネル管理機能をカバー

## テスト結果
```
Tests: 119 passed (331 assertions)
Duration: 3.06s
```
- 既存テスト: 106 tests, 287 assertions
- 新規テスト: 13 tests, 44 assertions

## テスト内容

### チャンネル一覧取得 (2テスト)
- チャンネル一覧の正常取得
- 空配列の正常処理

### アーカイブ表示/非表示切り替え (6テスト)
- 表示→非表示の切り替えとchange_list連携
- 非表示→表示の切り替えとchange_list連携
- 存在しないアーカイブIDでのエラーハンドリング
- バリデーションエラー（id必須、is_display必須、値の範囲）

### タイムスタンプ編集 (5テスト)
- 一括編集とデータベース更新
- change_listの洗替処理（古いレコード削除、新規作成）
- バリデーションエラー（id必須、comment_id必須、is_display必須）

## コードレビュー結果
- Test Quality: 7/10
- Test Coverage: 主要機能をカバー
- 認証テストはPhase 1のAuthorizationTestで既にカバー済み
- 外部サービス連携を含む複雑なメソッドは今後のフェーズで実装予定

## 関連Issue
Part of #183 (Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)