### PR TITLE
improvement: APIキー管理とアカウント削除の改善 (#215)

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -45,6 +45,18 @@ class ProfileController extends Controller
     }
 
     /**
+     * Delete the user's API key.
+     */
+    public function destroyApiKey(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+        $user->api_key = null;
+        $user->save();
+
+        return Redirect::route('profile.edit')->with('status', 'api-key-deleted');
+    }
+
+    /**
      * Delete the user's account.
      */
     public function destroy(Request $request): RedirectResponse
@@ -57,6 +69,10 @@ class ProfileController extends Controller
 
         Auth::logout();
 
+        // ユーザーに紐づくチャンネルもソフトデリート
+        $user->channels()->delete();
+
+        // ユーザーをソフトデリート
         $user->delete();
 
         $request->session()->invalidate();

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -4,10 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Channel extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = ['handle', 'channel_id', 'title', 'thumbnail', 'user_id'];
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -24,7 +25,7 @@ use Laravel\Sanctum\HasApiTokens;
  */
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.

--- a/database/migrations/2025_11_16_100947_add_soft_deletes_to_users_table.php
+++ b/database/migrations/2025_11_16_100947_add_soft_deletes_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2025_11_16_100948_add_soft_deletes_to_channels_table.php
+++ b/database/migrations/2025_11_16_100948_add_soft_deletes_to_channels_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/resources/views/manage/index.blade.php
+++ b/resources/views/manage/index.blade.php
@@ -35,8 +35,12 @@
                 <div id="channels" class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 w-[100%] max-w-5xl border shadow p-4 rounded-lg"></div>
             </div>
         @else
-            <div>
-                <p class="text-gray-500">Googleアカウントでログインしてください。</p>
+            <div class="text-center p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+                <p class="text-gray-700 dark:text-gray-300 mb-4">YouTube Data API キーが設定されていません。</p>
+                <p class="text-gray-600 dark:text-gray-400 mb-6 text-sm">プロフィール画面でAPIキーを登録してください。</p>
+                <a href="{{ route('profile.edit') }}" class="inline-flex items-center px-4 py-2 bg-gray-800 dark:bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-white dark:text-gray-800 uppercase tracking-widest hover:bg-gray-700 dark:hover:bg-white focus:bg-gray-700 dark:focus:bg-white active:bg-gray-900 dark:active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
+                    プロフィール画面へ
+                </a>
             </div>
         @endif
     </div>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -50,14 +50,46 @@
         </div>
 
         <div>
-            <x-input-label for="api_key" value="YouTube API Key" />
-            <x-text-input id="api_key" name="api_key" type="text" class="mt-1 block w-full" :value="old('api_key')" autocomplete="api_key" placeholder="AIzaSy..." />
+            <div class="flex items-center gap-2">
+                <x-input-label for="api_key" value="YouTube API Key" />
+                @if ($user->api_key)
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100">
+                        ✓ 登録済み
+                    </span>
+                @else
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+                        未登録
+                    </span>
+                @endif
+            </div>
+            <div class="flex gap-2">
+                <x-text-input id="api_key" name="api_key" type="text" class="mt-1 block w-full" :value="old('api_key')" autocomplete="api_key" placeholder="AIzaSy..." />
+                @if ($user->api_key)
+                    <button type="button" onclick="confirmDeleteApiKey()" class="mt-1 px-4 py-2 bg-red-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-red-500 active:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition ease-in-out duration-150">
+                        削除
+                    </button>
+                @endif
+            </div>
             <x-input-error class="mt-2" :messages="$errors->get('api_key')" />
             <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
                 YouTube Data APIアクセス用のAPIキーを入力してください。<br>
-                登録済みの場合は空欄のままで保存すると現在のキーを維持します。
+                登録済みの場合は空欄のままで保存すると現在のキーを維持します。変更する場合は新しいキーを入力してください。
             </p>
         </div>
+
+        <!-- APIキー削除用のフォーム -->
+        <form id="delete-api-key-form" method="post" action="{{ route('profile.api-key.destroy') }}" class="hidden">
+            @csrf
+            @method('delete')
+        </form>
+
+        <script>
+        function confirmDeleteApiKey() {
+            if (confirm('APIキーを削除してもよろしいですか？削除後はチャンネル管理機能が使用できなくなります。')) {
+                document.getElementById('delete-api-key-form').submit();
+            }
+        }
+        </script>
 
         <div class="flex items-center gap-4">
             <x-primary-button>{{ __('Save') }}</x-primary-button>
