### PR TITLE
fix: Spotify APIのエラーハンドリングを改善

### DIFF
--- a/app/Services/SpotifyService.php
+++ b/app/Services/SpotifyService.php
@@ -25,7 +25,7 @@ class SpotifyService
             return true;
         }
 
-        return false;
+        throw new \Exception('Spotify authentication failed with status '.$response->status());
     }
 
     /**
@@ -47,7 +47,7 @@ class SpotifyService
             return $response->json()['tracks']['items'];
         }
 
-        return [];
+        throw new \Exception('Spotify search request failed with status '.$response->status());
     }
 
     /**
@@ -65,6 +65,6 @@ class SpotifyService
             return $response->json();
         }
 
-        return null;
+        throw new \Exception('Spotify get track request failed with status '.$response->status());
     }
 }

--- a/tests/Unit/Services/SpotifyServiceTest.php
+++ b/tests/Unit/Services/SpotifyServiceTest.php
@@ -46,9 +46,10 @@ class SpotifyServiceTest extends TestCase
             ], 401),
         ]);
 
-        $result = $this->service->authenticate('invalid_client_id', 'invalid_secret');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Spotify authentication failed with status 401');
 
-        $this->assertFalse($result);
+        $this->service->authenticate('invalid_client_id', 'invalid_secret');
     }
 
     /**
@@ -130,9 +131,10 @@ class SpotifyServiceTest extends TestCase
             ], 400),
         ]);
 
-        $tracks = $this->service->searchTracks('invalid query');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Spotify search request failed with status 400');
 
-        $this->assertEmpty($tracks);
+        $this->service->searchTracks('invalid query');
     }
 
     /**
@@ -239,9 +241,10 @@ class SpotifyServiceTest extends TestCase
             ], 404),
         ]);
 
-        $track = $this->service->getTrack('nonexistent');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Spotify get track request failed with status 404');
 
-        $this->assertNull($track);
+        $this->service->getTrack('nonexistent');
     }
 
     /**


### PR DESCRIPTION
## Summary

Spotify APIのエラーハンドリングを改善しました。以前の実装では、APIエラー時に空の結果を返していたため、「エラー」と「検索結果なし」の区別がつきませんでした。

この修正により、APIエラー時には例外を投げるようになり、コントローラー側のtry-catchブロックで適切にハンドリングできるようになります。

## 変更内容

### 1. SpotifyService::authenticate()
- 認証失敗時に`false`を返す代わりに例外を投げる
- エラーメッセージにHTTPステータスコードを含める

### 2. SpotifyService::searchTracks()
- API エラー時に空配列を返す代わりに例外を投げる
- 「検索結果なし」と「APIエラー」を区別可能に

### 3. SpotifyService::getTrack()
- API エラー時に`null`を返す代わりに例外を投げる
- トラック情報取得の成否を明確に判定可能に

### 4. テスト修正
- エラーケースのテストで例外を期待するように修正
- `test_authenticate_failure`
- `test_search_tracks_api_error`
- `test_get_track_not_found`

## テスト結果

すべてのテストが通過しました：
- 133 tests, 421 assertions
- Laravel Pint: PASS

## 影響範囲

- `app/Services/SpotifyService.php`
- `tests/Unit/Services/SpotifyServiceTest.php`

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)