### PR TITLE
feat: バックグラウンドジョブとエラーハンドリングの強化（Phase 3）

### DIFF
--- a/app/Console/Commands/RefreshArchives.php
+++ b/app/Console/Commands/RefreshArchives.php
@@ -30,6 +30,19 @@ class RefreshArchives extends Command
         try {
             // 受け取ったIDで偽装ログイン
             $userId = $this->option('user-id');
+
+            if (! $userId) {
+                // user-idが未指定の場合、google_tokenを持つ最初のユーザーを使用
+                $user = \App\Models\User::whereNotNull('google_token')->first();
+                if (! $user) {
+                    $this->error('Error: No user with Google OAuth token found. Please run with --user-id option.');
+
+                    return 1;
+                }
+                $userId = $user->id;
+                $this->info("Using user: {$user->name} (ID: {$userId})");
+            }
+
             $service->cliLogin($userId);
 
             $channelCount = $service->getChannelCount();

--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -24,6 +24,11 @@ class RefreshArchiveService
     {
         // ログインを偽装
         $user = User::where('id', '=', $userId)->firstOrFail();
+
+        if (! $user->google_token) {
+            throw new Exception("User ID {$userId} does not have a Google OAuth token. Please authenticate with Google first.");
+        }
+
         Auth::login($user);
     }
 


### PR DESCRIPTION
## 概要

Issue #194 Phase 3: バックグラウンドジョブのGoogle OAuth対応とエラーハンドリング強化

## 変更内容

### 1. RefreshArchivesコマンドの改善 (`app/Console/Commands/RefreshArchives.php`)
- `--user-id`オプション未指定時に、`google_token`を持つ最初のユーザーを自動選択
- Google OAuthトークンを持つユーザーが存在しない場合の明確なエラーメッセージ
- 選択されたユーザー情報を表示

### 2. RefreshArchiveServiceの強化 (`app/Services/RefreshArchiveService.php`)
- `cliLogin()`メソッドにトークン検証を追加
- Google OAuthトークンが存在しない場合の例外スロー
- 明確なエラーメッセージでトラブルシューティングを支援

### 3. YouTubeServiceのロギング強化 (`app/Services/YouTubeService.php`)
- OAuth認証プロセスの詳細なロギング追加:
  - トークンリフレッシュの試行と結果
  - リフレッシュトークン不在の検出
  - トークンエラーの詳細情報
- YouTube APIエラーの詳細なロギング:
  - コメント無効化の検出（infoレベル）
  - API呼び出し失敗の詳細（errorレベル、エラーコード含む）

## テスト結果

```
Tests:    133 passed (421 assertions)
```

## 関連Issue

- Closes #194 (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)