### PR TITLE
fix: Quota枯渇問題の解決 - APIキー方式への移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,23 @@ npm install
 
 **重要**: ワークツリーごとに`.env.testing`の作成が必要です。これを忘れると、テスト実行時に本番データベースが削除される危険があります。
 
+### YouTube API設定（必須）
+
+**各ユーザーが独自のAPIキーを登録する必要があります。**
+
+詳細な手順は [docs/API_KEY_SETUP.md](docs/API_KEY_SETUP.md) を参照してください。
+
+#### 概要
+1. [Google Cloud Console](https://console.cloud.google.com/)で新しいプロジェクトを作成
+2. YouTube Data API v3を有効化
+3. APIキーを作成
+4. アプリケーションのプロフィール画面で作成したAPIキーを登録
+
+#### なぜ必要なのか
+- YouTube Data API v3には1日あたり10,000 unitsのquota制限があります
+- 各ユーザーが独自のAPIキーを持つことで、quotaを分離できます
+- これにより、多くのユーザーがアプリを利用してもquotaが枯渇しません
+
 ### Spotify API設定
 
 1. [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)にアクセス

--- a/app/Console/Commands/RefreshArchives.php
+++ b/app/Console/Commands/RefreshArchives.php
@@ -32,10 +32,10 @@ class RefreshArchives extends Command
             $userId = $this->option('user-id');
 
             if (! $userId) {
-                // user-idが未指定の場合、google_tokenを持つ最初のユーザーを使用
-                $user = \App\Models\User::whereNotNull('google_token')->first();
+                // user-idが未指定の場合、api_keyを持つ最初のユーザーを使用
+                $user = \App\Models\User::whereNotNull('api_key')->first();
                 if (! $user) {
-                    $this->error('Error: No user with Google OAuth token found. Please run with --user-id option.');
+                    $this->error('Error: No user with API key found. Please run with --user-id option.');
 
                     return 1;
                 }

--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -41,18 +41,18 @@ class ManageController extends Controller
 
     public function index()
     {
-        // Google OAuthトークンが存在すればOK
+        // APIキーが登録済みかチェック
         $user = Auth::user();
-        $api_key_flg = $user->google_token ? '1' : '';
+        $api_key_flg = $user->api_key ? '1' : '';
 
         return view('manage.index', compact('api_key_flg'));
     }
 
     public function show($id)
     {
-        // Google OAuthトークン未登録の場合はチャンネル管理に戻す
+        // APIキー未登録の場合はチャンネル管理に戻す
         $user = Auth::user();
-        $api_key_flg = $user->google_token ? '1' : '';
+        $api_key_flg = $user->api_key ? '1' : '';
         // ハンドルが存在しない場合はチャンネル管理に戻す
         $channel = Channel::where('handle', $id)->first();
         if (! $api_key_flg || ! $channel) {

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\ProfileUpdateRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
 
@@ -26,7 +27,14 @@ class ProfileController extends Controller
      */
     public function update(ProfileUpdateRequest $request): RedirectResponse
     {
-        $request->user()->fill($request->validated());
+        $validated = $request->validated();
+
+        // APIキーが入力されている場合は暗号化して保存
+        if (isset($validated['api_key']) && $validated['api_key']) {
+            $validated['api_key'] = Crypt::encryptString($validated['api_key']);
+        }
+
+        $request->user()->fill($validated);
 
         if ($request->user()->isDirty('email')) {
             $request->user()->email_verified_at = null;

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -18,6 +18,7 @@ class ProfileUpdateRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
+            'api_key' => ['nullable', 'string', 'max:255'],
         ];
     }
 }

--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -25,8 +25,8 @@ class RefreshArchiveService
         // ログインを偽装
         $user = User::where('id', '=', $userId)->firstOrFail();
 
-        if (! $user->google_token) {
-            throw new Exception("User ID {$userId} does not have a Google OAuth token. Please authenticate with Google first.");
+        if (! $user->api_key) {
+            throw new Exception("User ID {$userId} does not have an API key. Please register an API key in your profile first.");
         }
 
         Auth::login($user);

--- a/docs/API_KEY_SETUP.md
+++ b/docs/API_KEY_SETUP.md
@@ -1,0 +1,90 @@
+# YouTube Data API キー登録手順
+
+このアプリケーションでは、各ユーザーが独自のYouTube Data API キーを登録する必要があります。
+
+## なぜAPIキーが必要なのか
+
+- YouTube Data API v3には1日あたり10,000 unitsのquota制限があります
+- 各ユーザーが独自のAPIキーを持つことで、quotaを分離できます
+- これにより、多くのユーザーがアプリを利用してもquotaが枯渇しません
+
+## 登録手順
+
+### 1. Google Cloud Consoleにアクセス
+
+https://console.cloud.google.com/ にアクセスしてください。
+
+### 2. 新しいプロジェクトを作成
+
+1. 画面上部のプロジェクト選択ドロップダウンをクリック
+2. 「新しいプロジェクト」をクリック
+3. プロジェクト名を入力（例：「ycs-api」）
+4. 「作成」をクリック
+
+### 3. YouTube Data API v3を有効化
+
+1. 作成したプロジェクトを選択
+2. 左メニューから「APIとサービス」→「ライブラリ」を選択
+3. 検索ボックスに「YouTube Data API v3」と入力
+4. 「YouTube Data API v3」をクリック
+5. 「有効にする」ボタンをクリック
+
+### 4. APIキーを作成
+
+1. 左メニューから「APIとサービス」→「認証情報」を選択
+2. 画面上部の「認証情報を作成」ボタンをクリック
+3. 「APIキー」を選択
+4. APIキーが作成されます（`AIzaSy...`で始まる文字列）
+
+### 5. APIキーの制限を設定（推奨）
+
+セキュリティのため、APIキーに制限を設定することを推奨します：
+
+1. 作成されたAPIキーの右側にある鉛筆アイコン（編集）をクリック
+2. 「アプリケーションの制限」セクション：
+   - 「なし」を選択（サーバーサイドで使用するため）
+3. 「API の制限」セクション：
+   - 「キーを制限」を選択
+   - 「YouTube Data API v3」のみにチェック
+4. 「保存」をクリック
+
+### 6. アプリケーションにAPIキーを登録
+
+1. このアプリケーションにログイン
+2. プロフィール画面を開く
+3. 「YouTube API Key」欄に作成したAPIキーを貼り付け
+4. 「Save」ボタンをクリック
+
+## Quota について
+
+- デフォルトのquota: 10,000 units/日
+- 一般的な使用例：
+  - チャンネル情報取得：1 unit
+  - 動画リスト取得（50件）：1 unit
+  - コメント取得（100件）：1 unit
+
+### Quotaが不足する場合
+
+通常の使用では10,000 units/日で十分ですが、もし不足する場合は：
+
+1. Google Cloud Consoleで「IAMと管理」→「割り当て」を選択
+2. 「YouTube Data API v3」のquotaを検索
+3. 増量をリクエスト（無料で50,000 units程度まで増量可能な場合が多い）
+
+## トラブルシューティング
+
+### 「API key not valid」エラーが出る場合
+
+1. APIキーをコピペする際に余分な空白が入っていないか確認
+2. YouTube Data API v3が有効化されているか確認
+3. APIキー作成直後は反映に数分かかる場合があります
+
+### 「Quota exceeded」エラーが出る場合
+
+1日のquota（10,000 units）を使い切った場合です。翌日（太平洋時間0時）にリセットされます。
+
+## 参考リンク
+
+- [Google Cloud Console](https://console.cloud.google.com/)
+- [YouTube Data API v3 Documentation](https://developers.google.com/youtube/v3)
+- [API Quotas and Limits](https://developers.google.com/youtube/v3/getting-started#quota)

--- a/resources/views/profile/partials/google-account-info.blade.php
+++ b/resources/views/profile/partials/google-account-info.blade.php
@@ -5,7 +5,7 @@
         </h2>
 
         <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-            {{ __('YouTube APIへのアクセスに使用されているGoogleアカウント情報') }}
+            {{ __('ログイン用のGoogleアカウント情報（YouTube APIアクセスには上記のAPIキーを使用）') }}
         </p>
     </header>
 
@@ -53,18 +53,10 @@
                             d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
                     <div>
-                        <p>このGoogleアカウントを使用してYouTube Data APIにアクセスしています。</p>
-                        <p class="mt-1">アクセストークンは自動的に更新されます。</p>
+                        <p>このGoogleアカウントを使用してログインしています。</p>
+                        <p class="mt-1">YouTube APIへのアクセスには、上記で設定したAPIキーを使用します。</p>
                     </div>
                 </div>
-            </div>
-
-            <!-- 権限情報 -->
-            <div class="text-sm">
-                <div class="font-medium text-gray-700 dark:text-gray-300 mb-2">付与されている権限:</div>
-                <ul class="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-1">
-                    <li>YouTube Data API v3 - 読み取り専用</li>
-                </ul>
             </div>
         </div>
     @else

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -49,6 +49,16 @@
             @endif
         </div>
 
+        <div>
+            <x-input-label for="api_key" value="YouTube API Key" />
+            <x-text-input id="api_key" name="api_key" type="text" class="mt-1 block w-full" :value="old('api_key')" autocomplete="api_key" placeholder="AIzaSy..." />
+            <x-input-error class="mt-2" :messages="$errors->get('api_key')" />
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                YouTube Data APIアクセス用のAPIキーを入力してください。<br>
+                登録済みの場合は空欄のままで保存すると現在のキーを維持します。
+            </p>
+        </div>
+
         <div class="flex items-center gap-4">
             <x-primary-button>{{ __('Save') }}</x-primary-button>
 


### PR DESCRIPTION
## 概要

Issue #206の実装。共有quotaの枯渇問題を解決するため、各ユーザーが独自のAPIキーを持つ方式に変更しました。

## 問題

Issue #194で実装したGoogle OAuth認証では、全ユーザーが1つのGoogle Cloud Project（CLIENT_ID）を共有していました。これにより、YouTube Data API v3のquota（10,000 units/日）を全ユーザーで共有することになり、ファンサイトの用途（1ユーザーが複数の「推し」チャンネルを登録）では確実に枯渇します。

## 解決策

各ユーザーが独自のGoogle Cloud ProjectとAPIキーを持つことで、quotaを分離します（10ユーザーなら合計100,000 units/日）。

### ハイブリッド認証方式
- **ログイン**: Google OAuth（ユーザー認証用）- 維持
- **YouTube API**: APIキー（quota分離用）- 新規

## 変更内容

### Phase 1: YouTubeService改修
- `setAuth()`を`setApiKey()`に変更
- OAuth関連のトークンリフレッシュロジックを削除
- APIキー方式でYouTube APIにアクセス

### Phase 2: UI改修
- プロフィール画面にAPIキー入力欄を追加
- Google連携セクションの説明を更新（「ログイン用」と明記）
- ProfileController: APIキー暗号化保存ロジック追加
- ManageController: `google_token`→`api_key`チェックに変更

### Phase 3: バッチ処理改修
- RefreshArchives: `api_key`保有ユーザーを自動選択
- RefreshArchiveService: `api_key`検証ロジックに変更

### Phase 4: ドキュメント整備
- `docs/API_KEY_SETUP.md`: 詳細な登録手順書を作成
- `README.md`: YouTube API設定セクションを追加

## テスト結果

```
Tests:    133 passed (421 assertions)
Duration: 4.53s
```

## Issue #194との関係

Issue #194で実装した機能の一部を変更：

**削除した機能**:
- YouTube API呼び出しのOAuth方式
- トークンリフレッシュロジック

**維持した機能**:
- Googleログイン（OAuth認証）
- プロフィール画面のGoogle連携情報表示
- ユーザー登録・認証フロー

## 関連Issue

- Fixes #206
- Related to #194（部分的にrevert）
- Related to #205（マルチユーザー対応は本PR完了後に実装）

🤖 Generated with [Claude Code](https://claude.com/claude-code)