### PR TITLE
feat: マルチユーザー対応 - チャンネル所有権管理

### DIFF
--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -9,12 +9,17 @@ class Channel extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['handle', 'channel_id', 'title', 'thumbnail'];
+    protected $fillable = ['handle', 'channel_id', 'title', 'thumbnail', 'user_id'];
 
     protected $hidden = ['channel_id'];
 
     public function archives()
     {
         return $this->hasMany(Archive::class, 'channel_id', 'channel_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -65,4 +65,9 @@ class User extends Authenticatable
         'google_token' => 'encrypted:array',  // 配列として暗号化
         'google_refresh_token' => 'encrypted',
     ];
+
+    public function channels()
+    {
+        return $this->hasMany(Channel::class);
+    }
 }

--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -173,6 +173,26 @@ class RefreshArchiveService
         return Channel::count();
     }
 
+    public function getOldestUpdatedChannelForUser(int $userId): ?Channel
+    {
+        $archive = Archive::whereHas('channel', function ($query) use ($userId) {
+            $query->where('user_id', $userId);
+        })
+            ->orderBy('created_at', 'asc')
+            ->first();
+
+        if (! $archive) {
+            return null;
+        }
+
+        return Channel::where('channel_id', '=', $archive->channel_id)->first();
+    }
+
+    public function getChannelCountForUser(int $userId): int
+    {
+        return Channel::where('user_id', $userId)->count();
+    }
+
     /**
      * change_listの情報をts_itemsに反映
      *

--- a/database/factories/ChannelFactory.php
+++ b/database/factories/ChannelFactory.php
@@ -24,6 +24,7 @@ class ChannelFactory extends Factory
             'channel_id' => 'UC'.fake()->regexify('[A-Za-z0-9_-]{20}'),
             'title' => $this->faker->company().' Channel',
             'thumbnail' => $this->faker->imageUrl(200, 200, 'people', true),
+            'user_id' => \App\Models\User::factory(),
         ];
     }
 }

--- a/database/migrations/2025_11_16_063803_add_user_id_to_channels_table.php
+++ b/database/migrations/2025_11_16_063803_add_user_id_to_channels_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->nullable()->after('handle');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('set null');
+        });
+
+        // 既存のチャンネルをuser_id=2に紐づけ
+        DB::table('channels')->whereNull('user_id')->update(['user_id' => 2]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/tests/Feature/ChannelTimestampDownloadTest.php
+++ b/tests/Feature/ChannelTimestampDownloadTest.php
@@ -6,6 +6,7 @@ use App\Models\Archive;
 use App\Models\Channel;
 use App\Models\TimestampSongMapping;
 use App\Models\TsItem;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Tests\TestCase;
@@ -18,9 +19,14 @@ class ChannelTimestampDownloadTest extends TestCase
 
     private Archive $archive;
 
+    private User $user;
+
     protected function setUp(): void
     {
         parent::setUp();
+
+        // テスト用のユーザーを作成
+        $this->user = User::factory()->create();
 
         // テスト用のチャンネルとアーカイブを作成
         $this->channel = Channel::create([
@@ -28,6 +34,7 @@ class ChannelTimestampDownloadTest extends TestCase
             'channel_id' => 'UC123456789',
             'title' => 'Test Channel',
             'thumbnail' => 'https://example.com/thumb.jpg',
+            'user_id' => $this->user->id,
         ]);
 
         $this->archive = Archive::create([
@@ -522,6 +529,7 @@ class ChannelTimestampDownloadTest extends TestCase
             'channel_id' => 'UC987654321',
             'title' => 'Special Test Channel',
             'thumbnail' => 'https://example.com/special.jpg',
+            'user_id' => $this->user->id,
         ]);
 
         Archive::create([
@@ -563,6 +571,7 @@ class ChannelTimestampDownloadTest extends TestCase
             'channel_id' => 'UC111222333',
             'title' => 'Long Handle Channel',
             'thumbnail' => 'https://example.com/long.jpg',
+            'user_id' => $this->user->id,
         ]);
 
         Archive::create([
@@ -604,6 +613,7 @@ class ChannelTimestampDownloadTest extends TestCase
             'channel_id' => 'UC999888777',
             'title' => 'Special Only Channel',
             'thumbnail' => 'https://example.com/special-only.jpg',
+            'user_id' => $this->user->id,
         ]);
 
         Archive::create([


### PR DESCRIPTION
## 概要

Issue #205の実装。各ユーザーが自分の追加したチャンネルのみを管理できるようにし、同じYouTubeチャンネルを複数ユーザーが重複登録できないよう排他制御を実装しました。

## 変更内容

### Phase 1: データベース・モデル変更

**マイグレーション:**
- `channels.user_id` カラム追加（nullable, foreign key to users）
- 既存の3チャンネルを `user_id=2` に紐づけ

**モデル:**
- `Channel::user()` リレーション追加（belongsTo User）
- `User::channels()` リレーション追加（hasMany Channel）

### Phase 2: チャンネル登録時の所有権管理

**ManageController:**
- `addChannel()`: チャンネル作成時に `Auth::id()` を `user_id` として保存
  - `channel_id` の重複をDB::transactionで制御（unique constraint違反を検出）
- `fetchChannel()`: 自分のチャンネルのみ取得（`Auth::user()->channels()`）
- `show()`: 所有権チェック追加（403エラー）
- `fetchArchives()`: 所有権チェック追加（403エラー）
- `addArchives()`: 所有権チェック追加（403エラー）

### Phase 3: バッチ処理のマルチユーザー対応

**RefreshArchives コマンド:**
- `--user-id` 指定: 単一ユーザーのチャンネルを更新
- `--user-id` 未指定: APIキー保有ユーザー全員のチャンネルを順番に更新

**RefreshArchiveService:**
- `getOldestUpdatedChannelForUser(int $userId)`: ユーザー別の最古チャンネル取得
- `getChannelCountForUser(int $userId)`: ユーザー別のチャンネル数取得

### Phase 4: テスト修正

- `ChannelFactory`: `user_id` を自動設定
- `ManageControllerTest`: 所有権チェックのテスト追加（2件）
  - `test_show_denies_access_to_other_users_channel`
  - `test_add_archives_denies_access_to_other_users_channel`
- `ChannelTimestampDownloadTest`: user_id 設定

## セキュリティ対策

1. **排他制御**: `channel_id` のunique constraintとトランザクションで重複登録を防止
2. **所有権チェック**: 他のユーザーのチャンネルへの不正アクセスを403エラーで拒否
3. **レースコンディション対策**: DB::transactionとQueryExceptionで安全に処理

## テスト結果

```
Tests:    135 passed (423 assertions)
Duration: 4.80s
```

- 全既存テストがパス
- 新規テスト2件追加（所有権チェック）

## 互換性

### 後方互換性
- 既存のチャンネル表示・検索機能は影響なし
- アーカイブ・タイムスタンプ機能は影響なし

### 移行戦略
- マイグレーション実行時に既存3チャンネルを自動的にID:2に紐づけ
- ユーザーへの操作変更なし（透過的に所有権が管理される）

## 関連

- Fixes #205
- Depends on #206 / #207（APIキー方式への移行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)