### PR TITLE
fix: init()メソッドの重複定義を解消してタイムスタンプ表示を修正

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -295,6 +295,10 @@ function registerArchiveListComponent() {
                         const params = new URLSearchParams(window.location.search);
                         this.restoreStateFromURL(params);
                     });
+
+                    // 配信リンクパネルの設定を読み込み
+                    const dismissed = localStorage.getItem('distributionPanelDismissed');
+                    this.panelDismissed = dismissed === 'true';
                 },
 
                 // 報告モーダルを開く
@@ -351,12 +355,6 @@ function registerArchiveListComponent() {
                 },
 
                 // 配信リンクパネル関連メソッド
-                init() {
-                    // localStorageから設定を読み込み
-                    const dismissed = localStorage.getItem('distributionPanelDismissed');
-                    this.panelDismissed = dismissed === 'true';
-                },
-
                 selectSong(song) {
                     if (!song) return;
                     this.selectedSong = song;


### PR DESCRIPTION
## 概要
Issue #230で報告されたタイムスタンプが表示されない問題を修正しました。

## 問題の原因
`resources/js/channels/archive-list.js`で`init()`メソッドが重複定義されており、後の定義(354-358行目)が前の定義(269-298行目)を上書きしていたため、タイムスタンプの初期化処理が実行されなくなっていました。

## 修正内容
- 354-358行目の重複した2つ目の`init()`メソッドを削除
- 269-298行目の1つ目の`init()`メソッドに配信リンクパネルの初期化処理を統合
- これにより、タイムスタンプとアーカイブの初期化処理が正常に実行されるようになりました

## テスト
- ✅ 全テストパス (149 tests)
- ✅ Laravel Pint (コードスタイルチェック) パス
- ✅ フロントエンドビルド成功

## 確認手順
1. v___richeチャンネルなど、タイムスタンプを持つチャンネルページを開く
2. タイムスタンプタブとアーカイブタブでタイムスタンプが表示されることを確認
3. 配信リンクパネルが正常に動作することを確認

Fixes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)