### PR TITLE
fix: タイムスタンプ検索で半角チルダが検索できない問題を修正

### DIFF
--- a/app/Helpers/TextNormalizer.php
+++ b/app/Helpers/TextNormalizer.php
@@ -8,13 +8,14 @@ class TextNormalizer
      * タイムスタンプテキストを正規化
      *
      * 以下の処理を行います：
-     * - 全角文字を半角に変換
+     * - 全角英数字を半角に変換（チルダは除く）
      * - 区切り文字（スラッシュ、ハイフン、コロン等）を統一
+     * - チルダ系文字（～、〜）を半角チルダ（~）に統一
      * - 空白文字を統一（全て半角スペースに）
      * - 先頭・末尾の空白をトリム
      * - 小文字に統一
      */
-    public static function normalize($text)
+    public static function normalize(?string $text): string
     {
         if (empty($text)) {
             return '';
@@ -28,6 +29,9 @@ class TextNormalizer
         foreach ($separators as $sep) {
             $text = str_replace($sep, '/', $text);
         }
+
+        // チルダ系文字を半角チルダに統一
+        $text = str_replace(['～', '〜'], '~', $text);
 
         // 連続する区切り文字を1つに
         $text = preg_replace('/\/+/', '/', $text);
@@ -47,18 +51,15 @@ class TextNormalizer
     /**
      * 2つのテキストが正規化後に一致するか判定
      */
-    public static function equals($text1, $text2)
+    public static function equals(?string $text1, ?string $text2): bool
     {
         return static::normalize($text1) === static::normalize($text2);
     }
 
     /**
      * 先頭の全角スペース（および半角スペース）を除外
-     *
-     * @param  string  $text
-     * @return string
      */
-    public static function trimFullwidthSpace($text)
+    public static function trimFullwidthSpace(?string $text): string
     {
         if (empty($text)) {
             return '';
@@ -71,9 +72,9 @@ class TextNormalizer
     /**
      * テキストから楽曲名とアーティスト名を抽出を試みる
      *
-     * @return array ['title' => string, 'artist' => string|null]
+     * @return array{title: string, artist: ?string}
      */
-    public static function extractSongInfo($text)
+    public static function extractSongInfo(?string $text): array
     {
         $normalized = static::normalize($text);
 

--- a/tests/Unit/Helpers/TextNormalizerTest.php
+++ b/tests/Unit/Helpers/TextNormalizerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Unit\Helpers;
+
+use App\Helpers\TextNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class TextNormalizerTest extends TestCase
+{
+    /**
+     * チルダ系文字が半角チルダに統一されることをテスト
+     */
+    public function test_tilde_normalization(): void
+    {
+        // 半角チルダ
+        $this->assertEquals('test~value', TextNormalizer::normalize('test~value'));
+
+        // 全角チルダ（U+FF5E）
+        $this->assertEquals('test~value', TextNormalizer::normalize('test～value'));
+
+        // 波ダッシュ（U+301C）
+        $this->assertEquals('test~value', TextNormalizer::normalize('test〜value'));
+
+        // 複数のチルダが混在する場合
+        $this->assertEquals('a~b~c~d', TextNormalizer::normalize('a~b～c〜d'));
+    }
+
+    /**
+     * 全角半角変換のテスト
+     */
+    public function test_fullwidth_to_halfwidth(): void
+    {
+        $this->assertEquals('abc123', TextNormalizer::normalize('ＡＢＣ１２３'));
+    }
+
+    /**
+     * 区切り文字の統一テスト
+     */
+    public function test_separator_normalization(): void
+    {
+        $this->assertEquals('artist/title', TextNormalizer::normalize('artist-title'));
+        $this->assertEquals('artist/title', TextNormalizer::normalize('artist／title'));
+        $this->assertEquals('artist/title', TextNormalizer::normalize('artist:title'));
+    }
+
+    /**
+     * 空白文字の統一テスト
+     */
+    public function test_whitespace_normalization(): void
+    {
+        $this->assertEquals('hello world', TextNormalizer::normalize('hello　world'));
+        $this->assertEquals('hello world', TextNormalizer::normalize('hello  world'));
+    }
+
+    /**
+     * 小文字統一のテスト
+     */
+    public function test_lowercase_conversion(): void
+    {
+        $this->assertEquals('hello world', TextNormalizer::normalize('HELLO WORLD'));
+        $this->assertEquals('hello world', TextNormalizer::normalize('Hello World'));
+    }
+
+    /**
+     * 複合的な正規化のテスト
+     */
+    public function test_combined_normalization(): void
+    {
+        // 実際のタイムスタンプを想定した複合テスト
+        $input = 'ＹＯＡＳＯＢＩー夜に駆ける～Live Ver.～';
+        $expected = 'yoasobi/夜に駆ける~live ver.~';
+        $this->assertEquals($expected, TextNormalizer::normalize($input));
+    }
+
+    /**
+     * equals メソッドのテスト
+     */
+    public function test_equals(): void
+    {
+        $this->assertTrue(TextNormalizer::equals('test~value', 'test～value'));
+        $this->assertTrue(TextNormalizer::equals('test〜value', 'test～value'));
+        $this->assertFalse(TextNormalizer::equals('test1', 'test2'));
+    }
+
+    /**
+     * trimFullwidthSpace メソッドのテスト
+     */
+    public function test_trim_fullwidth_space(): void
+    {
+        $this->assertEquals('test', TextNormalizer::trimFullwidthSpace('　test'));
+        $this->assertEquals('test', TextNormalizer::trimFullwidthSpace('  test'));
+        $this->assertEquals('test　', TextNormalizer::trimFullwidthSpace('　test　'));
+        $this->assertEquals('', TextNormalizer::trimFullwidthSpace(''));
+        $this->assertEquals('', TextNormalizer::trimFullwidthSpace(null));
+    }
+
+    /**
+     * extractSongInfo メソッドのテスト
+     */
+    public function test_extract_song_info(): void
+    {
+        // アーティスト / 楽曲名 パターン
+        $result = TextNormalizer::extractSongInfo('YOASOBI / 夜に駆ける');
+        $this->assertEquals('yoasobi', $result['artist']);
+        $this->assertEquals('夜に駆ける', $result['title']);
+
+        // 区切り文字なし
+        $result = TextNormalizer::extractSongInfo('夜に駆ける');
+        $this->assertEquals('夜に駆ける', $result['title']);
+        $this->assertNull($result['artist']);
+
+        // チルダを含むケース（チルダは区切り文字ではないので全体がtitleになる）
+        $result = TextNormalizer::extractSongInfo('YOASOBI～夜に駆ける～Live Ver.～');
+        $this->assertEquals('yoasobi~夜に駆ける~live ver.~', $result['title']);
+        $this->assertNull($result['artist']);
+    }
+
+    /**
+     * エッジケースのテスト
+     */
+    public function test_edge_cases(): void
+    {
+        // null入力
+        $this->assertEquals('', TextNormalizer::normalize(null));
+
+        // 空文字列
+        $this->assertEquals('', TextNormalizer::normalize(''));
+
+        // 連続するチルダ
+        $this->assertEquals('a~~~b', TextNormalizer::normalize('a～〜~b'));
+
+        // チルダのみ（チルダは区切り文字ではない）
+        $this->assertEquals('artist~title~version', TextNormalizer::normalize('artist～title〜version'));
+    }
+}


### PR DESCRIPTION
## 概要
Issue #217 の修正: タイムスタンプ検索で半角チルダ（~）が検索できない問題を解決

## 問題
- データベースに全角チルダ（～）や波ダッシュ（〜）で保存されているタイムスタンプを、半角チルダ（~）で検索してもマッチしない
- TextNormalizerがチルダ系文字を統一していなかったため、文字コードレベルで不一致が発生

## 変更内容

### 1. TextNormalizer::normalize()の改善
- チルダ系文字の統一処理を追加
- 全角チルダ（～ U+FF5E）→ 半角チルダ（~ U+007E）
- 波ダッシュ（〜 U+301C）→ 半角チルダ（~ U+007E）

### 2. 型安全性の向上
- 全メソッドに型ヒントを追加（`?string $text`, 戻り値型）
- PHP 8.1の機能を活用

### 3. ドキュメント改善
- docコメントを修正し、実際の処理順序を正確に記載
- チルダ正規化について明記

### 4. テストの追加
- `tests/Unit/Helpers/TextNormalizerTest.php`を新規作成
- チルダ正規化、その他の正規化機能、エッジケースを包括的にテスト
- 全10件のテストが成功（31 assertions）

## テスト結果
```
✓ tilde normalization
✓ fullwidth to halfwidth
✓ separator normalization
✓ whitespace normalization
✓ lowercase conversion
✓ combined normalization
✓ equals
✓ trim fullwidth space
✓ extract song info
✓ edge cases

Tests: 10 passed (31 assertions)
```

## 影響範囲
- `app/Helpers/TextNormalizer.php`
- 新規: `tests/Unit/Helpers/TextNormalizerTest.php`
- タイムスタンプ検索機能全般に影響（意図した動作）

## 確認項目
- [x] チルダ系文字が半角チルダに統一される
- [x] 既存の正規化機能が正常に動作する
- [x] エッジケースが適切に処理される
- [x] 全テストがパスする
- [x] コードスタイルが規約に準拠している

Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)