### PR TITLE
fix: YouTube URLフォーマットを短縮形式に統一

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -73,7 +73,7 @@ function registerArchiveListComponent() {
                 getYoutubeUrl(videoId, tsNum) {
                     const safeVideoId = encodeURIComponent(videoId || '');
                     const safeTsNum = parseInt(tsNum) || 0;
-                    return `https://youtube.com/watch?v=${safeVideoId}&t=${safeTsNum}s`;
+                    return `https://youtu.be/${safeVideoId}?t=${safeTsNum}s`;
                 },
 
                 getArchiveUrl(videoId, tsNum) {

--- a/resources/js/manage/archives.js
+++ b/resources/js/manage/archives.js
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 let html = paginationButtons;
 
                 archives.forEach(archive => {
-                    const youtubeUrl = "https://youtube.com/watch?v=" + encodeURIComponent(archive.video_id || '');
+                    const youtubeUrl = "https://youtu.be/" + encodeURIComponent(archive.video_id || '');
                     html += `
                         <div class="archive flex flex-col sm:flex-row w-[100%] max-w-5xl border rounded-lg shadow-lg p-4 gap-4 mb-6 ${archive.is_display ? 'bg-white' : 'bg-gray-200'}">
                             <div class="flex flex-col flex-shrink-0 sm:w-1/3">
@@ -500,7 +500,7 @@ function getTsItems(tsItems) {
         html += `
                 <div class="timestamp text-sm ${tsItem.is_display ? 'text-gray-700 is-display default-display' : 'text-gray-500 pl-4 bg-gray-200'}
                     ${lastCommentId != tsItem.comment_id && lastCommentId != '' ? 'mt-2' : ''}" data-key="${tsItem.id}" data-comment="${tsItem.comment_id}">
-                    <a href="${"https://youtube.com/watch?v=" + encodeURIComponent(tsItem.video_id || '')}&t=${encodeURIComponent(tsItem.ts_num || '0')}s"
+                    <a href="${"https://youtu.be/" + encodeURIComponent(tsItem.video_id || '')}?t=${parseInt(tsItem.ts_num) || 0}s"
                         target="_blank" rel="noopener noreferrer" class="text-blue-500 tabular-nums hover:underline">
                         ${tsItem.ts_text || '0:00:00'}
                     </a>

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -24,7 +24,7 @@ class TimestampNormalization {
             MAX_ARCHIVE_TITLE_WIDTH: '150px',
             MAX_STATUS_LENGTH: 30,
             MAX_SELECTION_TEXT_LENGTH: 100,
-            YOUTUBE_BASE_URL: 'https://youtube.com/watch?v='
+            YOUTUBE_BASE_URL: 'https://youtu.be/'
         };
 
         this.init();
@@ -1128,7 +1128,7 @@ class TimestampNormalization {
      */
     generateVideoUrl(videoId, tsNum) {
         if (!videoId) return null;
-        const timeParam = tsNum ? `&t=${tsNum}s` : '';
+        const timeParam = tsNum ? `?t=${tsNum}s` : '';
         return `${this.CONSTANTS.YOUTUBE_BASE_URL}${videoId}${timeParam}`;
     }
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -58,7 +58,7 @@
         }
 
         function getArchiveUrl(videoId, tsNum = 0) {
-            return 'https://youtube.com/watch?v=' + encodeURIComponentLocal(videoId || '') + (tsNum !== 0 ? '&t=' + tsNum + 's' : '');
+            return 'https://youtu.be/' + encodeURIComponentLocal(videoId || '') + (tsNum !== 0 ? '?t=' + tsNum + 's' : '');
         }
 
         function getCookie(name) {


### PR DESCRIPTION
## 概要
YouTube URLを短縮形式（`youtu.be`）に統一しました。

## 変更内容

**変更前:**
```
https://youtube.com/watch?v=VIDEO_ID&t=TIMEs
```

**変更後:**
```
https://youtu.be/VIDEO_ID?t=TIMEs
```

## 変更対象ファイル

| ファイル | 変更内容 |
|---|---|
| `resources/js/channels/archive-list.js` | `getYoutubeUrl`関数のURL形式を変更 |
| `resources/js/manage/archives.js` | アーカイブ一覧とタイムスタンプのURL生成を変更（2箇所） |
| `resources/js/songs/normalize.js` | `YOUTUBE_BASE_URL`定数と`generateVideoUrl`関数を変更 |
| `resources/views/layouts/app.blade.php` | `getArchiveUrl`関数のURL形式を変更 |

## 利点

- URLが短くなり、共有しやすくなる
- 全ての箇所で統一されたフォーマットになる
- youtu.beはYouTube公式の短縮URLサービス

## テスト結果

✅ 全テスト156件パス (505 assertions)
✅ フロントエンドビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)