### PR TITLE
fix: Amazon MusicとLINE MUSICの検索URL形式を修正

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -417,14 +417,24 @@ function registerArchiveListComponent() {
 
                 getAmazonMusicUrl(song) {
                     if (!song) return '';
-                    const query = encodeURIComponent(`${song.title} ${song.artist}`);
-                    return `https://music.amazon.co.jp/search/${query}`;
+                    // URLに使えない特殊文字を除去し、スペースを+に変換
+                    const searchText = `${song.title} ${song.artist}`
+                        .replace(/[/\\?#%&=:@!$'()*+,;[\]{}|^`<>"]/g, ' ')  // 特殊文字をスペースに
+                        .trim()
+                        .replace(/\s+/g, '+');  // 連続スペースを+に
+                    return `https://music.amazon.co.jp/search/${searchText}`;
                 },
 
                 getLineMusicUrl(song) {
                     if (!song) return '';
-                    const query = encodeURIComponent(`${song.title} ${song.artist}`);
-                    return `https://music.line.me/search/all?query=${query}`;
+                    // URLに使えない特殊文字を除去してからエンコード
+                    const searchText = `${song.title} ${song.artist}`
+                        .replace(/[/\\?#%&=:@!$'()*+,;[\]{}|^`<>"]/g, ' ')
+                        .trim()
+                        .replace(/\s+/g, ' ');  // 連続スペースを1つに
+                    const query = encodeURIComponent(searchText);
+                    // LINE MUSICのwebappは /webapp/ パスを使用
+                    return `https://music.line.me/webapp/search/tracks?query=${query}`;
                 }
             };
         });


### PR DESCRIPTION
## Summary
- Amazon MusicとLINE MUSICの配信リンクが404エラーになる問題を修正
- 両サービスでURL予約文字を除去

## 変更内容

### Amazon Music
- URL予約文字（`/ \ ? # % & = : @ ! $ ' ( ) * + , ; [ ] { } | ^ ` < > "`）をスペースに変換
- 連続するスペースを`+`に置換
- 例: `"CITRUS / Da-iCE"` → `"CITRUS+Da-iCE"`

### LINE MUSIC
- URL予約文字を同様にスペースに変換後、エンコード
- `/search/all?query=` → `/webapp/search/tracks?query=` に変更
- LINE MUSICのwebappは `/webapp/` パスを使用する形式

## Test plan
- [ ] Amazon Music検索リンクが正常に動作することを確認
- [ ] LINE MUSIC検索リンクが正常に動作することを確認
- [ ] 楽曲マッピングありの場合の動作確認
- [ ] テキスト検索（マッピングなし）の場合の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)