### PR TITLE
fix: メール認証ミドルウェアを削除（Option B）

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\Route;
 |
  */
 
-Route::middleware(['auth', 'verified'])->group(function () {
+Route::middleware(['auth'])->group(function () {
     // TODO: 別のサービスができるまでは自動的に歌枠検索に飛ばす
     Route::redirect('/manage', '/channels/manage', 301);
 

--- a/tests/Feature/AuthorizationTest.php
+++ b/tests/Feature/AuthorizationTest.php
@@ -80,32 +80,33 @@ class AuthorizationTest extends TestCase
     }
 
     /**
-     * メール未認証ユーザーでも管理画面にアクセスできる（現在の実装）
+     * メール未認証ユーザーでも管理画面にアクセスできる
      *
-     * Note: routes/web.phpでは'verified'ミドルウェアが指定されているが、
-     * テスト環境では実際にはメール認証チェックが無効化されている可能性がある。
-     * セキュリティ要件次第では、この動作を見直す必要があるかもしれない。
+     * Note: メール認証は不要としています（Issue #196でOption Bを選択）
+     * 認証（auth）のみで管理画面にアクセス可能です。
      */
     public function test_unverified_user_can_access_manage_pages(): void
     {
         $user = User::factory()->create(['email_verified_at' => null]);
 
         $response = $this->actingAs($user)->get('/channels/manage');
-        $response->assertStatus(200); // 現在の実装ではアクセス可能
+        $response->assertStatus(200);
 
         $response = $this->actingAs($user)->get('/manage/logs');
         $response->assertStatus(200);
     }
 
     /**
-     * メール未認証ユーザーでも管理APIにアクセスできる（現在の実装）
+     * メール未認証ユーザーでも管理APIにアクセスできる
+     *
+     * Note: メール認証は不要としています（Issue #196でOption Bを選択）
      */
     public function test_unverified_user_can_access_manage_api(): void
     {
         $user = User::factory()->create(['email_verified_at' => null]);
 
         $response = $this->actingAs($user)->getJson('/api/manage/channels');
-        $response->assertStatus(200); // 現在の実装ではアクセス可能
+        $response->assertStatus(200);
 
         $response = $this->actingAs($user)->getJson('/api/songs/timestamps');
         $response->assertStatus(200);


### PR DESCRIPTION
## 概要

Issue #196: セキュリティ: メール認証ミドルウェアが機能していない問題の解決

Option B（メール認証を不要にする）を選択しました。

## 変更内容

- `routes/web.php`から`verified`ミドルウェアを削除
- 認証（`auth`）のみで管理画面・管理APIにアクセス可能に変更
- `AuthorizationTest`のコメントを更新（設計として明示）

## 理由

ユーザーは登録後すぐに管理機能を使用できるようにすることで、UXを向上させます。

## 影響範囲

以下のルートがメール未認証ユーザーからアクセス可能（設計通り）:
- `/channels/manage` - チャンネル管理画面
- `/songs/normalize` - 楽曲マスタ管理画面
- `/manage/logs` - ログ管理画面
- `/api/manage/*` - 管理API全般
- `/api/songs/*` - 楽曲マスタAPI全般

## セキュリティ考慮

- ユーザー認証（`auth`ミドルウェア）は引き続き必須
- メール認証は不要だが、パスワード認証は必要

## テスト
- 全135テストが成功
- コードスタイルチェック: OK
- フロントエンドビルド: OK

## 関連Issue
Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)