@@ -65,6 +97,11 @@
             @if (session('status') === 'profile-updated')
                 <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
                     class="text-sm text-gray-600 dark:text-gray-400">{{ __('Saved.') }}</p>
+            @endif
+
+            @if (session('status') === 'api-key-deleted')
+                <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
+                    class="text-sm text-gray-600 dark:text-gray-400">APIキーを削除しました。</p>
             @endif
         </div>
     </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,6 +60,7 @@ Route::middleware(['auth'])->group(function () {
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+    Route::delete('/profile/api-key', [ProfileController::class, 'destroyApiKey'])->name('profile.api-key.destroy');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -76,7 +76,7 @@ class ProfileTest extends TestCase
             ->assertRedirect('/');
 
         $this->assertGuest();
-        $this->assertNull($user->fresh());
+        $this->assertTrue($user->fresh()->trashed());
     }
 
     public function test_correct_password_must_be_provided_to_delete_account(): void


### PR DESCRIPTION
## 概要
Issue #215で報告された4つの問題を解決し、APIキー管理とアカウント削除機能を改善しました。

## 実装内容

### 1. チャンネル管理画面のメッセージ修正
- **問題**: APIキー未登録時に「Google連携してください」という誤解を招くメッセージが表示されていた
- **解決**: 
  - 「YouTube Data API キーが設定されていません」という明確なメッセージに変更
  - プロフィール画面へのリンクボタンを追加し、設定方法を案内

### 2. プロフィール画面にステータスバッジ追加
- **問題**: APIキーの登録状態が視覚的に分かりにくかった
- **解決**:
  - 登録済み: 緑色のバッジ「✓ 登録済み」を表示
  - 未登録: グレーのバッジ「未登録」を表示
  - ユーザーが一目で状態を把握可能に

### 3. APIキー削除機能の実装
- **問題**: 一度登録したAPIキーを削除する手段が存在しなかった
- **解決**:
  - 「削除」ボタンを追加（APIキー登録時のみ表示）
  - 削除確認ダイアログを実装
  - 削除成功時のフラッシュメッセージ表示
  - 新しいエンドポイント: `DELETE /profile/api-key`

### 4. ソフトデリート機能の実装
- **問題**: アカウント削除時にユーザーとチャンネルが完全削除され、関連データの整合性が失われる可能性があった
- **解決**:
  - `users`テーブルに`deleted_at`カラムを追加
  - `channels`テーブルに`deleted_at`カラムを追加
  - UserモデルとChannelモデルに`SoftDeletes`トレイトを適用
  - アカウント削除時に関連チャンネルも自動的にソフトデリート
  - 既存テストを更新（`assertNull`から`assertTrue($user->fresh()->trashed())`へ）

## 変更ファイル
- `app/Http/Controllers/ProfileController.php` - APIキー削除メソッド追加、チャンネルのソフトデリート処理
- `app/Models/User.php` - SoftDeletesトレイト追加
- `app/Models/Channel.php` - SoftDeletesトレイト追加
- `resources/views/manage/index.blade.php` - メッセージとリンクの改善
- `resources/views/profile/partials/update-profile-information-form.blade.php` - ステータスバッジと削除ボタン追加
- `routes/web.php` - APIキー削除ルート追加
- `database/migrations/2025_11_16_100947_add_soft_deletes_to_users_table.php` - 新規
- `database/migrations/2025_11_16_100948_add_soft_deletes_to_channels_table.php` - 新規
- `tests/Feature/ProfileTest.php` - ソフトデリート対応

## テスト結果
全135テスト成功

## 動作確認項目
- [ ] APIキー未登録時のチャンネル管理画面でメッセージとリンクが正しく表示される
- [ ] プロフィール画面でAPIキーのステータスバッジが正しく表示される
- [ ] APIキーの削除機能が正常に動作する（確認ダイアログ含む）
- [ ] アカウント削除時にユーザーとチャンネルがソフトデリートされる
- [ ] ソフトデリートされたユーザーとチャンネルが通常のクエリで表示されない

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>