### PR TITLE
feat: タイムスタンプ報告機能のバックエンド実装 (#244)

### DIFF
--- a/app/Http/Controllers/TimestampReportController.php
+++ b/app/Http/Controllers/TimestampReportController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TimestampReport;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+
+class TimestampReportController extends Controller
+{
+    /**
+     * 報告を作成（ゲスト可、レートリミット付き）
+     */
+    public function store(Request $request): JsonResponse
+    {
+        // レートリミットチェック（1分間に5回まで）
+        $key = 'timestamp-report:'.$request->ip();
+        if (RateLimiter::tooManyAttempts($key, 5)) {
+            $seconds = RateLimiter::availableIn($key);
+
+            return response()->json([
+                'message' => "報告の送信制限中です。{$seconds}秒後に再度お試しください。",
+            ], 429);
+        }
+
+        $validated = $request->validate([
+            'ts_item_id' => 'required|string|max:26|exists:ts_items,id',
+            'video_id' => 'required|string|max:11',
+            'report_type' => 'required|string|max:20',
+            'comment' => 'nullable|string|max:1000',
+        ]);
+
+        RateLimiter::hit($key, 60);
+
+        $report = TimestampReport::create([
+            'ts_item_id' => $validated['ts_item_id'],
+            'video_id' => $validated['video_id'],
+            'report_type' => $validated['report_type'],
+            'comment' => $validated['comment'] ?? null,
+            'reporter_ip' => $request->ip(),
+        ]);
+
+        return response()->json([
+            'message' => '報告を受け付けました。ご協力ありがとうございます。',
+            'report_id' => $report->id,
+        ], 201);
+    }
+
+    /**
+     * 管理画面用の報告一覧
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $query = TimestampReport::with(['tsItem.archive'])
+            ->orderBy('created_at', 'desc');
+
+        // ステータスフィルター
+        if ($request->has('status') && in_array($request->status, ['pending', 'resolved'])) {
+            $query->where('status', $request->status);
+        }
+
+        $reports = $query->paginate(20);
+
+        return response()->json($reports);
+    }
+
+    /**
+     * 報告を解決済みにする
+     */
+    public function resolve(TimestampReport $report): JsonResponse
+    {
+        $report->markAsResolved();
+
+        return response()->json([
+            'message' => '報告を解決済みにしました。',
+            'report' => $report->fresh(),
+        ]);
+    }
+
+    /**
+     * 報告の詳細を取得
+     */
+    public function show(TimestampReport $report): JsonResponse
+    {
+        $report->load(['tsItem.archive']);
+
+        return response()->json($report);
+    }
+}

--- a/app/Models/TimestampReport.php
+++ b/app/Models/TimestampReport.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TimestampReport extends Model
+{
+    use HasFactory, HasUlids;
+
+    protected $fillable = [
+        'ts_item_id',
+        'video_id',
+        'report_type',
+        'comment',
+        'status',
+        'reporter_ip',
+        'resolved_at',
+    ];
+
+    protected $casts = [
+        'resolved_at' => 'datetime',
+    ];
+
+    /**
+     * 報告対象のタイムスタンプ
+     */
+    public function tsItem(): BelongsTo
+    {
+        return $this->belongsTo(TsItem::class, 'ts_item_id');
+    }
+
+    /**
+     * 報告を解決済みにする
+     */
+    public function markAsResolved(): void
+    {
+        $this->update([
+            'status' => 'resolved',
+            'resolved_at' => now(),
+        ]);
+    }
+
+    /**
+     * 未解決の報告をスコープで取得
+     */
+    public function scopePending($query)
+    {
+        return $query->where('status', 'pending');
+    }
+
+    /**
+     * 解決済みの報告をスコープで取得
+     */
+    public function scopeResolved($query)
+    {
+        return $query->where('status', 'resolved');
+    }
+}

--- a/database/migrations/2025_11_24_044436_create_timestamp_reports_table.php
+++ b/database/migrations/2025_11_24_044436_create_timestamp_reports_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('timestamp_reports', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->string('ts_item_id', 26);
+            $table->string('video_id', 11);
+            $table->string('report_type', 20);
+            $table->text('comment')->nullable();
+            $table->enum('status', ['pending', 'resolved'])->default('pending');
+            $table->string('reporter_ip', 45)->nullable();
+            $table->timestamp('resolved_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('ts_item_id')->references('id')->on('ts_items')
+                ->onDelete('cascade');
+            $table->index(['status', 'created_at']);
+            $table->index('reporter_ip');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('timestamp_reports');
+    }
+};

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -309,8 +309,8 @@ function registerArchiveListComponent() {
                     this.showReportModal = true;
                 },
 
-                // 報告を送信（暫定実装：コンソールに出力）
-                submitReport() {
+                // 報告を送信
+                async submitReport() {
                     // reportTargetの存在確認
                     if (!this.reportTarget) {
                         console.error('No report target set');
@@ -325,33 +325,36 @@ function registerArchiveListComponent() {
                     }
 
                     const reportData = {
-                        timestamp_id: this.reportTarget.id,
+                        ts_item_id: this.reportTarget.id,
                         video_id: this.reportTarget.video_id,
-                        timestamp_text: this.reportTarget.text,
-                        timestamp_time: this.reportTarget.ts_text,
                         report_type: this.reportType,
-                        comment: this.reportComment,
-                        reported_at: new Date().toISOString(),
+                        comment: this.reportComment || null,
                     };
 
-                    // 暫定実装：コンソールに出力
-                    console.log('=== タイムスタンプ報告 ===', reportData);
+                    try {
+                        const response = await fetch('/api/timestamp-reports', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                            },
+                            body: JSON.stringify(reportData),
+                        });
 
-                    // TODO: 将来的にはAPIエンドポイントに送信
-                    // Expected endpoint: POST /api/timestamp-reports
-                    // Expected response: { success: boolean, message: string }
-                    // Required headers: CSRF token
-                    // await fetch('/api/timestamp-reports', {
-                    //     method: 'POST',
-                    //     headers: {
-                    //         'Content-Type': 'application/json',
-                    //         'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-                    //     },
-                    //     body: JSON.stringify(reportData),
-                    // });
+                        const data = await response.json();
 
-                    toast.success('報告を受け付けました。（現在は暫定実装のため、コンソールに出力されています）');
-                    this.showReportModal = false;
+                        if (response.ok) {
+                            toast.success(data.message || '報告を受け付けました。ご協力ありがとうございます。');
+                            this.showReportModal = false;
+                        } else if (response.status === 429) {
+                            toast.error(data.message || '報告の送信制限中です。しばらくしてから再度お試しください。');
+                        } else {
+                            toast.error(data.message || '報告の送信に失敗しました。');
+                        }
+                    } catch (error) {
+                        console.error('報告の送信に失敗しました:', error);
+                        toast.error('報告の送信に失敗しました。時間をおいて再度お試しください。');
+                    }
                 },
 
                 // 配信リンクパネル関連メソッド

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\ManageController;
 use App\Http\Controllers\MarkdownController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\SongController;
+use App\Http\Controllers\TimestampReportController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -56,6 +57,11 @@ Route::middleware(['auth'])->group(function () {
     Route::get('api/songs/search-spotify', [SongController::class, 'searchSpotify'])->name('songs.searchSpotify');
     // Parameterized route - must be last to avoid capturing specific route names
     Route::delete('api/songs/{id}', [SongController::class, 'deleteSong'])->name('songs.deleteSong');
+
+    // タイムスタンプ報告管理API
+    Route::get('api/manage/timestamp-reports', [TimestampReportController::class, 'index'])->name('timestamp-reports.index');
+    Route::get('api/manage/timestamp-reports/{report}', [TimestampReportController::class, 'show'])->name('timestamp-reports.show');
+    Route::patch('api/manage/timestamp-reports/{report}/resolve', [TimestampReportController::class, 'resolve'])->name('timestamp-reports.resolve');
 });
 
 Route::middleware('auth')->group(function () {
@@ -76,5 +82,8 @@ Route::get('api/channels/{id}/timestamps/download', [ChannelController::class, '
     ->middleware('throttle:10,1'); // 1分間に10回まで
 
 Route::get('/terms', [MarkdownController::class, 'show'])->name('markdown.show');
+
+// タイムスタンプ報告API（ゲスト可）
+Route::post('api/timestamp-reports', [TimestampReportController::class, 'store'])->name('timestamp-reports.store');
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/TimestampReportTest.php
+++ b/tests/Feature/TimestampReportTest.php
@@ -1,0 +1,463 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Archive;
+use App\Models\Channel;
+use App\Models\TimestampReport;
+use App\Models\TsItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class TimestampReportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Channel $channel;
+
+    private Archive $archive;
+
+    private TsItem $tsItem;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // テスト用のユーザーを作成
+        $this->user = User::factory()->create();
+
+        // テスト用のチャンネルとアーカイブを作成
+        $this->channel = Channel::create([
+            'handle' => 'test-channel',
+            'channel_id' => 'UC123456789',
+            'title' => 'Test Channel',
+            'thumbnail' => 'https://example.com/thumb.jpg',
+            'user_id' => $this->user->id,
+        ]);
+
+        $this->archive = Archive::create([
+            'id' => 'video123',
+            'channel_id' => 'UC123456789',
+            'video_id' => 'video123',
+            'title' => 'Test Archive',
+            'thumbnail' => 'https://example.com/video.jpg',
+            'is_public' => true,
+            'is_display' => true,
+            'published_at' => now(),
+            'comments_updated_at' => now(),
+        ]);
+
+        // テスト用のタイムスタンプを作成
+        $this->tsItem = TsItem::create([
+            'id' => Str::ulid(),
+            'video_id' => 'video123',
+            'type' => '1',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
+            'text' => 'Test Song',
+            'is_display' => true,
+        ]);
+    }
+
+    /**
+     * ゲストユーザーが報告を作成できることをテスト
+     */
+    public function test_guest_can_create_report(): void
+    {
+        RateLimiter::clear('timestamp-report:127.0.0.1');
+
+        $response = $this->postJson('/api/timestamp-reports', [
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'comment' => 'テストコメント',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => '報告を受け付けました。ご協力ありがとうございます。',
+            ])
+            ->assertJsonStructure(['report_id']);
+
+        $this->assertDatabaseHas('timestamp_reports', [
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'comment' => 'テストコメント',
+            'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * コメントなしで報告を作成できることをテスト
+     */
+    public function test_can_create_report_without_comment(): void
+    {
+        RateLimiter::clear('timestamp-report:127.0.0.1');
+
+        $response = $this->postJson('/api/timestamp-reports', [
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'not_song',
+        ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('timestamp_reports', [
+            'ts_item_id' => $this->tsItem->id,
+            'report_type' => 'not_song',
+            'comment' => null,
+        ]);
+    }
+
+    /**
+     * 必須フィールドがない場合バリデーションエラーになることをテスト
+     */
+    public function test_validation_fails_without_required_fields(): void
+    {
+        RateLimiter::clear('timestamp-report:127.0.0.1');
+
+        $response = $this->postJson('/api/timestamp-reports', []);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['ts_item_id', 'video_id', 'report_type']);
+    }
+
+    /**
+     * 存在しないts_item_idでバリデーションエラーになることをテスト
+     */
+    public function test_validation_fails_with_invalid_ts_item_id(): void
+    {
+        RateLimiter::clear('timestamp-report:127.0.0.1');
+
+        $response = $this->postJson('/api/timestamp-reports', [
+            'ts_item_id' => 'nonexistent_id',
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['ts_item_id']);
+    }
+
+    /**
+     * レートリミットが適用されることをテスト
+     */
+    public function test_rate_limiting_is_applied(): void
+    {
+        RateLimiter::clear('timestamp-report:127.0.0.1');
+
+        // 5回の報告を送信（制限内）
+        for ($i = 0; $i < 5; $i++) {
+            $response = $this->postJson('/api/timestamp-reports', [
+                'ts_item_id' => $this->tsItem->id,
+                'video_id' => 'video123',
+                'report_type' => 'wrong_song',
+            ]);
+            $response->assertStatus(201);
+        }
+
+        // 6回目の報告はレートリミットエラー
+        $response = $this->postJson('/api/timestamp-reports', [
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+        ]);
+
+        $response->assertStatus(429)
+            ->assertJsonStructure(['message']);
+    }
+
+    /**
+     * 管理者が報告一覧を取得できることをテスト
+     */
+    public function test_authenticated_user_can_view_reports_list(): void
+    {
+        // 報告を作成
+        TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'comment' => 'テスト',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/manage/timestamp-reports');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'ts_item_id',
+                        'video_id',
+                        'report_type',
+                        'comment',
+                        'status',
+                        'created_at',
+                    ],
+                ],
+                'current_page',
+                'last_page',
+                'total',
+            ]);
+    }
+
+    /**
+     * 未認証ユーザーは報告一覧を取得できないことをテスト
+     */
+    public function test_guest_cannot_view_reports_list(): void
+    {
+        $response = $this->getJson('/api/manage/timestamp-reports');
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * ステータスでフィルタリングできることをテスト
+     */
+    public function test_can_filter_reports_by_status(): void
+    {
+        // pending報告を作成
+        TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'status' => 'pending',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        // resolved報告を作成
+        TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'not_song',
+            'status' => 'resolved',
+            'resolved_at' => now(),
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        // pendingでフィルター
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/manage/timestamp-reports?status=pending');
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $response->json('total'));
+        $this->assertEquals('pending', $response->json('data.0.status'));
+    }
+
+    /**
+     * 報告を解決済みにできることをテスト
+     */
+    public function test_can_resolve_report(): void
+    {
+        $report = TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->patchJson("/api/manage/timestamp-reports/{$report->id}/resolve");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => '報告を解決済みにしました。',
+            ]);
+
+        $this->assertDatabaseHas('timestamp_reports', [
+            'id' => $report->id,
+            'status' => 'resolved',
+        ]);
+
+        $report->refresh();
+        $this->assertNotNull($report->resolved_at);
+    }
+
+    /**
+     * 未認証ユーザーは報告を解決できないことをテスト
+     */
+    public function test_guest_cannot_resolve_report(): void
+    {
+        $report = TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        $response = $this->patchJson("/api/manage/timestamp-reports/{$report->id}/resolve");
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * 報告の詳細を取得できることをテスト
+     */
+    public function test_can_view_report_detail(): void
+    {
+        $report = TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'comment' => 'テストコメント',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson("/api/manage/timestamp-reports/{$report->id}");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'id' => $report->id,
+                'ts_item_id' => $this->tsItem->id,
+                'report_type' => 'wrong_song',
+                'comment' => 'テストコメント',
+            ]);
+    }
+
+    /**
+     * 未認証ユーザーは報告の詳細を取得できないことをテスト
+     */
+    public function test_guest_cannot_view_report_detail(): void
+    {
+        $report = TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        $response = $this->getJson("/api/manage/timestamp-reports/{$report->id}");
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * IPアドレスが記録されることをテスト
+     */
+    public function test_reporter_ip_is_recorded(): void
+    {
+        RateLimiter::clear('timestamp-report:192.168.1.1');
+
+        $response = $this->withServerVariables(['REMOTE_ADDR' => '192.168.1.1'])
+            ->postJson('/api/timestamp-reports', [
+                'ts_item_id' => $this->tsItem->id,
+                'video_id' => 'video123',
+                'report_type' => 'wrong_song',
+            ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('timestamp_reports', [
+            'ts_item_id' => $this->tsItem->id,
+            'reporter_ip' => '192.168.1.1',
+        ]);
+    }
+
+    /**
+     * コメントが1000文字を超えるとバリデーションエラーになることをテスト
+     */
+    public function test_validation_fails_with_too_long_comment(): void
+    {
+        RateLimiter::clear('timestamp-report:127.0.0.1');
+
+        $longComment = str_repeat('あ', 1001);
+
+        $response = $this->postJson('/api/timestamp-reports', [
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'comment' => $longComment,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['comment']);
+    }
+
+    /**
+     * TsItemが削除されると関連する報告も削除されることをテスト
+     */
+    public function test_reports_are_deleted_when_ts_item_is_deleted(): void
+    {
+        $report = TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        $reportId = $report->id;
+
+        // TsItemを削除
+        $this->tsItem->delete();
+
+        // 報告も削除されていることを確認
+        $this->assertDatabaseMissing('timestamp_reports', [
+            'id' => $reportId,
+        ]);
+    }
+
+    /**
+     * pendingスコープが正しく動作することをテスト
+     */
+    public function test_pending_scope_works(): void
+    {
+        TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'status' => 'pending',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'not_song',
+            'status' => 'resolved',
+            'resolved_at' => now(),
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        $pendingReports = TimestampReport::pending()->get();
+
+        $this->assertCount(1, $pendingReports);
+        $this->assertEquals('pending', $pendingReports->first()->status);
+    }
+
+    /**
+     * resolvedスコープが正しく動作することをテスト
+     */
+    public function test_resolved_scope_works(): void
+    {
+        TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'wrong_song',
+            'status' => 'pending',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        TimestampReport::create([
+            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'report_type' => 'not_song',
+            'status' => 'resolved',
+            'resolved_at' => now(),
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        $resolvedReports = TimestampReport::resolved()->get();
+
+        $this->assertCount(1, $resolvedReports);
+        $this->assertEquals('resolved', $resolvedReports->first()->status);
+    }
+}


### PR DESCRIPTION
## Summary
- タイムスタンプ報告機能のバックエンド実装（Issue #244）
- `timestamp_reports`テーブルのマイグレーション作成
- `TimestampReport`モデル作成（ULID、スコープ、リレーション付き）
- `TimestampReportController`作成（レートリミット対応：1分間に5回まで）
- APIルート追加（ゲスト用POST、管理者用GET/PATCH）
- フロントエンドの`submitReport()`をAPI呼び出しに変更
- テスト17件追加（全173件パス）

## 実装内容

### データベース
- `timestamp_reports`テーブル
  - ULID主キー
  - ts_item_id（外部キー、CASCADE削除）
  - video_id
  - report_type（wrong_song, not_song, not_timestamp, problem, other）
  - comment（任意、最大1000文字）
  - status（pending/resolved）
  - reporter_ip（スパム対策）
  - resolved_at

### API エンドポイント
- `POST /api/timestamp-reports` - 報告作成（ゲスト可、レートリミット付き）
- `GET /api/manage/timestamp-reports` - 報告一覧（認証必須）
- `GET /api/manage/timestamp-reports/{id}` - 報告詳細（認証必須）
- `PATCH /api/manage/timestamp-reports/{id}/resolve` - 報告解決（認証必須）

## Test plan
- [x] ゲストユーザーが報告を作成できる
- [x] コメントなしでも報告できる
- [x] バリデーションエラーが適切に返される
- [x] レートリミット（1分間5回）が機能する
- [x] 管理者が報告一覧・詳細を閲覧できる
- [x] 管理者が報告を解決済みにできる
- [x] ゲストは管理APIにアクセスできない
- [x] IPアドレスが記録される
- [x] TsItem削除時に関連報告も削除される

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)