### PR TITLE
fix: APIキーのセキュリティとエラーハンドリングの改善

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -6,7 +6,6 @@ use App\Http\Requests\ProfileUpdateRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
 
@@ -29,9 +28,9 @@ class ProfileController extends Controller
     {
         $validated = $request->validated();
 
-        // APIキーが入力されている場合は暗号化して保存
-        if (isset($validated['api_key']) && $validated['api_key']) {
-            $validated['api_key'] = Crypt::encryptString($validated['api_key']);
+        // APIキーの空文字列をnullに変換（モデルのcastsで自動暗号化される）
+        if (isset($validated['api_key'])) {
+            $validated['api_key'] = trim($validated['api_key']) ?: null;
         }
 
         $request->user()->fill($validated);

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -21,4 +21,11 @@ class ProfileUpdateRequest extends FormRequest
             'api_key' => ['nullable', 'string', 'regex:/^AIza[0-9A-Za-z_-]{35}$/'],
         ];
     }
+
+    public function messages(): array
+    {
+        return [
+            'api_key.regex' => 'YouTube API キーの形式が正しくありません。APIキーは "AIza" で始まる39文字の文字列である必要があります。',
+        ];
+    }
 }

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -18,7 +18,7 @@ class ProfileUpdateRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
-            'api_key' => ['nullable', 'string', 'max:255'],
+            'api_key' => ['nullable', 'string', 'regex:/^AIza[0-9A-Za-z_-]{35}$/'],
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -50,6 +50,7 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'api_key',
         'google_token',
         'google_refresh_token',
     ];
@@ -62,6 +63,7 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
+        'api_key' => 'encrypted',
         'google_token' => 'encrypted:array',  // 配列として暗号化
         'google_refresh_token' => 'encrypted',
     ];

--- a/app/Services/YouTubeService.php
+++ b/app/Services/YouTubeService.php
@@ -8,7 +8,6 @@ use Google\Client as Google_Client;
 use Google\Service\YouTube as Google_Service_YouTube;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 

--- a/app/Services/YouTubeService.php
+++ b/app/Services/YouTubeService.php
@@ -32,6 +32,8 @@ class YouTubeService
 
     /**
      * APIキーを設定してYouTube APIクライアントを初期化
+     *
+     * @throws Exception APIキーが設定されていない、または無効な場合
      */
     private function setApiKey()
     {
@@ -40,8 +42,14 @@ class YouTubeService
             return;
         }
 
-        $apiKey = Crypt::decryptString(Auth::user()->api_key);
-        $this->client->setDeveloperKey($apiKey);
+        $user = Auth::user();
+
+        if (! $user || ! $user->api_key) {
+            throw new Exception('APIキーが設定されていません。プロフィール画面でYouTube Data APIキーを登録してください。');
+        }
+
+        // モデルのcastsで自動復号化されるため、Crypt::decryptString()は不要
+        $this->client->setDeveloperKey($user->api_key);
         $this->youtube = new Google_Service_YouTube($this->client);
     }
 


### PR DESCRIPTION
## 概要

Issue #208: APIキーのセキュリティとエラーハンドリングの改善

## 変更内容

### Phase 1: Userモデルの修正
- `api_key`を`$casts`に追加（`encrypted`として暗号化）
- `api_key`を`$hidden`に追加（JSON出力時に非表示）

### Phase 2: バリデーション強化
- YouTube API key形式の正規表現バリデーションを追加
- パターン: `/^AIza[0-9A-Za-z_-]{35}$/`

### Phase 3: エラーハンドリング改善
- `ProfileController`から手動暗号化処理を削除
- `YouTubeService`から手動復号化処理を削除
- APIキー未設定時の明確なエラーメッセージを追加
- 空文字列をnullに変換する処理を追加

## 修正ファイル
- `app/Models/User.php`: API keyの暗号化cast追加、$hiddenに追加
- `app/Http/Requests/ProfileUpdateRequest.php`: YouTube API key形式のバリデーション追加
- `app/Http/Controllers/ProfileController.php`: 手動暗号化処理を削除
- `app/Services/YouTubeService.php`: 手動復号化処理を削除、エラーメッセージ改善

## テスト
- 全135テストが成功
- コードスタイルチェック: OK
- フロントエンドビルド: OK

## 関連Issue
Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)