### PR TITLE
feat: 「楽曲ではない」判定の取り消し機能を追加

### DIFF
--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -474,6 +474,27 @@ class SongController extends Controller
     }
 
     /**
+     * 「楽曲ではない」フラグを解除
+     */
+    public function unmarkAsNotSong(Request $request)
+    {
+        $validated = $request->validate([
+            'normalized_text' => 'required|string',
+        ]);
+
+        DB::transaction(function () use ($validated) {
+            $mapping = TimestampSongMapping::where('normalized_text', $validated['normalized_text'])->first();
+
+            if ($mapping && $mapping->is_not_song) {
+                // マッピングを削除して未紐づけ状態に戻す
+                $mapping->delete();
+            }
+        });
+
+        return response()->json(['message' => '「楽曲ではない」マークを解除しました。']);
+    }
+
+    /**
      * マッピングを解除
      */
     public function unlinkTimestamp(Request $request)

--- a/database/factories/TimestampSongMappingFactory.php
+++ b/database/factories/TimestampSongMappingFactory.php
@@ -53,7 +53,8 @@ class TimestampSongMappingFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'song_id' => null,
             'is_not_song' => true,
-            'confidence' => null,
+            'is_manual' => true,
+            'confidence' => 1.0,
         ]);
     }
 

--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -173,6 +173,9 @@
                             <button id="markAsNotSongBtn" class="w-full px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:bg-gray-400 disabled:cursor-not-allowed" disabled>
                                 楽曲ではないとマークする
                             </button>
+                            <button id="unmarkAsNotSongBtn" class="w-full px-4 py-2 bg-yellow-600 text-white rounded-md hover:bg-yellow-700 disabled:bg-gray-400 disabled:cursor-not-allowed" disabled>
+                                楽曲ではないを解除
+                            </button>
                             <button id="unlinkBtn" class="w-full px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700 disabled:bg-gray-400 disabled:cursor-not-allowed" disabled>
                                 紐づけを解除
                             </button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('api/songs', [SongController::class, 'storeSong'])->name('songs.storeSong');
     Route::post('api/songs/link', [SongController::class, 'linkTimestamp'])->name('songs.linkTimestamp');
     Route::post('api/songs/mark-not-song', [SongController::class, 'markAsNotSong'])->name('songs.markAsNotSong');
+    Route::post('api/songs/unmark-not-song', [SongController::class, 'unmarkAsNotSong'])->name('songs.unmarkAsNotSong');
     // Specific routes must come before parameterized routes to avoid parameter capture
     Route::delete('api/songs/unlink', [SongController::class, 'unlinkTimestamp'])->name('songs.unlinkTimestamp');
     Route::get('api/songs/fuzzy-search', [SongController::class, 'fuzzySearch'])->name('songs.fuzzySearch');


### PR DESCRIPTION
## 概要
Issue #220 の修正: 「楽曲ではない」と誤ってマークしてしまったタイムスタンプを、元の未紐づけ状態に戻す機能を追加

## 背景
現在、「楽曲ではない」とマークする機能は存在しますが、誤ってマークした場合に取り消す専用機能がありません。unlinkTimestampメソッドでレコードを削除できますが、これは全てのマッピングを削除してしまうため、「楽曲ではない」フラグだけを解除する専用機能が必要でした。

## 変更内容

### 1. バックエンド: unmarkAsNotSongメソッド追加
**SongController.php**
- `unmarkAsNotSong()`メソッドを追加
- is_not_song=trueのマッピングのみを削除し、未紐づけ状態に戻す

**routes/web.php**
- `POST /api/songs/unmark-not-song`ルートを追加

### 2. フロントエンド: 解除機能の実装
**normalize.js**
- `unmarkAsNotSong()`関数を追加
- is_not_songのタイムスタンプのみをフィルタして処理
- イベントリスナーをbindEvents()に追加
- updateSelectionDisplay()でボタンの有効化制御を追加
  - 1件選択時: is_not_songの場合のみ有効化
  - 複数件選択時: is_not_song が含まれる場合のみ有効化

**index.blade.php**
- 「楽曲ではないを解除」ボタンを追加（黄色）

### 3. テストの追加
**SongControllerTest.php**
- `test_unmark_as_not_song()`: 基本的な解除機能のテスト
- `test_unmark_as_not_song_does_not_delete_normal_mapping()`: 通常のマッピングは削除されないことを確認

**TimestampSongMappingFactory.php**
- notSong()メソッドを修正
  - confidenceをnullから1.0に変更
  - is_manual=trueを追加

## 使用方法

1. タイムスタンプ正規化画面で、「楽曲ではない」とマークされたタイムスタンプを選択
2. 「楽曲ではないを解除」ボタンが有効化される
3. ボタンをクリックして確認
4. マッピングが削除され、タイムスタンプは未紐づけ状態に戻る
5. 再度楽曲を紐づけることが可能になる

## テスト結果
```
✓ unmark as not song
✓ unmark as not song does not delete normal mapping

Tests: 148 passed (460 assertions)
```

## 影響範囲
- `app/Http/Controllers/SongController.php`
- `routes/web.php`
- `resources/js/songs/normalize.js`
- `resources/views/songs/index.blade.php`
- `tests/Feature/SongControllerTest.php`
- `database/factories/TimestampSongMappingFactory.php`

## 確認項目
- [x] unmarkAsNotSongメソッドを実装
- [x] ルートを追加
- [x] フロントエンドに解除機能を追加
- [x] ボタンの有効化制御を実装
- [x] UIにボタンを追加
- [x] テストケースを追加
- [x] 全テストがパスする
- [x] コードスタイルが規約に準拠している

Fixes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)