### PR TITLE
refactor: タイムスタンプタブのUI改善とコード整理

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -146,13 +146,11 @@ class ChannelController extends Controller
             'per_page' => 'integer|min:1|max:100',
             'page' => 'integer|min:1',
             'search' => 'string|max:255',
-            'sort' => 'string|in:time_desc,time_asc,song_asc,archive_desc',
         ]);
 
         $perPage = $validated['per_page'] ?? 50;
         $currentPage = $validated['page'] ?? 1;
         $search = $validated['search'] ?? '';
-        $sort = $validated['sort'] ?? 'song_asc';
 
         // タイムスタンプ取得（チャンネルフィルタ付き）
         $query = $this->buildTimestampQuery($channel, withArchive: true);
@@ -256,55 +254,38 @@ class ChannelController extends Controller
             return ! ($ts['mapping'] && $ts['mapping']['is_not_song']);
         })->values();
 
-        // ソート処理
-        switch ($sort) {
-            case 'time_asc':
-                $timestampsWithMapping = $timestampsWithMapping->sortBy('ts_num');
-                break;
-            case 'time_desc':
-                $timestampsWithMapping = $timestampsWithMapping->sortByDesc('ts_num');
-                break;
-            case 'song_asc':
-                $timestampsWithMapping = $timestampsWithMapping->sort(function ($a, $b) {
-                    // 楽曲紐づけ済みは楽曲名、未紐づけはテキストでソート
-                    $aTitle = $a['mapping']['song']['title'] ?? $a['text'] ?? '';
-                    $bTitle = $b['mapping']['song']['title'] ?? $b['text'] ?? '';
+        // ソート処理（楽曲名順）
+        $timestampsWithMapping = $timestampsWithMapping->sort(function ($a, $b) {
+            // 楽曲紐づけ済みは楽曲名、未紐づけはテキストでソート
+            $aTitle = $a['mapping']['song']['title'] ?? $a['text'] ?? '';
+            $bTitle = $b['mapping']['song']['title'] ?? $b['text'] ?? '';
 
-                    return strcasecmp($aTitle, $bTitle);
-                });
-                break;
-            case 'archive_desc':
-                $timestampsWithMapping = $timestampsWithMapping->sortByDesc(function ($ts) {
-                    return $ts['archive']['published_at'];
-                });
-                break;
-        }
+            return strcasecmp($aTitle, $bTitle);
+        });
 
         $timestampsWithMapping = $timestampsWithMapping->values();
 
-        // 頭文字インデックスマップを生成（楽曲名ソート時のみ）
+        // 頭文字インデックスマップを生成
         $indexMap = [];
         $availableIndexes = [];
