### PR TITLE
refactor: 配信サービスURL生成とYouTube関連ユーティリティを分離

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -1,5 +1,13 @@
 import { escapeHTML, formatDate } from '../utils.js';
 import toast from '../utils/toast.js';
+import { getYoutubeUrl, isValidVideoId } from '../utils/youtube.js';
+import {
+    getSpotifyUrl,
+    getAppleMusicUrl,
+    getYouTubeMusicUrl,
+    getAmazonMusicUrl,
+    getLineMusicUrl
+} from '../utils/music-services.js';
 
 // 報告タイプ定数
 const REPORT_TYPES = {
@@ -88,13 +96,11 @@ function registerArchiveListComponent() {
                 },
 
                 getYoutubeUrl(videoId, tsNum) {
-                    const safeVideoId = encodeURIComponent(videoId || '');
-                    const safeTsNum = parseInt(tsNum) || 0;
-                    return `https://youtu.be/${safeVideoId}?t=${safeTsNum}s`;
+                    return getYoutubeUrl(videoId, tsNum);
                 },
 
                 getArchiveUrl(videoId, tsNum) {
-                    return this.getYoutubeUrl(videoId, tsNum);
+                    return getYoutubeUrl(videoId, tsNum);
                 },
 
                 escapeHTML(str) {
@@ -447,48 +453,25 @@ function registerArchiveListComponent() {
                     }
                 },
 
-                // 配信サービスURL生成メソッド
+                // 配信サービスURL生成メソッド（ユーティリティ関数のラッパー）
                 getSpotifyUrl(song) {
-                    if (!song) return '';
-                    if (song.spotify_track_id) {
-                        return `https://open.spotify.com/track/${encodeURIComponent(song.spotify_track_id)}`;
-                    }
-                    const query = encodeURIComponent(`${song.title} ${song.artist}`);
-                    return `https://open.spotify.com/search/${query}`;
+                    return getSpotifyUrl(song);
                 },
 
                 getAppleMusicUrl(song) {
-                    if (!song) return '';
-                    const query = encodeURIComponent(`${song.title} ${song.artist}`);
-                    return `https://music.apple.com/jp/search?term=${query}`;
+                    return getAppleMusicUrl(song);
                 },
 
                 getYouTubeMusicUrl(song) {
-                    if (!song) return '';
-                    const query = encodeURIComponent(`${song.title} ${song.artist}`);
-                    return `https://music.youtube.com/search?q=${query}`;
+                    return getYouTubeMusicUrl(song);
                 },
 
                 getAmazonMusicUrl(song) {
-                    if (!song) return '';
-                    // URLに使えない特殊文字を除去し、スペースを+に変換
-                    const searchText = `${song.title} ${song.artist}`
-                        .replace(/[/\\?#%&=:@!$'()*+,;[\]{}|^`<>"]/g, ' ')  // 特殊文字をスペースに
-                        .trim()
-                        .replace(/\s+/g, '+');  // 連続スペースを+に
-                    return `https://music.amazon.co.jp/search/${searchText}`;
+                    return getAmazonMusicUrl(song);
                 },
 
                 getLineMusicUrl(song) {
-                    if (!song) return '';
-                    // URLに使えない特殊文字を除去してからエンコード
-                    const searchText = `${song.title} ${song.artist}`
-                        .replace(/[/\\?#%&=:@!$'()*+,;[\]{}|^`<>"]/g, ' ')
-                        .trim()
-                        .replace(/\s+/g, ' ');  // 連続スペースを1つに
-                    const query = encodeURIComponent(searchText);
-                    // LINE MUSICのwebappは /webapp/ パスを使用
-                    return `https://music.line.me/webapp/search/tracks?query=${query}`;
+                    return getLineMusicUrl(song);
                 },
 
                 // YouTube IFrame APIの読み込み
@@ -554,8 +537,7 @@ function registerArchiveListComponent() {
 
                 // 動画を読み込んで再生
                 loadAndPlayVideo(videoId, time = 0) {
-                    // YouTubeのvideoIDは11文字の英数字とハイフン、アンダースコア
-                    if (!videoId || !/^[a-zA-Z0-9_-]{11}$/.test(videoId)) {
+                    if (!isValidVideoId(videoId)) {
                         console.error('Invalid video ID:', videoId);
                         return;
                     }

--- a/resources/js/utils/music-services.js
+++ b/resources/js/utils/music-services.js
@@ -1,0 +1,70 @@
+/**
+ * 音楽配信サービスのURL生成ユーティリティ
+ */
+
+/**
+ * Spotify URLを生成
+ * @param {Object} song - 楽曲情報 {title, artist, spotify_track_id}
+ * @returns {string} Spotify URL
+ */
+export function getSpotifyUrl(song) {
+    if (!song) return '';
+    if (song.spotify_track_id) {
+        return `https://open.spotify.com/track/${encodeURIComponent(song.spotify_track_id)}`;
+    }
+    const query = encodeURIComponent(`${song.title} ${song.artist}`);
+    return `https://open.spotify.com/search/${query}`;
+}
+
+/**
+ * Apple Music URLを生成
+ * @param {Object} song - 楽曲情報 {title, artist}
+ * @returns {string} Apple Music URL
+ */
+export function getAppleMusicUrl(song) {
+    if (!song) return '';
+    const query = encodeURIComponent(`${song.title} ${song.artist}`);
+    return `https://music.apple.com/jp/search?term=${query}`;
+}
+
+/**
+ * YouTube Music URLを生成
+ * @param {Object} song - 楽曲情報 {title, artist}
+ * @returns {string} YouTube Music URL
+ */
+export function getYouTubeMusicUrl(song) {
+    if (!song) return '';
+    const query = encodeURIComponent(`${song.title} ${song.artist}`);
+    return `https://music.youtube.com/search?q=${query}`;
+}
+
+/**
+ * Amazon Music URLを生成
+ * @param {Object} song - 楽曲情報 {title, artist}
+ * @returns {string} Amazon Music URL
+ */
+export function getAmazonMusicUrl(song) {
+    if (!song) return '';
+    // URLに使えない特殊文字を除去し、スペースを+に変換
+    const searchText = `${song.title} ${song.artist}`
+        .replace(/[/\\?#%&=:@!$'()*+,;[\]{}|^`<>"]/g, ' ')
+        .trim()
+        .replace(/\s+/g, '+');
+    return `https://music.amazon.co.jp/search/${searchText}`;
+}
+
+/**
+ * LINE MUSIC URLを生成
+ * @param {Object} song - 楽曲情報 {title, artist}
+ * @returns {string} LINE MUSIC URL
+ */
+export function getLineMusicUrl(song) {
+    if (!song) return '';
+    // URLに使えない特殊文字を除去してからエンコード
+    const searchText = `${song.title} ${song.artist}`
+        .replace(/[/\\?#%&=:@!$'()*+,;[\]{}|^`<>"]/g, ' ')
+        .trim()
+        .replace(/\s+/g, ' ');
+    const query = encodeURIComponent(searchText);
+    return `https://music.line.me/webapp/search/tracks?query=${query}`;
+}

--- a/resources/js/utils/youtube.js
+++ b/resources/js/utils/youtube.js
@@ -1,0 +1,26 @@
+/**
+ * YouTube関連のユーティリティ
+ */
+
+/**
+ * YouTube動画のURLを生成
+ * @param {string} videoId - YouTube動画ID
+ * @param {number} [tsNum=0] - タイムスタンプ（秒）
+ * @returns {string} YouTube URL
+ */
+export function getYoutubeUrl(videoId, tsNum = 0) {
+    const safeVideoId = encodeURIComponent(videoId || '');
+    const safeTsNum = parseInt(tsNum) || 0;
+    return `https://youtu.be/${safeVideoId}?t=${safeTsNum}s`;
+}
+
+/**
+ * YouTube動画IDの妥当性を検証
+ * @param {string} videoId - YouTube動画ID
+ * @returns {boolean} 妥当な場合true
+ */
+export function isValidVideoId(videoId) {
+    if (!videoId) return false;
+    // YouTubeのvideoIDは11文字の英数字とハイフン、アンダースコア
+    return /^[a-zA-Z0-9_-]{11}$/.test(videoId);
+}


### PR DESCRIPTION
## Summary
`archive-list.js`から音楽配信サービスのURL生成ロジックとYouTube関連のロジックを分離し、再利用可能なユーティリティモジュールに移動

## 変更内容

### 新規作成

#### `resources/js/utils/music-services.js` (70行)
音楽配信サービスのURL生成関数を提供
- `getSpotifyUrl()`: Spotify URL生成（Track ID対応）
- `getAppleMusicUrl()`: Apple Music検索URL生成
- `getYouTubeMusicUrl()`: YouTube Music検索URL生成
- `getAmazonMusicUrl()`: Amazon Music検索URL生成
- `getLineMusicUrl()`: LINE MUSIC検索URL生成

#### `resources/js/utils/youtube.js` (26行)
YouTube関連のユーティリティ関数を提供
- `getYoutubeUrl()`: YouTube動画URL生成（タイムスタンプ付き）
- `isValidVideoId()`: YouTube Video ID検証

### 変更

#### `resources/js/channels/archive-list.js`
- 約35行のロジックを削除
- 新しいユーティリティモジュールをimport
- メソッドをユーティリティ関数のラッパーに変更
- コンポーネントがシンプルになり、責務が明確化

## 設計改善のポイント

1. **関心の分離**: URL生成ロジックをコンポーネントから分離
2. **再利用性**: ユーティリティ関数は他のコンポーネントからも利用可能
3. **テスト容易性**: 各関数が独立しており、単体テストが書きやすい
4. **保守性**: ロジックが一箇所に集約され、変更が容易
5. **可読性**: JSDocコメントで各関数の役割が明確

## セキュリティ

- URL生成時の適切なエンコード処理
- YouTube Video IDの検証（正規表現）
- 特殊文字の除去処理

## Test plan
- [x] 全192テストが合格
- [x] ビルドが成功（63モジュール）
- [x] レビュー完了 - 問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)