### PR TITLE
security: ログアウト時にGoogle OAuthトークンをrevoke

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -5,9 +5,11 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
 use App\Providers\RouteServiceProvider;
+use Google\Client as Google_Client;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 
 class AuthenticatedSessionController extends Controller
@@ -37,6 +39,24 @@ class AuthenticatedSessionController extends Controller
      */
     public function destroy(Request $request): RedirectResponse
     {
+        // Google OAuthトークンをrevokeする
+        $user = Auth::user();
+        if ($user && $user->google_token && isset($user->google_token['access_token'])) {
+            try {
+                $client = new Google_Client;
+                $client->revokeToken($user->google_token['access_token']);
+                Log::info('Google OAuth token revoked successfully', [
+                    'user_id' => $user->id,
+                ]);
+            } catch (\Exception $e) {
+                // トークンのrevokeに失敗してもログアウト自体は成功させる
+                Log::warning('Failed to revoke Google token', [
+                    'user_id' => $user->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
         Auth::guard('web')->logout();
 
         $request->session()->invalidate();


### PR DESCRIPTION
## 概要

Issue #202: ログアウト時のGoogle OAuthトークンrevoke機能

## 変更内容

- ログアウト時に`Google\Client::revokeToken()`を呼び出し
- トークンを無効化することでセキュリティを向上
- エラーハンドリングを追加（revoke失敗時もログアウトは成功）
- ログ出力を追加（成功・失敗両方）

## セキュリティ効果

### 現状の問題
- ログアウトしてもGoogleトークンは有効なまま
- 万が一DBが漏洩した場合、トークンが悪用される可能性

### 改善後
- ログアウト後、DBに保存されているトークンが無効化される
- 万が一DB漏洩しても、トークンは使用不可
- トークン漏洩リスクの軽減

## 実装詳細

- `AuthenticatedSessionController::destroy()`メソッドを修正
- ログアウト前にユーザーの`google_token`をチェック
- トークンが存在する場合、Googleにrevokeリクエストを送信
- try-catchでエラーハンドリング（失敗してもログアウトは成功）
- ログ出力でrevoke成功/失敗を記録

## テスト
- 全135テストが成功
- コードスタイルチェック: OK
- フロントエンドビルド: OK

## 関連Issue
Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)