-        if ($sort === 'song_asc') {
-            foreach ($timestampsWithMapping as $index => $ts) {
-                $title = $ts['mapping']['song']['title'] ?? $ts['text'] ?? '';
-                if (empty($title)) {
-                    continue;
-                }
+        foreach ($timestampsWithMapping as $index => $ts) {
+            $title = $ts['mapping']['song']['title'] ?? $ts['text'] ?? '';
+            if (empty($title)) {
+                continue;
+            }
 
-                // 頭文字を取得
-                $firstChar = mb_substr($title, 0, 1, 'UTF-8');
-                $firstChar = mb_strtoupper($firstChar, 'UTF-8');
+            // 頭文字を取得
+            $firstChar = mb_substr($title, 0, 1, 'UTF-8');
+            $firstChar = mb_strtoupper($firstChar, 'UTF-8');
 
-                // カテゴリ分け
-                $category = $this->categorizeFirstChar($firstChar);
+            // カテゴリ分け
+            $category = $this->categorizeFirstChar($firstChar);
 
-                // まだ記録されていないカテゴリの場合、ページ番号を記録
-                if (! isset($indexMap[$category])) {
-                    $pageNum = (int) floor($index / $perPage) + 1;
-                    $indexMap[$category] = $pageNum;
-                    $availableIndexes[] = $category;
-                }
+            // まだ記録されていないカテゴリの場合、ページ番号を記録
+            if (! isset($indexMap[$category])) {
+                $pageNum = (int) floor($index / $perPage) + 1;
+                $indexMap[$category] = $pageNum;
+                $availableIndexes[] = $category;
             }
         }
 

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -44,12 +44,6 @@ function registerArchiveListComponent() {
                 showDistributionPanel: false,
                 panelDismissed: false,
 
-                // YouTube埋め込みの状態管理
-                showYoutubePlayer: false,
-                autoplayEnabled: false,
-                currentVideoId: null,
-                currentTsNum: null,
-
                 // computed property
                 get maxPage() {
                     if (!this.archives.total || !this.archives.per_page) return 1;
@@ -298,10 +292,6 @@ function registerArchiveListComponent() {
                     // 配信リンクパネルの設定を読み込み
                     const dismissed = localStorage.getItem('distributionPanelDismissed');
                     this.panelDismissed = dismissed === 'true';
-
-                    // 自動再生設定を読み込み
-                    const autoplay = localStorage.getItem('youtubeAutoplayEnabled');
-                    this.autoplayEnabled = autoplay === 'true';
                 },
 
                 // 報告モーダルを開く
@@ -383,10 +373,6 @@ function registerArchiveListComponent() {
                     if (!this.panelDismissed) {
                         this.showDistributionPanel = true;
                     }
-                    // 自動再生が有効な場合はYouTubeプレーヤーを開く
-                    if (this.autoplayEnabled && timestamp) {
-                        this.playYoutube(timestamp.video_id, timestamp.ts_num);
-                    }
                 },
 
                 // テキストから検索用の疑似songオブジェクトを作成して選択
@@ -404,37 +390,6 @@ function registerArchiveListComponent() {
                     if (!this.panelDismissed) {
                         this.showDistributionPanel = true;
                     }
-                    // 自動再生が有効な場合はYouTubeプレーヤーを開く
-                    if (this.autoplayEnabled && timestamp) {
-                        this.playYoutube(timestamp.video_id, timestamp.ts_num);
-                    }
-                },
-
-                // YouTube埋め込みプレーヤーを開く
-                playYoutube(videoId, tsNum = 0) {
-                    this.currentVideoId = videoId;
-                    this.currentTsNum = tsNum;
-                    this.showYoutubePlayer = true;
-                },
-
-                // YouTube埋め込みプレーヤーを閉じる
-                closeYoutubePlayer() {
-                    this.showYoutubePlayer = false;
-                    this.currentVideoId = null;
-                    this.currentTsNum = null;
-                },
-
-                // 自動再生設定を切り替え
-                toggleAutoplay() {
-                    this.autoplayEnabled = !this.autoplayEnabled;
-                    localStorage.setItem('youtubeAutoplayEnabled', this.autoplayEnabled ? 'true' : 'false');
-                },
-
-                // YouTube埋め込みURLを生成
-                getYoutubeEmbedUrl(videoId, tsNum = 0) {
-                    const safeVideoId = encodeURIComponent(videoId || '');
-                    const safeTsNum = parseInt(tsNum) || 0;
-                    return `https://www.youtube.com/embed/${safeVideoId}?start=${safeTsNum}&autoplay=1`;
                 },
 
                 closePanel() {

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -28,7 +28,6 @@ function registerArchiveListComponent() {
                 tsFlg: '',
                 searchTimeout: null,
                 currentTimestampPage: 1,
-                timestampSort: 'song_asc',
                 loading: false,
                 error: null,
                 isFiltered: false,
@@ -44,6 +43,12 @@ function registerArchiveListComponent() {
                 selectedTimestamp: null,
                 showDistributionPanel: false,
                 panelDismissed: false,
+
+                // YouTube埋め込みの状態管理
+                showYoutubePlayer: false,
+                autoplayEnabled: false,
+                currentVideoId: null,
+                currentTsNum: null,
 
                 // computed property
                 get maxPage() {
@@ -109,8 +114,7 @@ function registerArchiveListComponent() {
 
                         const params = new URLSearchParams({
                             page: page,
-                            per_page: 50,
-                            sort: this.timestampSort
+                            per_page: 50
                         });
 
                         if (search) {
@@ -201,10 +205,6 @@ function registerArchiveListComponent() {
                             params.set('search', this.searchQuery);
                         }
 
-                        if (this.timestampSort && this.timestampSort !== 'song_asc') {
-                            params.set('sort', this.timestampSort);
-                        }
-
                         if (this.currentTimestampPage && this.currentTimestampPage > 1) {
                             params.set('page', this.currentTimestampPage);
                         }
@@ -241,7 +241,6 @@ function registerArchiveListComponent() {
                 restoreStateFromURL(params) {
                     const view = params.get('view');
                     const search = params.get('search');
-                    const sort = params.get('sort');
                     // ページパラメータのバリデーション: 1以上の整数に制限
                     const page = Math.max(1, parseInt(params.get('page')) || 1);
 
@@ -261,7 +260,6 @@ function registerArchiveListComponent() {
                         // タイムスタンプタブの状態を復元（デフォルト）
                         this.activeTab = 'timestamps';
                         this.searchQuery = search || '';
-                        this.timestampSort = sort || 'song_asc';
                         this.currentTimestampPage = page;
                         this.fetchTimestamps(page, this.searchQuery);
                     }
@@ -300,6 +298,10 @@ function registerArchiveListComponent() {
                     // 配信リンクパネルの設定を読み込み
                     const dismissed = localStorage.getItem('distributionPanelDismissed');
                     this.panelDismissed = dismissed === 'true';
+
+                    // 自動再生設定を読み込み
+                    const autoplay = localStorage.getItem('youtubeAutoplayEnabled');
+                    this.autoplayEnabled = autoplay === 'true';
                 },
 
                 // 報告モーダルを開く
@@ -381,6 +383,10 @@ function registerArchiveListComponent() {
                     if (!this.panelDismissed) {
                         this.showDistributionPanel = true;
                     }
+                    // 自動再生が有効な場合はYouTubeプレーヤーを開く
+                    if (this.autoplayEnabled && timestamp) {
+                        this.playYoutube(timestamp.video_id, timestamp.ts_num);
+                    }
                 },
 
                 // テキストから検索用の疑似songオブジェクトを作成して選択
@@ -398,6 +404,37 @@ function registerArchiveListComponent() {
                     if (!this.panelDismissed) {
                         this.showDistributionPanel = true;
                     }
+                    // 自動再生が有効な場合はYouTubeプレーヤーを開く
+                    if (this.autoplayEnabled && timestamp) {
+                        this.playYoutube(timestamp.video_id, timestamp.ts_num);
+                    }
+                },
+
+                // YouTube埋め込みプレーヤーを開く
+                playYoutube(videoId, tsNum = 0) {
+                    this.currentVideoId = videoId;
+                    this.currentTsNum = tsNum;
+                    this.showYoutubePlayer = true;
+                },
+
+                // YouTube埋め込みプレーヤーを閉じる
+                closeYoutubePlayer() {
+                    this.showYoutubePlayer = false;
+                    this.currentVideoId = null;
+                    this.currentTsNum = null;
+                },
+
+                // 自動再生設定を切り替え
+                toggleAutoplay() {
+                    this.autoplayEnabled = !this.autoplayEnabled;
+                    localStorage.setItem('youtubeAutoplayEnabled', this.autoplayEnabled ? 'true' : 'false');
+                },
+
+                // YouTube埋め込みURLを生成
+                getYoutubeEmbedUrl(videoId, tsNum = 0) {
+                    const safeVideoId = encodeURIComponent(videoId || '');
+                    const safeTsNum = parseInt(tsNum) || 0;
+                    return `https://www.youtube.com/embed/${safeVideoId}?start=${safeTsNum}&autoplay=1`;
                 },
 
                 closePanel() {

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -501,18 +501,10 @@
              x-transition:leave-end="transform translate-y-full"
              class="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t-2 border-gray-300 dark:border-gray-600 shadow-lg z-50 px-4 py-3">
             <div class="max-w-7xl mx-auto">
-                <!-- ヘッダー: 楽曲タイトル / 自動再生チェック / 閉じる -->
+                <!-- ヘッダー: 楽曲タイトル / 閉じる -->
                 <div class="flex items-center justify-between mb-2 gap-2">
                     <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate flex-1"
                          x-text="selectedSong ? `${selectedSong.title}${selectedSong.artist ? ' / ' + selectedSong.artist : ''}` : ''"></div>
-                    <!-- 自動再生チェックボックス -->
-                    <label class="hidden sm:flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-pointer select-none whitespace-nowrap">
-                        <input type="checkbox"
-                               x-model="autoplayEnabled"
-                               @change="toggleAutoplay()"
-                               class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-red-600 focus:ring-red-500">
-                        <span>自動再生</span>
-                    </label>
                     <button @click="closePanel()"
                             class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 p-1 flex-shrink-0"
                             aria-label="閉じる">
@@ -522,38 +514,10 @@
                     </button>
                 </div>
 
-                <!-- YouTube埋め込みプレーヤー -->
-                <div x-show="showYoutubePlayer && currentVideoId" class="mb-3">
-                    <div class="relative w-full" style="padding-bottom: 56.25%; max-height: 240px;">
-                        <iframe
-                            x-show="showYoutubePlayer && currentVideoId"
-                            :src="showYoutubePlayer && currentVideoId ? getYoutubeEmbedUrl(currentVideoId, currentTsNum) : ''"
-                            class="absolute top-0 left-0 w-full h-full max-h-[240px] rounded-lg"
-                            frameborder="0"
-                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                            allowfullscreen>
-                        </iframe>
-                    </div>
-                    <button @click="closeYoutubePlayer()"
-                            class="mt-2 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
-                        プレーヤーを閉じる
-                    </button>
-                </div>
-
-                <!-- コンテンツ: 配信サービス / YouTube再生ボタン / 報告 -->
+                <!-- コンテンツ: 配信サービス / 報告 -->
                 <div class="flex flex-wrap gap-3 items-start">
                     <!-- 配信サービスボタン群 -->
                     <div class="flex flex-wrap gap-2 flex-1">
-                        <!-- YouTube再生ボタン（自動再生OFF時、タイムスタンプ選択時のみ） -->
-                        <template x-if="selectedTimestamp && !autoplayEnabled">
-                            <button @click="playYoutube(selectedTimestamp.video_id, selectedTimestamp.ts_num)"
-                                    class="inline-flex items-center gap-1.5 px-3 py-2 bg-red-600 hover:bg-red-700 text-white text-sm rounded-md transition-colors">
-                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                                    <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
-                                </svg>
-                                <span>ここで再生</span>
-                            </button>
-                        </template>
                         <!-- Spotify -->
                         <a :href="getSpotifyUrl(selectedSong)"
                            target="_blank"

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -240,6 +240,17 @@
                 <div x-show="timestamps.available_indexes && timestamps.available_indexes.length > 0" class="mb-4 hidden sm:block">
                     <div class="flex flex-wrap items-center gap-1">
                         <span class="text-xs text-gray-500 dark:text-gray-400 mr-1">頭文字:</span>
+                        <!-- 数字 -->
+                        <button
+                            @click="jumpToIndex('0-9')"
+                            :disabled="!timestamps.available_indexes?.includes('0-9')"
+                            :class="timestamps.available_indexes?.includes('0-9')
+                                ? 'bg-purple-500 hover:bg-purple-600 text-white cursor-pointer'
+                                : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
+                            class="px-2 h-7 text-xs rounded transition-colors">
+                            0-9
+                        </button>
+                        <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>
                         <!-- アルファベット（A, F, K, P, U） -->
                         <template x-for="letter in ['A','F','K','P','U']" :key="letter">
                             <button
@@ -266,16 +277,7 @@
                             </button>
                         </template>
                         <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>
-                        <!-- 数字・その他 -->
-                        <button
-                            @click="jumpToIndex('0-9')"
-                            :disabled="!timestamps.available_indexes?.includes('0-9')"
-                            :class="timestamps.available_indexes?.includes('0-9')
-                                ? 'bg-purple-500 hover:bg-purple-600 text-white cursor-pointer'
-                                : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
-                            class="px-2 h-7 text-xs rounded transition-colors">
-                            0-9
-                        </button>
+                        <!-- 漢字・その他 -->
                         <button
                             @click="jumpToIndex('その他')"
                             :disabled="!timestamps.available_indexes?.includes('その他')"
@@ -283,7 +285,7 @@
                                 ? 'bg-gray-500 hover:bg-gray-600 text-white cursor-pointer'
                                 : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
                             class="px-2 h-7 text-xs rounded transition-colors">
-                            他
+                            漢字
                         </button>
                     </div>
                 </div>

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -110,12 +110,27 @@
                         </button>
                     </template>
                     <template x-if="activeTab === 'timestamps'">
-                        <button
-                            type="button"
-                            @click="searchQuery = ''"
-                            class="bg-gray-500 text-white px-6 py-2 rounded hover:bg-gray-600 whitespace-nowrap">
-                            クリア
-                        </button>
+                        <div class="flex items-center gap-2">
+                            <button
+                                type="button"
+                                @click="searchQuery = ''"
+                                class="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600 whitespace-nowrap">
+                                クリア
+                            </button>
+                            <!-- 件数表示 -->
+                            <span class="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap"
+                                  x-text="timestamps.total !== undefined ? `${timestamps.total}件` : ''"></span>
+                            <!-- ダウンロードボタン -->
+                            <button
+                                type="button"
+                                @click="downloadTimestamps()"
+                                :disabled="loading || !timestamps.total"
+                                :class="loading || !timestamps.total ? 'opacity-50 cursor-not-allowed' : ''"
+                                class="hidden sm:flex bg-green-600 text-white px-3 py-2 rounded hover:bg-green-700 items-center gap-1 whitespace-nowrap text-sm"
+                                title="全タイムスタンプをテキストファイルとしてダウンロード">
+                                📥
+                            </button>
+                        </div>
                     </template>
                 </form>
             </div>
@@ -192,23 +207,6 @@
 
             <!-- タイムスタンプタブ -->
             <div x-show="activeTab === 'timestamps'">
-                <!-- 検索結果とダウンロードボタン -->
-                <div class="mb-4 flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
-                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                        <span x-show="searchQuery">検索結果: </span>
-                        <span x-text="timestamps.total !== undefined ? `${timestamps.total}件` : ''"></span>
-                    </div>
-                    <button
-                        type="button"
-                        @click="downloadTimestamps()"
-                        :disabled="loading || !timestamps.total"
-                        :class="loading || !timestamps.total ? 'opacity-50 cursor-not-allowed' : ''"
-                        class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 hidden sm:flex items-center gap-1 whitespace-nowrap text-sm"
-                        title="全タイムスタンプをテキストファイルとしてダウンロード">
-                        📥 ダウンロード
-                    </button>
-                </div>
-
                 <!-- ページネーション（上） -->
                 <div class="flex justify-center gap-2 mb-4">
                     <button @click="fetchTimestamps(1, searchQuery)"
@@ -238,27 +236,24 @@
                     </button>
                 </div>
 
-                <!-- 頭文字ジャンプナビゲーション（楽曲名ソート時のみ表示） -->
-                <div x-show="timestampSort === 'song_asc' && timestamps.available_indexes && timestamps.available_indexes.length > 0" class="mb-4 border-b border-gray-200 dark:border-gray-700 pb-4 hidden sm:block">
-                    <div class="text-xs text-gray-600 dark:text-gray-400 mb-2">頭文字でジャンプ:</div>
-
-                    <!-- アルファベット -->
-                    <div class="flex flex-wrap gap-1 mb-2">
-                        <template x-for="letter in ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z']" :key="letter">
+                <!-- 頭文字ジャンプナビゲーション -->
+                <div x-show="timestamps.available_indexes && timestamps.available_indexes.length > 0" class="mb-4 hidden sm:block">
+                    <div class="flex flex-wrap items-center gap-1">
+                        <span class="text-xs text-gray-500 dark:text-gray-400 mr-1">頭文字:</span>
+                        <!-- アルファベット（A, F, K, P, U） -->
+                        <template x-for="letter in ['A','F','K','P','U']" :key="letter">
                             <button
                                 @click="jumpToIndex(letter)"
                                 :disabled="!timestamps.available_indexes?.includes(letter)"
                                 :class="timestamps.available_indexes?.includes(letter)
                                     ? 'bg-blue-500 hover:bg-blue-600 text-white cursor-pointer'
                                     : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
-                                class="w-8 h-8 text-xs rounded transition-colors">
+                                class="w-7 h-7 text-xs rounded transition-colors">
                                 <span x-text="letter"></span>
                             </button>
                         </template>
-                    </div>
-
-                    <!-- 五十音 -->
-                    <div class="flex flex-wrap gap-1 mb-2">
+                        <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>
+                        <!-- 五十音 -->
                         <template x-for="kana in ['あ','か','さ','た','な','は','ま','や','ら','わ']" :key="kana">
                             <button
                                 @click="jumpToIndex(kana)"
@@ -266,31 +261,29 @@
                                 :class="timestamps.available_indexes?.includes(kana)
                                     ? 'bg-green-500 hover:bg-green-600 text-white cursor-pointer'
                                     : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
-                                class="w-8 h-8 text-xs rounded transition-colors">
+                                class="w-7 h-7 text-xs rounded transition-colors">
                                 <span x-text="kana"></span>
                             </button>
                         </template>
-                    </div>
-
-                    <!-- その他 -->
-                    <div class="flex gap-1">
+                        <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>
+                        <!-- 数字・その他 -->
                         <button
                             @click="jumpToIndex('0-9')"
                             :disabled="!timestamps.available_indexes?.includes('0-9')"
                             :class="timestamps.available_indexes?.includes('0-9')
                                 ? 'bg-purple-500 hover:bg-purple-600 text-white cursor-pointer'
                                 : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
-                            class="px-3 py-1 text-xs rounded transition-colors">
+                            class="px-2 h-7 text-xs rounded transition-colors">
                             0-9
                         </button>
                         <button
                             @click="jumpToIndex('その他')"
                             :disabled="!timestamps.available_indexes?.includes('その他')"
                             :class="timestamps.available_indexes?.includes('その他')
-                                    ? 'bg-gray-500 hover:bg-gray-600 text-white cursor-pointer'
-                                    : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
-                            class="px-3 py-1 text-xs rounded transition-colors">
-                            その他
+                                ? 'bg-gray-500 hover:bg-gray-600 text-white cursor-pointer'
+                                : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
+                            class="px-2 h-7 text-xs rounded transition-colors">
+                            他
                         </button>
                     </div>
                 </div>
@@ -506,103 +499,129 @@
              x-transition:leave-end="transform translate-y-full"
              class="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t-2 border-gray-300 dark:border-gray-600 shadow-lg z-50 px-4 py-3">
             <div class="max-w-7xl mx-auto">
-                <!-- 楽曲タイトルと閉じるボタン -->
-                <div class="flex items-center justify-between mb-2">
-                    <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate"
-                         x-text="selectedSong ? `${selectedSong.title} / ${selectedSong.artist}` : ''"></div>
+                <!-- ヘッダー: 楽曲タイトル / 自動再生チェック / 閉じる -->
+                <div class="flex items-center justify-between mb-2 gap-2">
+                    <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate flex-1"
+                         x-text="selectedSong ? `${selectedSong.title}${selectedSong.artist ? ' / ' + selectedSong.artist : ''}` : ''"></div>
+                    <!-- 自動再生チェックボックス -->
+                    <label class="hidden sm:flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-400 cursor-pointer select-none whitespace-nowrap">
+                        <input type="checkbox"
+                               x-model="autoplayEnabled"
+                               @change="toggleAutoplay()"
+                               class="w-4 h-4 rounded border-gray-300 dark:border-gray-600 text-red-600 focus:ring-red-500">
+                        <span>自動再生</span>
+                    </label>
                     <button @click="closePanel()"
-                            class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 p-1"
+                            class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 p-1 flex-shrink-0"
                             aria-label="閉じる">
                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                         </svg>
                     </button>
                 </div>
-                <!-- 2列レイアウト -->
-                <div class="flex gap-4">
-                    <!-- 左列: 配信サービス -->
-                    <div class="flex-1">
-                        <div class="text-xs text-gray-600 dark:text-gray-400 mb-1">配信サービスで聴く:</div>
-                        <div class="flex flex-wrap gap-2">
-                    <!-- Spotify -->
-                    <a :href="getSpotifyUrl(selectedSong)"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="inline-flex items-center gap-1.5 px-3 py-2 bg-green-600 hover:bg-green-700 text-white text-sm rounded-md transition-colors">
-                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
-                        </svg>
-                        <span>Spotify</span>
-                    </a>
-                    <!-- Apple Music -->
-                    <a :href="getAppleMusicUrl(selectedSong)"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="inline-flex items-center gap-1.5 px-3 py-2 bg-pink-600 hover:bg-pink-700 text-white text-sm rounded-md transition-colors">
-                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M23.997 6.124c0-.738-.065-1.47-.24-2.19-.317-1.31-1.062-2.31-2.18-3.043C21.003.517 20.373.285 19.7.164c-.517-.093-1.038-.135-1.564-.15-.04-.003-.083-.01-.124-.013H5.986c-.152.01-.303.017-.455.026C4.786.07 4.043.15 3.34.428 2.004.958 1.04 1.88.475 3.208c-.192.448-.292.925-.363 1.408-.056.392-.088.785-.1 1.18 0 .032-.007.062-.01.093v12.223c.01.14.017.283.027.424.05.815.154 1.624.497 2.373.65 1.42 1.738 2.353 3.234 2.801.42.127.856.187 1.293.228.555.053 1.11.06 1.667.06h11.03c.525 0 1.048-.034 1.57-.1.823-.106 1.597-.35 2.296-.81a5.08 5.08 0 0 0 1.88-2.207c.186-.42.293-.87.37-1.324.113-.675.138-1.358.137-2.04-.002-3.8 0-7.595-.003-11.393zm-6.423 3.99v5.712c0 .417-.058.827-.244 1.206-.29.59-.76 1.035-1.388 1.29-.47.19-.96.27-1.46.27-.93 0-1.72-.407-2.22-1.24-.34-.565-.435-1.187-.39-1.822.09-1.232.85-2.011 2.07-2.067.582-.027 1.164-.017 1.745-.017.153 0 .306-.01.46-.016v-3.46c0-.08-.018-.097-.096-.086-.86.12-1.72.24-2.58.36-.86.12-1.72.24-2.58.36-.085.01-.106.04-.105.124.002 2.644 0 5.29 0 7.934 0 .4-.06.796-.24 1.167-.283.585-.756 1.026-1.38 1.278-.474.192-.965.273-1.47.273-.93 0-1.717-.408-2.216-1.242-.34-.566-.435-1.188-.39-1.823.09-1.232.85-2.01 2.07-2.066.582-.027 1.164-.018 1.745-.018.153 0 .306-.01.46-.016V7.21c0-.08.018-.097.096-.086 1.72.24 3.44.48 5.16.72.86.12 1.72.24 2.58.36.085.01.106-.04.105-.124-.002-.645 0-1.29 0-1.935z"/>
-                        </svg>
-                        <span>Apple Music</span>
-                    </a>
-                    <!-- YouTube Music -->
-                    <a :href="getYouTubeMusicUrl(selectedSong)"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="inline-flex items-center gap-1.5 px-3 py-2 bg-red-600 hover:bg-red-700 text-white text-sm rounded-md transition-colors">
-                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M12 0C5.376 0 0 5.376 0 12s5.376 12 12 12 12-5.376 12-12S18.624 0 12 0zm0 19.104c-3.924 0-7.104-3.18-7.104-7.104S8.076 4.896 12 4.896s7.104 3.18 7.104 7.104-3.18 7.104-7.104 7.104zm0-13.332c-3.432 0-6.228 2.796-6.228 6.228S8.568 18.228 12 18.228s6.228-2.796 6.228-6.228S15.432 5.772 12 5.772zM9.684 15.54V8.46L15.816 12l-6.132 3.54z"/>
-                        </svg>
-                        <span>YouTube Music</span>
-                    </a>
-                    <!-- Amazon Music -->
-                    <a :href="getAmazonMusicUrl(selectedSong)"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="inline-flex items-center gap-1.5 px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-md transition-colors">
-                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M13.55 17.526L10.2 15.3v-2.4l5.7 3.4v2.8l-2.35-1.574zM10.2 8.7v2.4l3.35 2.226 2.35-1.574v-2.8l-5.7 3.4V8.7zm8.4 7.674l-6.05 4.026v2.4l8.45-5.626v-2.8l-2.4 1.6zm-2.4-10.8L10.2 2.3v2.4l5.7 3.8 2.3-1.926V3.774L16.2 5.574z"/>
-                        </svg>
-                        <span>Amazon Music</span>
-                    </a>
-                    <!-- LINE MUSIC -->
-                    <a :href="getLineMusicUrl(selectedSong)"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="inline-flex items-center gap-1.5 px-3 py-2 bg-green-500 hover:bg-green-600 text-white text-sm rounded-md transition-colors">
-                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/>
-                        </svg>
-                        <span>LINE MUSIC</span>
-                    </a>
-                        </div>
+
+                <!-- YouTube埋め込みプレーヤー -->
+                <div x-show="showYoutubePlayer && currentVideoId" class="mb-3">
+                    <div class="relative w-full" style="padding-bottom: 56.25%; max-height: 240px;">
+                        <iframe
+                            x-show="showYoutubePlayer && currentVideoId"
+                            :src="showYoutubePlayer && currentVideoId ? getYoutubeEmbedUrl(currentVideoId, currentTsNum) : ''"
+                            class="absolute top-0 left-0 w-full h-full max-h-[240px] rounded-lg"
+                            frameborder="0"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            allowfullscreen>
+                        </iframe>
                     </div>
-                    <!-- 区切り線 -->
-                    <template x-if="selectedTimestamp">
-                        <div class="w-px bg-gray-300 dark:bg-gray-600 self-stretch"></div>
-                    </template>
-                    <!-- 右列: 報告 -->
+                    <button @click="closeYoutubePlayer()"
+                            class="mt-2 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">
+                        プレーヤーを閉じる
+                    </button>
+                </div>
+
+                <!-- コンテンツ: 配信サービス / YouTube再生ボタン / 報告 -->
+                <div class="flex flex-wrap gap-3 items-start">
+                    <!-- 配信サービスボタン群 -->
+                    <div class="flex flex-wrap gap-2 flex-1">
+                        <!-- YouTube再生ボタン（自動再生OFF時、タイムスタンプ選択時のみ） -->
+                        <template x-if="selectedTimestamp && !autoplayEnabled">
+                            <button @click="playYoutube(selectedTimestamp.video_id, selectedTimestamp.ts_num)"
+                                    class="inline-flex items-center gap-1.5 px-3 py-2 bg-red-600 hover:bg-red-700 text-white text-sm rounded-md transition-colors">
+                                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+                                </svg>
+                                <span>ここで再生</span>
+                            </button>
+                        </template>
+                        <!-- Spotify -->
+                        <a :href="getSpotifyUrl(selectedSong)"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="inline-flex items-center gap-1.5 px-3 py-2 bg-green-600 hover:bg-green-700 text-white text-sm rounded-md transition-colors">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
+                            </svg>
+                            <span class="hidden sm:inline">Spotify</span>
+                        </a>
+                        <!-- Apple Music -->
+                        <a :href="getAppleMusicUrl(selectedSong)"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="inline-flex items-center gap-1.5 px-3 py-2 bg-pink-600 hover:bg-pink-700 text-white text-sm rounded-md transition-colors">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M23.997 6.124c0-.738-.065-1.47-.24-2.19-.317-1.31-1.062-2.31-2.18-3.043C21.003.517 20.373.285 19.7.164c-.517-.093-1.038-.135-1.564-.15-.04-.003-.083-.01-.124-.013H5.986c-.152.01-.303.017-.455.026C4.786.07 4.043.15 3.34.428 2.004.958 1.04 1.88.475 3.208c-.192.448-.292.925-.363 1.408-.056.392-.088.785-.1 1.18 0 .032-.007.062-.01.093v12.223c.01.14.017.283.027.424.05.815.154 1.624.497 2.373.65 1.42 1.738 2.353 3.234 2.801.42.127.856.187 1.293.228.555.053 1.11.06 1.667.06h11.03c.525 0 1.048-.034 1.57-.1.823-.106 1.597-.35 2.296-.81a5.08 5.08 0 0 0 1.88-2.207c.186-.42.293-.87.37-1.324.113-.675.138-1.358.137-2.04-.002-3.8 0-7.595-.003-11.393zm-6.423 3.99v5.712c0 .417-.058.827-.244 1.206-.29.59-.76 1.035-1.388 1.29-.47.19-.96.27-1.46.27-.93 0-1.72-.407-2.22-1.24-.34-.565-.435-1.187-.39-1.822.09-1.232.85-2.011 2.07-2.067.582-.027 1.164-.017 1.745-.017.153 0 .306-.01.46-.016v-3.46c0-.08-.018-.097-.096-.086-.86.12-1.72.24-2.58.36-.86.12-1.72.24-2.58.36-.085.01-.106.04-.105.124.002 2.644 0 5.29 0 7.934 0 .4-.06.796-.24 1.167-.283.585-.756 1.026-1.38 1.278-.474.192-.965.273-1.47.273-.93 0-1.717-.408-2.216-1.242-.34-.566-.435-1.188-.39-1.823.09-1.232.85-2.01 2.07-2.066.582-.027 1.164-.018 1.745-.018.153 0 .306-.01.46-.016V7.21c0-.08.018-.097.096-.086 1.72.24 3.44.48 5.16.72.86.12 1.72.24 2.58.36.085.01.106-.04.105-.124-.002-.645 0-1.29 0-1.935z"/>
+                            </svg>
+                            <span class="hidden sm:inline">Apple</span>
+                        </a>
+                        <!-- YouTube Music -->
+                        <a :href="getYouTubeMusicUrl(selectedSong)"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="inline-flex items-center gap-1.5 px-3 py-2 bg-red-500 hover:bg-red-600 text-white text-sm rounded-md transition-colors">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M12 0C5.376 0 0 5.376 0 12s5.376 12 12 12 12-5.376 12-12S18.624 0 12 0zm0 19.104c-3.924 0-7.104-3.18-7.104-7.104S8.076 4.896 12 4.896s7.104 3.18 7.104 7.104-3.18 7.104-7.104 7.104zm0-13.332c-3.432 0-6.228 2.796-6.228 6.228S8.568 18.228 12 18.228s6.228-2.796 6.228-6.228S15.432 5.772 12 5.772zM9.684 15.54V8.46L15.816 12l-6.132 3.54z"/>
+                            </svg>
+                            <span class="hidden sm:inline">YT Music</span>
+                        </a>
+                        <!-- Amazon Music -->
+                        <a :href="getAmazonMusicUrl(selectedSong)"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="inline-flex items-center gap-1.5 px-3 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-md transition-colors">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M13.55 17.526L10.2 15.3v-2.4l5.7 3.4v2.8l-2.35-1.574zM10.2 8.7v2.4l3.35 2.226 2.35-1.574v-2.8l-5.7 3.4V8.7zm8.4 7.674l-6.05 4.026v2.4l8.45-5.626v-2.8l-2.4 1.6zm-2.4-10.8L10.2 2.3v2.4l5.7 3.8 2.3-1.926V3.774L16.2 5.574z"/>
+                            </svg>
+                            <span class="hidden sm:inline">Amazon</span>
+                        </a>
+                        <!-- LINE MUSIC -->
+                        <a :href="getLineMusicUrl(selectedSong)"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="inline-flex items-center gap-1.5 px-3 py-2 bg-green-500 hover:bg-green-600 text-white text-sm rounded-md transition-colors">
+                            <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                                <path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.63 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61v1.125h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/>
+                            </svg>
+                            <span class="hidden sm:inline">LINE</span>
+                        </a>
+                    </div>
+                    <!-- 報告ボタン（タイムスタンプ選択時のみ） -->
                     <template x-if="selectedTimestamp">
                         <div class="flex-shrink-0">
-                            <div class="text-xs text-gray-600 dark:text-gray-400 mb-1">このタイムスタンプに問題がある場合:</div>
-                            <!-- 報告済みの場合はメッセージを表示 -->
                             <template x-if="selectedTimestamp.has_pending_report">
-                                <div class="inline-flex items-center gap-1.5 px-3 py-2 bg-gray-300 dark:bg-gray-600 text-gray-600 dark:text-gray-300 text-sm rounded-md">
-                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <div class="inline-flex items-center gap-1 px-2 py-2 bg-gray-200 dark:bg-gray-700 text-gray-500 dark:text-gray-400 text-xs rounded-md">
+                                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
                                     </svg>
-                                    <span>報告済みです。対応をお待ちください</span>
+                                    <span class="hidden sm:inline">報告済み</span>
                                 </div>
                             </template>
-                            <!-- 未報告の場合は報告ボタンを表示 -->
                             <template x-if="!selectedTimestamp.has_pending_report">
                                 <button @click="openReportModal(selectedTimestamp)"
-                                        class="inline-flex items-center gap-1.5 px-3 py-2 bg-gray-500 hover:bg-gray-600 text-white text-sm rounded-md transition-colors"
-                                        title="このタイムスタンプを報告"
-                                        aria-label="このタイムスタンプを報告">
-                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        class="inline-flex items-center gap-1 px-2 py-2 bg-gray-400 hover:bg-gray-500 text-white text-xs rounded-md transition-colors"
+                                        title="このタイムスタンプを報告">
+                                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
                                     </svg>
-                                    <span>報告</span>
+                                    <span class="hidden sm:inline">報告</span>
                                 </button>
                             </template>
                         </div>

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -282,7 +282,7 @@
                             @click="jumpToIndex('その他')"
                             :disabled="!timestamps.available_indexes?.includes('その他')"
                             :class="timestamps.available_indexes?.includes('その他')
-                                ? 'bg-gray-500 hover:bg-gray-600 text-white cursor-pointer'
+                                ? 'bg-orange-500 hover:bg-orange-600 text-white cursor-pointer'
                                 : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
                             class="px-2 h-7 text-xs rounded transition-colors">
                             漢字

--- a/tests/Feature/ChannelArchiveTest.php
+++ b/tests/Feature/ChannelArchiveTest.php
@@ -279,40 +279,6 @@ class ChannelArchiveTest extends TestCase
     }
 
     /**
-     * タイムスタンプのソート機能が動作する（時間降順）
-     */
-    public function test_fetch_timestamps_sort_by_time_desc(): void
-    {
-        $channel = Channel::factory()->create();
-        $archive = Archive::factory()->create([
-            'channel_id' => $channel->channel_id,
-            'is_display' => 1,
-        ]);
-
-        TsItem::factory()->create([
-            'video_id' => $archive->video_id,
-            'ts_num' => 100,
-            'text' => 'Early timestamp',
-            'is_display' => 1,
-        ]);
-        TsItem::factory()->create([
-            'video_id' => $archive->video_id,
-            'ts_num' => 200,
-            'text' => 'Late timestamp',
-            'is_display' => 1,
-        ]);
-
-        $response = $this->getJson("/api/channels/{$channel->handle}/timestamps?sort=time_desc");
-
-        $response->assertStatus(200);
-
-        $data = $response->json('data');
-        $this->assertCount(2, $data);
-        $this->assertEquals(200, $data[0]['ts_num']);
-        $this->assertEquals(100, $data[1]['ts_num']);
-    }
-
-    /**
      * バリデーションエラー: per_pageが範囲外
      */
     public function test_fetch_timestamps_validation_per_page_out_of_range(): void
@@ -323,19 +289,6 @@ class ChannelArchiveTest extends TestCase
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['per_page']);
-    }
-
-    /**
-     * バリデーションエラー: sortが不正な値
-     */
-    public function test_fetch_timestamps_validation_invalid_sort(): void
-    {
-        $channel = Channel::factory()->create();
-
-        $response = $this->getJson("/api/channels/{$channel->handle}/timestamps?sort=invalid_sort");
-
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['sort']);
     }
 
     /**


### PR DESCRIPTION
## Summary
タイムスタンプタブのUI/UXを改善し、コードを整理しました。

## 変更内容

### UIの改善
- **検索バーの最適化**: ダウンロードボタンと件数表示を検索バー横に統合
- **頭文字ジャンプナビゲーション**: 
  - 常時表示に変更（1行にコンパクト化）
  - 順序を「数字 | アルファベット(A,F,K,P,U) | 五十音 | 漢字」に変更
  - 「その他」を「漢字」に変更し、オレンジ色で視認性向上
- **配信リンクパネル**: レイアウト最適化、モバイルでサービス名を非表示に

### コードの整理
- **ソート機能の削除**: 楽曲名ソート固定に統一
  - `ChannelController::fetchTimestamps`からソートパラメータ削除
  - `archive-list.js`からソート関連の状態管理削除
  - 関連するテストを削除

### その他
- YouTube埋め込み機能を削除（将来の再実装を考慮）

## 変更されたファイル

| ファイル | 変更内容 |
|----------|----------|
| `app/Http/Controllers/ChannelController.php` | ソート機能削除 |
| `resources/js/channels/archive-list.js` | ソート関連の状態管理削除 |
| `resources/views/channels/show.blade.php` | UI改善 |
| `tests/Feature/ChannelArchiveTest.php` | ソート関連テスト削除 |

## Test plan
- [x] 全192テストパス
- [x] ビルド成功
- [x] UIの視認性・使いやすさの向上

🤖 Generated with [Claude Code](https://claude.com/claude-code)