### PR TITLE
refactor: 頭文字ナビをページジャンプから絞り込み方式に変更

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -142,11 +142,15 @@ class ChannelController extends Controller
         $channel = Channel::where('handle', $id)->firstOrFail();
 
         // バリデーション
+        $allowedIndexes = array_merge(
+            range('A', 'Z'),
+            ['0-9', 'あ', 'か', 'さ', 'た', 'な', 'は', 'ま', 'や', 'ら', 'わ', 'その他']
+        );
         $validated = $request->validate([
             'per_page' => 'integer|min:1|max:100',
             'page' => 'integer|min:1',
             'search' => 'string|max:255',
-            'index' => 'string|max:10',
+            'index' => ['nullable', 'string', \Illuminate\Validation\Rule::in($allowedIndexes)],
         ]);
 
         $perPage = $validated['per_page'] ?? 50;
@@ -271,15 +275,9 @@ class ChannelController extends Controller
         $availableIndexes = [];
         foreach ($timestampsWithMapping as $ts) {
             $title = $ts['mapping']['song']['title'] ?? $ts['text'] ?? '';
-            if (empty($title)) {
-                continue;
-            }
+            $category = $this->getFirstCharCategory($title);
 
-            $firstChar = mb_substr($title, 0, 1, 'UTF-8');
-            $firstChar = mb_strtoupper($firstChar, 'UTF-8');
-            $category = $this->categorizeFirstChar($firstChar);
-
-            if (! in_array($category, $availableIndexes)) {
+            if ($category && ! in_array($category, $availableIndexes)) {
                 $availableIndexes[] = $category;
             }
         }
@@ -288,15 +286,8 @@ class ChannelController extends Controller
         if ($index) {
             $timestampsWithMapping = $timestampsWithMapping->filter(function ($ts) use ($index) {
                 $title = $ts['mapping']['song']['title'] ?? $ts['text'] ?? '';
-                if (empty($title)) {
-                    return false;
-                }
 
-                $firstChar = mb_substr($title, 0, 1, 'UTF-8');
-                $firstChar = mb_strtoupper($firstChar, 'UTF-8');
-                $category = $this->categorizeFirstChar($firstChar);
-
-                return $category === $index;
+                return $this->getFirstCharCategory($title) === $index;
             })->values();
         }
 
@@ -359,6 +350,21 @@ class ChannelController extends Controller
 
         // その他（記号など）
         return 'その他';
+    }
+
+    /**
+     * タイトルから頭文字カテゴリを取得
+     */
+    private function getFirstCharCategory(?string $title): ?string
+    {
+        if (empty($title)) {
+            return null;
+        }
+
+        $firstChar = mb_substr($title, 0, 1, 'UTF-8');
+        $firstChar = mb_strtoupper($firstChar, 'UTF-8');
+
+        return $this->categorizeFirstChar($firstChar);
     }
 
     /**

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -142,10 +142,10 @@ class ChannelController extends Controller
         $channel = Channel::where('handle', $id)->firstOrFail();
 
         // バリデーション
-        $allowedIndexes = array_merge(
-            range('A', 'Z'),
-            ['0-9', 'あ', 'か', 'さ', 'た', 'な', 'は', 'ま', 'や', 'ら', 'わ', 'その他']
-        );
+        $allowedIndexes = [
+            'A-E', 'F-J', 'K-O', 'P-T', 'U-Z',
+            '0-9', 'あ', 'か', 'さ', 'た', 'な', 'は', 'ま', 'や', 'ら', 'わ', 'その他',
+        ];
         $validated = $request->validate([
             'per_page' => 'integer|min:1|max:100',
             'page' => 'integer|min:1',
@@ -312,9 +312,22 @@ class ChannelController extends Controller
      */
     private function categorizeFirstChar($char)
     {
-        // アルファベット（A-Z）
-        if (preg_match('/^[A-Z]$/i', $char)) {
-            return strtoupper($char);
+        // アルファベット（A-E, F-J, K-O, P-T, U-Z）
+        $upperChar = strtoupper($char);
+        if (preg_match('/^[A-E]$/', $upperChar)) {
+            return 'A-E';
+        }
+        if (preg_match('/^[F-J]$/', $upperChar)) {
+            return 'F-J';
+        }
+        if (preg_match('/^[K-O]$/', $upperChar)) {
+            return 'K-O';
+        }
+        if (preg_match('/^[P-T]$/', $upperChar)) {
+            return 'P-T';
+        }
+        if (preg_match('/^[U-Z]$/', $upperChar)) {
+            return 'U-Z';
         }
 
         // ひらがな・カタカナ（五十音行に分類）

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -146,11 +146,13 @@ class ChannelController extends Controller
             'per_page' => 'integer|min:1|max:100',
             'page' => 'integer|min:1',
             'search' => 'string|max:255',
+            'index' => 'string|max:10',
         ]);
 
         $perPage = $validated['per_page'] ?? 50;
         $currentPage = $validated['page'] ?? 1;
         $search = $validated['search'] ?? '';
