### PR TITLE
refactor: 検索パラメータ名をbaramutsuからsearchに統一

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -53,7 +53,7 @@ class ChannelController extends Controller
     {
         $archives = $this->getArchiveService->getArchives(
             $id,
-            (string) $request->query('baramutsu', ''),
+            (string) $request->query('search', ''),
             (string) $request->query('visible', ''),
             (string) $request->query('ts', '')
         )

--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -126,7 +126,7 @@ class ManageController extends Controller
 
         $archives = $this->getArchiveService->getArchivesForManage(
             $id,
-            (string) $request->query('baramutsu', ''),
+            (string) $request->query('search', ''),
             (string) $request->query('visible', ''),
             (string) $request->query('ts', '')
         )

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -107,7 +107,7 @@ function registerArchiveListComponent() {
 
                 archiveSearch() {
                     const params = new URLSearchParams();
-                    params.append('baramutsu', this.archiveQuery);
+                    params.append('search', this.archiveQuery);
                     params.append('visible', '');
                     params.append('ts', this.tsFlg);
 
@@ -218,7 +218,7 @@ function registerArchiveListComponent() {
                     } else {
                         // アーカイブタブのパラメータ
                         if (this.archiveQuery) {
-                            params.set('baramutsu', this.archiveQuery);
+                            params.set('search', this.archiveQuery);
                         }
 
                         if (this.tsFlg) {
@@ -253,7 +253,7 @@ function registerArchiveListComponent() {
 
                     if (view === 'archives') {
                         this.activeTab = 'archives';
-                        const archiveQuery = params.get('baramutsu') || '';
+                        const archiveQuery = params.get('search') || '';
                         const tsFlg = params.get('ts') || '';
                         this.archiveQuery = archiveQuery;
                         this.tsFlg = tsFlg;

--- a/resources/views/components/search.blade.php
+++ b/resources/views/components/search.blade.php
@@ -48,7 +48,7 @@
 
                 try {
                     const params = new URLSearchParams();
-                    params.append('baramutsu', this.query);
+                    params.append('search', this.query);
                     params.append('visible', this.visibleFlg);
                     params.append('ts', this.tsFlg);
 


### PR DESCRIPTION
## Summary
検索パラメータ名を `baramutsu` から `search` に統一するリファクタリング

## 変更内容

### バックエンド
- `app/Http/Controllers/ChannelController.php`: fetchArchivesメソッドでのパラメータ名変更
- `app/Http/Controllers/ManageController.php`: fetchArchivesメソッドでのパラメータ名変更

### フロントエンド
- `resources/js/channels/archive-list.js`: URLパラメータ名を3箇所で変更
  - archiveSearch()
  - updateURL()
  - restoreStateFromURL()
- `resources/views/components/search.blade.php`: 検索コンポーネントでのパラメータ名変更

## 変更理由
- `baramutsu` という不明瞭な名前から `search` という明確な名前に変更
- コードの可読性と保守性の向上
- パラメータ名の意味を明確化

## 影響範囲
- 古いURLパラメータ `?baramutsu=...` を使用しているブックマークやリンクは動作しなくなる
- ただし、これは内部的なパラメータであり、外部公開APIではないため影響は限定的

## Test plan
- [x] 全192テストが合格
- [x] ビルドが成功
- [x] レビュー完了 - 問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)