### PR TITLE
feat: Spotify APIにmarket=JPパラメータを追加

### DIFF
--- a/app/Services/SpotifyService.php
+++ b/app/Services/SpotifyService.php
@@ -30,6 +30,9 @@ class SpotifyService
 
     /**
      * 楽曲を検索
+     *
+     * market=JP を指定することで、日本市場向けのローカライズされた
+     * アーティスト名が返される可能性があります。
      */
     public function searchTracks($query, $limit = 10)
     {
@@ -41,6 +44,7 @@ class SpotifyService
             'q' => $query,
             'type' => 'track',
             'limit' => $limit,
+            'market' => 'JP',
         ]);
 
         if ($response->successful()) {
@@ -52,6 +56,9 @@ class SpotifyService
 
     /**
      * トラック情報を取得
+     *
+     * market=JP を指定することで、日本市場向けのローカライズされた
+     * アーティスト名が返される可能性があります。
      */
     public function getTrack($trackId)
     {
@@ -59,7 +66,9 @@ class SpotifyService
             throw new \Exception('Spotify API is not authenticated.');
         }
 
-        $response = Http::withToken($this->accessToken)->get("https://api.spotify.com/v1/tracks/{$trackId}");
+        $response = Http::withToken($this->accessToken)->get("https://api.spotify.com/v1/tracks/{$trackId}", [
+            'market' => 'JP',
+        ]);
 
         if ($response->successful()) {
             return $response->json();


### PR DESCRIPTION
## 概要
Issue #218 の修正: Spotify APIにmarket=JPパラメータを追加し、日本市場向けのローカライズされたアーティスト名が返される可能性を向上させます。

## 背景
現在、Spotify APIで楽曲を検索した際、アーティスト名が英語表記で統一されてしまう問題があります。`market=JP`パラメータを指定することで、日本市場向けのローカライズされた名前が返される可能性があります。

## 変更内容

### 1. searchTracks()メソッドの改善
- `market=JP`パラメータを追加
- docコメントを追加し、ローカライゼーションについて説明

### 2. getTrack()メソッドの改善
- `market=JP`パラメータを追加（一貫性のため）
- docコメントを追加

### 3. テストの更新
- 既存テスト`test_search_tracks_with_custom_limit()`を更新
- 新規テスト`test_get_track_sends_market_parameter()`を追加
- `Http::fake()`の呼び出し方法を修正（複数エンドポイントを同時にモック）

## テスト結果
```
✓ authenticate success
✓ authenticate failure
✓ search tracks success
✓ search tracks without authentication
✓ search tracks api error
✓ search tracks no results
✓ get track success
✓ get track without authentication
✓ get track not found
✓ search tracks with custom limit
✓ authenticate sends correct parameters
✓ get track sends correct authorization header
✓ get track sends market parameter

Tests: 13 passed (25 assertions)
```

## 影響範囲
- `app/Services/SpotifyService.php`
- `tests/Unit/Services/SpotifyServiceTest.php`
- 新規検索のみに影響（既存の楽曲マスタデータは変更なし）

## 注意事項
- `market=JP`を指定することで、日本市場で利用できない楽曲が検索結果から除外される可能性があります
- 既存のsongs テーブルに保存されているspotify_dataは、marketパラメータなしで取得されたデータのため、今後取得されるデータとアーティスト名の表記が異なる可能性があります

## 確認項目
- [x] searchTracks()に`market=JP`を追加
- [x] getTrack()に`market=JP`を追加
- [x] marketパラメータが正しく送信されることをテストで検証
- [x] 全テストがパスする
- [x] コードスタイルが規約に準拠している

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)