+        $index = $validated['index'] ?? '';
 
         // タイムスタンプ取得（チャンネルフィルタ付き）
         $query = $this->buildTimestampQuery($channel, withArchive: true);
@@ -265,33 +267,42 @@ class ChannelController extends Controller
 
         $timestampsWithMapping = $timestampsWithMapping->values();
 
-        // 頭文字インデックスマップを生成
-        $indexMap = [];
+        // 利用可能な頭文字カテゴリを収集（フィルタリング前に行う）
         $availableIndexes = [];
-        foreach ($timestampsWithMapping as $index => $ts) {
+        foreach ($timestampsWithMapping as $ts) {
             $title = $ts['mapping']['song']['title'] ?? $ts['text'] ?? '';
             if (empty($title)) {
                 continue;
             }
 
-            // 頭文字を取得
             $firstChar = mb_substr($title, 0, 1, 'UTF-8');
             $firstChar = mb_strtoupper($firstChar, 'UTF-8');
-
-            // カテゴリ分け
             $category = $this->categorizeFirstChar($firstChar);
 
-            // まだ記録されていないカテゴリの場合、ページ番号を記録
-            if (! isset($indexMap[$category])) {
-                $pageNum = (int) floor($index / $perPage) + 1;
-                $indexMap[$category] = $pageNum;
+            if (! in_array($category, $availableIndexes)) {
                 $availableIndexes[] = $category;
             }
         }
 
+        // 頭文字フィルタリング
+        if ($index) {
+            $timestampsWithMapping = $timestampsWithMapping->filter(function ($ts) use ($index) {
+                $title = $ts['mapping']['song']['title'] ?? $ts['text'] ?? '';
+                if (empty($title)) {
+                    return false;
+                }
+
+                $firstChar = mb_substr($title, 0, 1, 'UTF-8');
+                $firstChar = mb_strtoupper($firstChar, 'UTF-8');
+                $category = $this->categorizeFirstChar($firstChar);
+
+                return $category === $index;
+            })->values();
+        }
+
         // 手動でページネーション
         $total = $timestampsWithMapping->count();
-        $lastPage = (int) ceil($total / $perPage);
+        $lastPage = max(1, (int) ceil($total / $perPage));
         $offset = ($currentPage - 1) * $perPage;
         $items = $timestampsWithMapping->slice($offset, $perPage)->values();
 
@@ -301,7 +312,6 @@ class ChannelController extends Controller
             'last_page' => $lastPage,
             'per_page' => $perPage,
             'total' => $total,
-            'index_map' => $indexMap,
             'available_indexes' => $availableIndexes,
         ]);
     }

--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -143,7 +143,7 @@ class ChannelController extends Controller
 
         // バリデーション
         $allowedIndexes = [
-            'A-E', 'F-J', 'K-O', 'P-T', 'U-Z',
+            'ABCDE', 'FGHIJ', 'KLMNO', 'PQRST', 'UVWXYZ',
             '0-9', 'あ', 'か', 'さ', 'た', 'な', 'は', 'ま', 'や', 'ら', 'わ', 'その他',
         ];
         $validated = $request->validate([
@@ -312,22 +312,22 @@ class ChannelController extends Controller
      */
     private function categorizeFirstChar($char)
     {
-        // アルファベット（A-E, F-J, K-O, P-T, U-Z）
+        // アルファベット（ABCDE, FGHIJ, KLMNO, PQRST, UVWXYZ）
         $upperChar = strtoupper($char);
         if (preg_match('/^[A-E]$/', $upperChar)) {
-            return 'A-E';
+            return 'ABCDE';
         }
         if (preg_match('/^[F-J]$/', $upperChar)) {
-            return 'F-J';
+            return 'FGHIJ';
         }
         if (preg_match('/^[K-O]$/', $upperChar)) {
-            return 'K-O';
+            return 'KLMNO';
         }
         if (preg_match('/^[P-T]$/', $upperChar)) {
-            return 'P-T';
+            return 'PQRST';
         }
         if (preg_match('/^[U-Z]$/', $upperChar)) {
-            return 'U-Z';
+            return 'UVWXYZ';
         }
 
         // ひらがな・カタカナ（五十音行に分類）

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -148,12 +148,7 @@ function registerArchiveListComponent() {
                 },
 
                 filterByIndex(index) {
-                    // 同じインデックスをクリックした場合は解除
-                    if (this.selectedIndex === index) {
-                        this.selectedIndex = '';
-                    } else {
-                        this.selectedIndex = index;
-                    }
+                    this.selectedIndex = index;
                     this.currentTimestampPage = 1;
                     this.fetchTimestamps(1, this.searchQuery, this.selectedIndex);
                 },

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -28,6 +28,7 @@ function registerArchiveListComponent() {
                 tsFlg: '',
                 searchTimeout: null,
                 currentTimestampPage: 1,
+                selectedIndex: '',
                 loading: false,
                 error: null,
                 isFiltered: false,
@@ -101,7 +102,7 @@ function registerArchiveListComponent() {
                     this.updateURL();
                 },
 
-                async fetchTimestamps(page = 1, search = '') {
+                async fetchTimestamps(page = 1, search = '', index = '') {
                     try {
                         this.loading = true;
                         this.error = null;
@@ -113,6 +114,10 @@ function registerArchiveListComponent() {
 
                         if (search) {
                             params.set('search', search);
+                        }
+
+                        if (index) {
+                            params.set('index', index);
                         }
 
                         const response = await fetch(`/api/channels/${this.channel.handle}/timestamps?${params}`);
@@ -139,31 +144,24 @@ function registerArchiveListComponent() {
 
                 searchTimestamps() {
                     this.currentTimestampPage = 1;
-                    this.fetchTimestamps(1, this.searchQuery);
+                    this.fetchTimestamps(1, this.searchQuery, this.selectedIndex);
                 },
 
-                jumpToIndex(letter) {
-                    if (!this.timestamps.index_map || !this.timestamps.index_map[letter]) {
-                        return;
+                filterByIndex(index) {
+                    // 同じインデックスをクリックした場合は解除
+                    if (this.selectedIndex === index) {
+                        this.selectedIndex = '';
+                    } else {
+                        this.selectedIndex = index;
                     }
+                    this.currentTimestampPage = 1;
+                    this.fetchTimestamps(1, this.searchQuery, this.selectedIndex);
+                },
 
-                    const targetPage = this.timestamps.index_map[letter];
-                    this.fetchTimestamps(targetPage, this.searchQuery);
-
-                    // スムーズスクロール + オフセット
-                    setTimeout(() => {
-                        const tabElement = document.querySelector('#archives');
-                        if (tabElement) {
-                            const offset = 100; // 100pxの余白
-                            const elementPosition = tabElement.getBoundingClientRect().top;
-                            const offsetPosition = elementPosition + window.pageYOffset - offset;
-
-                            window.scrollTo({
-                                top: offsetPosition,
-                                behavior: 'smooth'
-                            });
-                        }
-                    }, 100); // データ取得待ち
+                clearIndexFilter() {
+                    this.selectedIndex = '';
+                    this.currentTimestampPage = 1;
+                    this.fetchTimestamps(1, this.searchQuery, '');
                 },
 
                 downloadTimestamps() {
@@ -197,6 +195,10 @@ function registerArchiveListComponent() {
                     if (this.activeTab === 'timestamps') {
                         if (this.searchQuery) {
                             params.set('search', this.searchQuery);
+                        }
+
+                        if (this.selectedIndex) {
+                            params.set('index', this.selectedIndex);
                         }
 
                         if (this.currentTimestampPage && this.currentTimestampPage > 1) {
@@ -254,8 +256,9 @@ function registerArchiveListComponent() {
                         // タイムスタンプタブの状態を復元（デフォルト）
                         this.activeTab = 'timestamps';
                         this.searchQuery = search || '';
+                        this.selectedIndex = params.get('index') || '';
                         this.currentTimestampPage = page;
-                        this.fetchTimestamps(page, this.searchQuery);
+                        this.fetchTimestamps(page, this.searchQuery, this.selectedIndex);
                     }
                 },
 

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -209,26 +209,26 @@
             <div x-show="activeTab === 'timestamps'">
                 <!-- ページネーション（上） -->
                 <div class="flex justify-center gap-2 mb-4">
-                    <button @click="fetchTimestamps(1, searchQuery)"
+                    <button @click="fetchTimestamps(1, searchQuery, selectedIndex)"
                             :disabled="timestamps.current_page <= 1"
                             :class="timestamps.current_page <= 1 ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-300 dark:hover:bg-gray-600'"
                             class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded text-sm">
                         最初
                     </button>
-                    <button @click="fetchTimestamps(timestamps.current_page - 1, searchQuery)"
+                    <button @click="fetchTimestamps(timestamps.current_page - 1, searchQuery, selectedIndex)"
                             :disabled="timestamps.current_page <= 1"
                             :class="timestamps.current_page <= 1 ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-300 dark:hover:bg-gray-600'"
                             class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded text-sm">
                         前へ
                     </button>
                     <span class="px-3 py-1 text-sm font-medium" x-text="`${timestamps.current_page || 1} / ${timestamps.last_page || 1}`"></span>
-                    <button @click="fetchTimestamps(timestamps.current_page + 1, searchQuery)"
+                    <button @click="fetchTimestamps(timestamps.current_page + 1, searchQuery, selectedIndex)"
                             :disabled="timestamps.current_page >= timestamps.last_page"
                             :class="timestamps.current_page >= timestamps.last_page ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-300 dark:hover:bg-gray-600'"
                             class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded text-sm">
                         次へ
                     </button>
-                    <button @click="fetchTimestamps(timestamps.last_page, searchQuery)"
+                    <button @click="fetchTimestamps(timestamps.last_page, searchQuery, selectedIndex)"
                             :disabled="timestamps.current_page >= timestamps.last_page"
                             :class="timestamps.current_page >= timestamps.last_page ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-300 dark:hover:bg-gray-600'"
                             class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded text-sm">
@@ -236,29 +236,43 @@
                     </button>
                 </div>
 
-                <!-- 頭文字ジャンプナビゲーション -->
+                <!-- 頭文字フィルタナビゲーション -->
                 <div x-show="timestamps.available_indexes && timestamps.available_indexes.length > 0" class="mb-4 hidden sm:block">
                     <div class="flex flex-wrap items-center gap-1">
-                        <span class="text-xs text-gray-500 dark:text-gray-400 mr-1">頭文字:</span>
+                        <span class="text-xs text-gray-500 dark:text-gray-400 mr-1">絞り込み:</span>
+                        <!-- すべて -->
+                        <button
+                            @click="clearIndexFilter()"
+                            :class="!selectedIndex
+                                ? 'bg-gray-600 text-white cursor-pointer'
+                                : 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-400 hover:bg-gray-300 dark:hover:bg-gray-600 cursor-pointer'"
+                            class="px-2 h-7 text-xs rounded transition-colors">
+                            すべて
+                        </button>
+                        <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>
                         <!-- 数字 -->
                         <button
-                            @click="jumpToIndex('0-9')"
+                            @click="filterByIndex('0-9')"
                             :disabled="!timestamps.available_indexes?.includes('0-9')"
-                            :class="timestamps.available_indexes?.includes('0-9')
-                                ? 'bg-purple-500 hover:bg-purple-600 text-white cursor-pointer'
-                                : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
+                            :class="selectedIndex === '0-9'
+                                ? 'bg-purple-700 text-white cursor-pointer ring-2 ring-purple-300'
+                                : (timestamps.available_indexes?.includes('0-9')
+                                    ? 'bg-purple-500 hover:bg-purple-600 text-white cursor-pointer'
+                                    : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed')"
                             class="px-2 h-7 text-xs rounded transition-colors">
                             0-9
                         </button>
                         <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>
-                        <!-- アルファベット（A, F, K, P, U） -->
-                        <template x-for="letter in ['A','F','K','P','U']" :key="letter">
+                        <!-- アルファベット（A-Z全文字） -->
+                        <template x-for="letter in ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z']" :key="letter">
                             <button
-                                @click="jumpToIndex(letter)"
+                                @click="filterByIndex(letter)"
                                 :disabled="!timestamps.available_indexes?.includes(letter)"
-                                :class="timestamps.available_indexes?.includes(letter)
-                                    ? 'bg-blue-500 hover:bg-blue-600 text-white cursor-pointer'
-                                    : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
+                                :class="selectedIndex === letter
+                                    ? 'bg-blue-700 text-white cursor-pointer ring-2 ring-blue-300'
+                                    : (timestamps.available_indexes?.includes(letter)
+                                        ? 'bg-blue-500 hover:bg-blue-600 text-white cursor-pointer'
+                                        : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed')"
                                 class="w-7 h-7 text-xs rounded transition-colors">
                                 <span x-text="letter"></span>
                             </button>
@@ -267,11 +281,13 @@
                         <!-- 五十音 -->
                         <template x-for="kana in ['あ','か','さ','た','な','は','ま','や','ら','わ']" :key="kana">
                             <button
-                                @click="jumpToIndex(kana)"
+                                @click="filterByIndex(kana)"
                                 :disabled="!timestamps.available_indexes?.includes(kana)"
-                                :class="timestamps.available_indexes?.includes(kana)
-                                    ? 'bg-green-500 hover:bg-green-600 text-white cursor-pointer'
-                                    : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
+                                :class="selectedIndex === kana
+                                    ? 'bg-green-700 text-white cursor-pointer ring-2 ring-green-300'
+                                    : (timestamps.available_indexes?.includes(kana)
+                                        ? 'bg-green-500 hover:bg-green-600 text-white cursor-pointer'
+                                        : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed')"
                                 class="w-7 h-7 text-xs rounded transition-colors">
                                 <span x-text="kana"></span>
                             </button>
@@ -279,11 +295,13 @@
                         <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>
                         <!-- 漢字・その他 -->
                         <button
-                            @click="jumpToIndex('その他')"
+                            @click="filterByIndex('その他')"
                             :disabled="!timestamps.available_indexes?.includes('その他')"
-                            :class="timestamps.available_indexes?.includes('その他')
-                                ? 'bg-orange-500 hover:bg-orange-600 text-white cursor-pointer'
-                                : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed'"
+                            :class="selectedIndex === 'その他'
+                                ? 'bg-orange-700 text-white cursor-pointer ring-2 ring-orange-300'
+                                : (timestamps.available_indexes?.includes('その他')
+                                    ? 'bg-orange-500 hover:bg-orange-600 text-white cursor-pointer'
+                                    : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed')"
                             class="px-2 h-7 text-xs rounded transition-colors">
                             漢字
                         </button>
@@ -379,26 +397,26 @@
 
                 <!-- ページネーション（下） -->
                 <div class="flex justify-center gap-2 mt-4">
-                    <button @click="fetchTimestamps(1, searchQuery); document.querySelector('#archives').scrollIntoView({ behavior: 'auto' })"
+                    <button @click="fetchTimestamps(1, searchQuery, selectedIndex); document.querySelector('#archives').scrollIntoView({ behavior: 'auto' })"
                             :disabled="timestamps.current_page <= 1"
                             :class="timestamps.current_page <= 1 ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-300 dark:hover:bg-gray-600'"
                             class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded text-sm">
                         最初
                     </button>
-                    <button @click="fetchTimestamps(timestamps.current_page - 1, searchQuery); document.querySelector('#archives').scrollIntoView({ behavior: 'auto' })"
+                    <button @click="fetchTimestamps(timestamps.current_page - 1, searchQuery, selectedIndex); document.querySelector('#archives').scrollIntoView({ behavior: 'auto' })"
                             :disabled="timestamps.current_page <= 1"
                             :class="timestamps.current_page <= 1 ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-300 dark:hover:bg-gray-600'"
                             class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded text-sm">
                         前へ
                     </button>
                     <span class="px-3 py-1 text-sm font-medium" x-text="`${timestamps.current_page || 1} / ${timestamps.last_page || 1}`"></span>
-                    <button @click="fetchTimestamps(timestamps.current_page + 1, searchQuery); document.querySelector('#archives').scrollIntoView({ behavior: 'auto' })"
+                    <button @click="fetchTimestamps(timestamps.current_page + 1, searchQuery, selectedIndex); document.querySelector('#archives').scrollIntoView({ behavior: 'auto' })"
                             :disabled="timestamps.current_page >= timestamps.last_page"
                             :class="timestamps.current_page >= timestamps.last_page ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-300 dark:hover:bg-gray-600'"
                             class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded text-sm">
                         次へ
                     </button>
-                    <button @click="fetchTimestamps(timestamps.last_page, searchQuery); document.querySelector('#archives').scrollIntoView({ behavior: 'auto' })"
+                    <button @click="fetchTimestamps(timestamps.last_page, searchQuery, selectedIndex); document.querySelector('#archives').scrollIntoView({ behavior: 'auto' })"
                             :disabled="timestamps.current_page >= timestamps.last_page"
                             :class="timestamps.current_page >= timestamps.last_page ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-300 dark:hover:bg-gray-600'"
                             class="px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded text-sm">

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -263,8 +263,8 @@
                             0-9
                         </button>
                         <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>
-                        <!-- アルファベット（A-E, F-J, K-O, P-T, U-Z） -->
-                        <template x-for="group in ['A-E','F-J','K-O','P-T','U-Z']" :key="group">
+                        <!-- アルファベット（ABCDE, FGHIJ, KLMNO, PQRST, UVWXYZ） -->
+                        <template x-for="group in ['ABCDE','FGHIJ','KLMNO','PQRST','UVWXYZ']" :key="group">
                             <button
                                 @click="filterByIndex(group)"
                                 :disabled="!timestamps.available_indexes?.includes(group)"

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -263,18 +263,18 @@
                             0-9
                         </button>
                         <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>
-                        <!-- アルファベット（A-Z全文字） -->
-                        <template x-for="letter in ['A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z']" :key="letter">
+                        <!-- アルファベット（A-E, F-J, K-O, P-T, U-Z） -->
+                        <template x-for="group in ['A-E','F-J','K-O','P-T','U-Z']" :key="group">
                             <button
-                                @click="filterByIndex(letter)"
-                                :disabled="!timestamps.available_indexes?.includes(letter)"
-                                :class="selectedIndex === letter
+                                @click="filterByIndex(group)"
+                                :disabled="!timestamps.available_indexes?.includes(group)"
+                                :class="selectedIndex === group
                                     ? 'bg-blue-700 text-white cursor-pointer ring-2 ring-blue-300'
-                                    : (timestamps.available_indexes?.includes(letter)
+                                    : (timestamps.available_indexes?.includes(group)
                                         ? 'bg-blue-500 hover:bg-blue-600 text-white cursor-pointer'
                                         : 'bg-gray-200 dark:bg-gray-700 text-gray-400 cursor-not-allowed')"
-                                class="w-7 h-7 text-xs rounded transition-colors">
-                                <span x-text="letter"></span>
+                                class="px-2 h-7 text-xs rounded transition-colors">
+                                <span x-text="group"></span>
                             </button>
                         </template>
                         <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>

--- a/tests/Feature/ChannelArchiveTest.php
+++ b/tests/Feature/ChannelArchiveTest.php
@@ -162,7 +162,6 @@ class ChannelArchiveTest extends TestCase
                 'last_page',
                 'per_page',
                 'total',
-                'index_map',
                 'available_indexes',
             ]);
     }


### PR DESCRIPTION
## Summary
頭文字ナビゲーションをページジャンプ方式から絞り込み（フィルタリング）方式に変更し、UXを改善しました。

## 変更内容

### 機能の変更
- **ページジャンプ → フィルタリング方式**
  - 以前: 頭文字をクリックすると該当ページにジャンプ
  - 現在: 頭文字をクリックすると該当する楽曲のみ表示
- **「すべて」ボタンの追加**: フィルタを解除して全件表示
- **選択状態の視覚化**: 選択中のフィルタにリング効果を追加

### アルファベットのグループ化
- 26個のアルファベット → 5グループに統合
  - ABCDE, FGHIJ, KLMNO, PQRST, UVWXYZ
- グループラベルを全文字表示に変更（視認性向上）

### バックエンド改善
- `index`パラメータの追加とバリデーション
- サーバーサイドでフィルタリング処理を実装
- `index_map`を削除し、`available_indexes`のみ返却

### URLパラメータ対応
- フィルタ状態をURLに保持（`?index=ABCDE`など）
- ページ共有・リロード時も状態を保持

## 変更されたファイル

| ファイル | 変更内容 |
|----------|----------|
| `app/Http/Controllers/ChannelController.php` | indexパラメータ対応、フィルタリング処理追加 |
| `resources/js/channels/archive-list.js` | フィルタ機能の実装 |
| `resources/views/channels/show.blade.php` | UIの改善（すべてボタン、選択状態表示） |
| `tests/Feature/ChannelArchiveTest.php` | index_map削除に伴うテスト修正 |

## メリット
- **直感的な操作**: 頭文字で絞り込み→スクロールで探す、という自然な流れ
- **視認性の向上**: 5グループ化により、UI がコンパクトでわかりやすく
- **状態の保持**: URLパラメータで状態を保持、共有可能

## Test plan
- [x] 全192テストパス
- [x] ビルド成功
- [x] フィルタリング動作確認
- [x] URLパラメータの保持確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)