### PR TITLE
refactor: YouTubeServiceの責任分離と4つのサービスへの分割

### DIFF
--- a/app/Services/ArchiveProcessorService.php
+++ b/app/Services/ArchiveProcessorService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Services;
+
+class ArchiveProcessorService
+{
+    /**
+     * タイムスタンプの表示/非表示を更新
+     *
+     * comment_idごとの出現回数をカウントし、最も多いものを表示対象とする
+     *
+     * @param  array  $tsItems  タイムスタンプ配列（参照渡し）
+     */
+    public function updateDisplayTsItems(array &$tsItems): void
+    {
+        if (empty($tsItems)) {
+            return;
+        }
+
+        // comment_idごとの出現回数をカウント
+        $countByCommentId = [];
+        foreach ($tsItems as &$item) {
+            $item['is_display'] = '0';
+            $commentId = $item['comment_id'];
+            $countByCommentId[$commentId] = ($countByCommentId[$commentId] ?? 0) + 1;
+        }
+
+        // 最も多い comment_id を取得
+        $maxCount = max($countByCommentId);
+        // 1件しかない場合は初期表示なしとする
+        if ($maxCount > 1) {
+            $mostFrequentCommentIds = array_keys($countByCommentId, $maxCount, true);
+            // タイムスタンプが同数の場合も考えられるが先勝ちとする
+            if (count($mostFrequentCommentIds) > 0) {
+                // is_display を更新
+                foreach ($tsItems as &$item) {
+                    $item['is_display'] = ($item['comment_id'] === $mostFrequentCommentIds[0]);
+                }
+            }
+        }
+    }
+}

--- a/app/Services/TimestampExtractorService.php
+++ b/app/Services/TimestampExtractorService.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Services;
+
+use App\Helpers\TextNormalizer;
+use Illuminate\Support\Str;
+
+class TimestampExtractorService
+{
+    /**
+     * テキストからタイムスタンプを抽出
+     *
+     * @param  string  $videoId  動画ID
+     * @param  string  $type  タイプ（1: description, 2: comment）
+     * @param  string  $description  抽出対象のテキスト
+     * @param  string  $commentId  コメントID
+     * @return array タイムスタンプ配列
+     */
+    public function extractTimestamps(string $videoId, string $type, string $description, string $commentId): array
+    {
+        // 引数のバリデーション
+        if (! is_string($videoId) || ! is_string($description)) {
+            error_log('Invalid video_id or description: '
+                .var_export($videoId, true).', '.var_export($description, true));
+
+            return [];
+        }
+
+        if (! in_array($type, ['1', '2'])) {
+            error_log('Invalid type: '.var_export($type, true));
+
+            return [];
+        }
+
+        // 正規表現でタイムスタンプを抽出 (MM:SS または HH:MM:SS)
+        $pattern = '/\b(\d{1,2}:\d{2}(?::\d{2})?)\b/';
+        $lines = explode("\n", $description); // 改行で分割
+        $results = [];
+
+        foreach ($lines as $line) {
+            // 各行からタイムスタンプを抽出
+            if (preg_match($pattern, $line, $matches)) {
+                $timestamp = $matches[1];                              // タイムスタンプ部分
+                $comment = trim(str_replace($timestamp, '', $line)); // タイムスタンプを除外した部分
+                // 先頭の全角スペースを除外
+                $comment = TextNormalizer::trimFullwidthSpace($comment);
+
+                // 結果に追加
+                $results[] = [
+                    'id' => Str::ulid(),
+                    'comment_id' => $commentId,
+                    'video_id' => $videoId,
+                    'type' => $type,
+                    'ts_text' => $timestamp,
+                    'ts_num' => $this->timestampToSeconds($timestamp),
+                    'text' => $comment,
+                ];
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * タイムスタンプ文字列を秒数に変換
+     *
+     * @param  string  $timestamp  タイムスタンプ (MM:SS または HH:MM:SS)
+     * @return int 秒数
+     */
+    public function timestampToSeconds(string $timestamp): int
+    {
+        $parts = explode(':', $timestamp);
+        $count = count($parts);
+
+        if ($count === 2) {
+            return ($parts[0] * 60) + $parts[1];
+        } elseif ($count === 3) {
+            return ($parts[0] * 3600) + ($parts[1] * 60) + $parts[2];
+        }
+
+        return 0; // 不正なフォーマットの場合
+    }
+}

--- a/app/Services/VideoAnalyzerService.php
+++ b/app/Services/VideoAnalyzerService.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Services;
+
+class VideoAnalyzerService
+{
+    /**
+     * 動画タイトルから歌枠かどうかを判定
+     *
+     * @param  string  $title  動画タイトル
+     * @return bool 歌枠の場合true
+     */
+    public function isSingingStream(string $title): bool
+    {
+        // 特定の歌枠タイトルに含まれるかを判定する
+        $keywords = ['singing stream', '歌枠', 'カラオケ', 'karaoke'];
+        foreach ($keywords as $keyword) {
+            if (str_contains(strtolower($title), $keyword)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Services/YouTubeApiService.php
+++ b/app/Services/YouTubeApiService.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace App\Services;
+
+use Carbon\Carbon;
+use Exception;
+use Google\Client as Google_Client;
+use Google\Service\YouTube as Google_Service_YouTube;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * YouTube Data API v3 通信サービス
+ *
+ * APIキーを使用してYouTube APIへの通信のみを担当
+ */
+class YouTubeApiService
+{
+    protected $client;
+
+    protected $youtube;
+
+    public function __construct()
+    {
+        $this->client = new Google_Client;
+    }
+
+    /**
+     * APIキーを設定してYouTube APIクライアントを初期化
+     *
+     * @throws Exception APIキーが設定されていない、または無効な場合
+     */
+    public function setApiKey(): void
+    {
+        // 定義済みの場合は終了
+        if ($this->youtube) {
+            return;
+        }
+
+        $user = Auth::user();
+
+        if (! $user || ! $user->api_key) {
+            throw new Exception('APIキーが設定されていません。プロフィール画面でYouTube Data APIキーを登録してください。');
+        }
+
+        // モデルのcastsで自動復号化されるため、Crypt::decryptString()は不要
+        $this->client->setDeveloperKey($user->api_key);
+        $this->youtube = new Google_Service_YouTube($this->client);
+    }
+
+    /**
+     * ハンドル名からチャンネル情報を取得
+     *
+     * @param  string  $handle  チャンネルハンドル
+     * @return array|null チャンネル情報、見つからない場合null
+     */
+    public function getChannelByHandle(string $handle): ?array
+    {
+        $this->setApiKey();
+
+        $response = $this->youtube->channels->listChannels('snippet', [
+            'forHandle' => $handle,
+        ]);
+
+        // 検索結果が存在するかを確認
+        if (count($response->getItems()) > 0) {
+            $channel = $response->getItems()[0];
+
+            // 安全なアクセサーメソッドを使用
+            $snippet = $channel->getSnippet();
+            $thumbnails = $snippet ? $snippet->getThumbnails() : null;
+            $defaultThumb = $thumbnails ? ($thumbnails->getDefault() ? $thumbnails->getDefault()->getUrl() : null) : null;
+
+            return [
+                'title' => $snippet ? $snippet->getTitle() : '',
+                'channel_id' => $channel->getId(),
+                'thumbnail' => $defaultThumb ?? '',
+            ];
+        }
+
+        return null; // 該当するチャンネルが見つからない場合
+    }
+
+    /**
+     * チャンネルIDからアーカイブ一覧を取得
+     *
+     * @param  string  $channelId  チャンネルID
+     * @return array アーカイブ配列
+     */
+    public function getArchives(string $channelId): array
+    {
+        $this->setApiKey();
+
+        // チャンネルIDの先頭2文字をUUに置き換える
+        $playlistId = 'UU'.substr($channelId, 2);
+
+        // nextPageTokenが取得できなくなるまでループ
+        $maxResults = App::environment('local') ? config('utils.page') : 50;
+        $response = null;
+        $archives = [];
+        do {
+            $response = $this->youtube->playlistItems->listPlaylistItems('snippet', [
+                'playlistId' => $playlistId,
+                'maxResults' => $maxResults,
+                'pageToken' => $response ? $response->getNextPageToken() : '',
+            ]);
+
+            if (is_array($response->getItems())) {
+                foreach ($response->getItems() as $item) {
+                    $snippet = $item->getSnippet();
+                    $resourceId = $snippet?->getResourceId();
+                    $mediumThumb = $snippet?->getThumbnails()?->getMedium()?->getUrl() ?? '';
+
+                    $archives[] = [
+                        'id' => Str::ulid(),
+                        'channel_id' => $channelId,
+                        'video_id' => $resourceId?->getVideoId() ?? '',
+                        'title' => $snippet?->getTitle() ?? '',
+                        'thumbnail' => $mediumThumb,
+                        'is_public' => true,
+                        'is_display' => true,
+                        'published_at' => ($snippet && ($publishedAt = $snippet->getPublishedAt()))
+                            ? Carbon::parse($publishedAt)->format('Y-m-d H:i:s')
+                            : now()->format('Y-m-d H:i:s'),
+                        'comments_updated_at' => today(),
+                        'description' => $snippet?->getDescription() ?? '',
+                    ];
+                }
+            }
+            if (App::environment('local') && count($archives) >= config('utils.max_archive_count')) {
+                break;
+            }
+        } while ($response->getNextPageToken());
+
+        return $archives;
+    }
+
+    /**
+     * 動画IDからコメント一覧を取得
+     *
+     * @param  string  $videoId  動画ID
+     * @return array コメント配列
+     */
+    public function getComments(string $videoId): array
+    {
+        $this->setApiKey();
+
+        $comments = [];
+        $response = null;
+        do {
+            // リクエストパラメータを設定
+            $params = [
+                'videoId' => $videoId,
+                'part' => 'snippet,replies', // コメントのスニペットとリプライを取得
+                'maxResults' => 100,               // 1回のリクエストで取得するコメント数
+                'pageToken' => $response ? $response->getNextPageToken() : '',
+            ];
+
+            try {
+                // コメントスレッドを取得
+                $response = $this->youtube->commentThreads->listCommentThreads('snippet', $params);
+            } catch (Exception $e) {
+                // コメントが無効な場合はスキップ
+                if (strpos($e->getMessage(), 'has disabled comments') !== false) {
+                    Log::info('YouTube API: Comments disabled for video', [
+                        'video_id' => $videoId,
+                    ]);
+                    break; // コメントが無効の場合はループを抜ける
+                } else {
+                    Log::error('YouTube API: Failed to fetch comments', [
+                        'video_id' => $videoId,
+                        'error' => $e->getMessage(),
+                        'code' => $e->getCode(),
+                    ]);
+                    break; // その他のエラーもループを抜ける
+                }
+            }
+
+            // レスポンスがない場合はスキップ
+            if (! $response || ! $response->getItems()) {
+                break;
+            }
+
+            // 各コメントを処理
+            foreach ($response->getItems() as $item) {
+                $commentId = $item->getId();
+                $snippet = $item->getSnippet();
+                $topLevelComment = $snippet ? $snippet->getTopLevelComment() : null;
+                $topLevelSnippet = $topLevelComment ? $topLevelComment->getSnippet() : null;
+                $textOriginal = $topLevelSnippet ? $topLevelSnippet->getTextOriginal() : '';
+
+                $comments[] = [
+                    'id' => $commentId,
+                    'description' => $textOriginal,
+                ];
+            }
+            // 次のページトークンを取得
+        } while ($response && $response->getNextPageToken());
+
+        return $comments;
+    }
+}

--- a/app/Services/YouTubeService.php
+++ b/app/Services/YouTubeService.php
@@ -2,347 +2,111 @@
 
 namespace App\Services;
 
-use Carbon\Carbon;
-use Exception;
-use Google\Client as Google_Client;
-use Google\Service\YouTube as Google_Service_YouTube;
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
-
 /**
  * YouTube Data API v3 サービス
  *
- * APIキーを使用してYouTube APIにアクセスします。
- * 各ユーザーが独自のGoogle Cloud ProjectとAPIキーを持つことで、
- * quota（10,000 units/日）を分離します。
+ * 各専門サービスを統合して、アーカイブとタイムスタンプの取得を管理
  */
 class YouTubeService
 {
-    protected $client;
+    protected YouTubeApiService $youtubeApiService;
 
-    protected $youtube;
+    protected TimestampExtractorService $timestampExtractorService;
 
-    public function __construct()
-    {
-        $this->client = new Google_Client;
+    protected VideoAnalyzerService $videoAnalyzerService;
+
+    protected ArchiveProcessorService $archiveProcessorService;
+
+    public function __construct(
+        YouTubeApiService $youtubeApiService,
+        TimestampExtractorService $timestampExtractorService,
+        VideoAnalyzerService $videoAnalyzerService,
+        ArchiveProcessorService $archiveProcessorService
+    ) {
+        $this->youtubeApiService = $youtubeApiService;
+        $this->timestampExtractorService = $timestampExtractorService;
+        $this->videoAnalyzerService = $videoAnalyzerService;
+        $this->archiveProcessorService = $archiveProcessorService;
     }
 
     /**
-     * APIキーを設定してYouTube APIクライアントを初期化
+     * ハンドル名からチャンネル情報を取得
      *
-     * @throws Exception APIキーが設定されていない、または無効な場合
+     * @param  string  $handle  チャンネルハンドル
+     * @return array|null チャンネル情報、見つからない場合null
      */
-    private function setApiKey()
+    public function getChannelByHandle(string $handle): ?array
     {
-        // 定義済みの場合は終了
-        if ($this->youtube) {
-            return;
-        }
-
-        $user = Auth::user();
-
-        if (! $user || ! $user->api_key) {
-            throw new Exception('APIキーが設定されていません。プロフィール画面でYouTube Data APIキーを登録してください。');
-        }
-
-        // モデルのcastsで自動復号化されるため、Crypt::decryptString()は不要
-        $this->client->setDeveloperKey($user->api_key);
-        $this->youtube = new Google_Service_YouTube($this->client);
+        return $this->youtubeApiService->getChannelByHandle($handle);
     }
 
-    public function getChannelByHandle($handle)
+    /**
+     * アーカイブとタイムスタンプを取得
+     *
+     * @param  string  $channelId  チャンネルID
+     * @return array アーカイブ配列（タイムスタンプ付き）
+     */
+    public function getArchivesAndTsItems(string $channelId): array
     {
-        $this->setApiKey();
+        $archives = $this->youtubeApiService->getArchives($channelId);
+        $rtnArchives = [];
 
-        $response = $this->youtube->channels->listChannels('snippet', [
-            'forHandle' => $handle,
-        ]);
-
-        // 検索結果が存在するかを確認
-        if (count($response->getItems()) > 0) {
-            $channel = $response->getItems()[0];
-
-            // 安全なアクセサーメソッドを使用
-            $snippet = $channel->getSnippet();
-            $thumbnails = $snippet ? $snippet->getThumbnails() : null;
-            $defaultThumb = $thumbnails ? ($thumbnails->getDefault() ? $thumbnails->getDefault()->getUrl() : null) : null;
-
-            return [
-                'title' => $snippet ? $snippet->getTitle() : '',
-                'channel_id' => $channel->getId(),
-                'thumbnail' => $defaultThumb ?? '',
-            ];
-        }
-
-        return null; // 該当するチャンネルが見つからない場合
-    }
-
-    public function getArchivesAndTsItems($channel_id)
-    {
-        $this->setApiKey();
-
-        $archives = $this->getArchives($channel_id);
-        $rtn_archives = [];
         foreach ($archives as &$archive) {
             // 概要欄に存在するタイムスタンプをts_itemsとして取得する
             // 概要欄なので、comment_idにvideo_idを設定している
             // typeがあるんだからいいじゃないかという気がするがchangeListの管理方法とズレているためこんなことになっている
-            $archive['ts_items'] = $this->getTimeStampsFromText(
+            $archive['ts_items'] = $this->timestampExtractorService->extractTimestamps(
                 $archive['video_id'],
                 '1', // description
                 $archive['description'],
                 $archive['video_id'],
             );
+
             // 歌枠の場合は一旦表示にする
-            $archive['is_display'] = $this->isSingingStream($archive['title']);
+            $archive['is_display'] = $this->videoAnalyzerService->isSingingStream($archive['title']);
+
             // コメントを個別取得のみにする場合はここをコメントアウト
             // 以下の場合にコメントを検索する
             // 概要欄にタイムスタンプが1件以下（過去のコピペなどで0:00:00が残っている場合がある）
             // かつ、歌枠の場合（タイトルに特定の文字列が含まれる場合）
             if ((empty($archive['ts_items']) || count($archive['ts_items']) <= 1) && $archive['is_display']) {
-                $comment_ts_items = $this->getTimeStampsFromComments($archive['video_id']);
-                foreach ($comment_ts_items as $ts_item) {
-                    $archive['ts_items'][] = $ts_item;
-                }
-            }
-            $this->updateDisplayTsItems($archive['ts_items']);
-
-            $rtn_archives[] = $archive;
-        }
-
-        return $rtn_archives;
-    }
-
-    private function getArchives($channel_id)
-    {
-        // チャンネルIDの先頭2文字をUUに置き換える
-        $playlist_id = 'UU'.substr($channel_id, 2);
-
-        // nextPageTokenが取得できなくなるまでループ
-        $maxResults = App::environment('local') ? config('utils.page') : 50;
-        $response = null;
-        $archives = [];
-        do {
-            $response = $this->youtube->playlistItems->listPlaylistItems('snippet', [
-                'playlistId' => $playlist_id,
-                'maxResults' => $maxResults,
-                'pageToken' => $response ? $response->getNextPageToken() : '',
-            ]);
-
-            if (is_array($response->getItems())) {
-                foreach ($response->getItems() as $item) {
-                    $snippet = $item->getSnippet();
-                    $resourceId = $snippet?->getResourceId();
-                    $mediumThumb = $snippet?->getThumbnails()?->getMedium()?->getUrl() ?? '';
-
-                    $archives[] = [
-                        'id' => Str::ulid(),
-                        'channel_id' => $channel_id,
-                        'video_id' => $resourceId?->getVideoId() ?? '',
-                        'title' => $snippet?->getTitle() ?? '',
-                        'thumbnail' => $mediumThumb,
-                        'is_public' => true,
-                        'is_display' => true,
-                        'published_at' => ($snippet && ($publishedAt = $snippet->getPublishedAt()))
-                            ? Carbon::parse($publishedAt)->format('Y-m-d H:i:s')
-                            : now()->format('Y-m-d H:i:s'),
-                        'comments_updated_at' => today(),
-                        'description' => $snippet?->getDescription() ?? '',
-                    ];
-                }
-            }
-            if (App::environment('local') && count($archives) >= config('utils.max_archive_count')) {
-                break;
-            }
-        } while ($response->getNextPageToken());
-
-        return $archives;
-    }
-
-    private function getTimeStampsFromText($video_id, $type, $description, $comment_id): array
-    {
-        // 引数のバリデーション
-        // 最低限のチェック
-        if (! is_string($video_id) || ! is_string($description)) {
-            // 無効なデータが来た場合、空の結果を返却
-            error_log('Invalid video_id or description: '
-                .var_export($video_id, true).', '.var_export($description, true));
-
-            return [];
-        }
-
-        if (! in_array($type, ['1', '2'])) {
-            // タイプが不正ならデフォルト値にする（例えば1）
-            error_log('Invalid type: '.var_export($type, true));
-
-            return [];
-        }
-
-        // 正規表現でタイムスタンプを抽出 (MM:SS または HH:MM:SS)
-        $pattern = '/\b(\d{1,2}:\d{2}(?::\d{2})?)\b/';
-        $lines = explode("\n", $description); // 改行で分割
-        $results = [];
-
-        foreach ($lines as $line) {
-            // 各行からタイムスタンプを抽出
-            if (preg_match($pattern, $line, $matches)) {
-                $timestamp = $matches[1];                              // タイムスタンプ部分
-                $comment = trim(str_replace($timestamp, '', $line)); // タイムスタンプを除外した部分
-                // 先頭の全角スペースを除外
-                $comment = \App\Helpers\TextNormalizer::trimFullwidthSpace($comment);
-
-                // 結果に追加
-                $results[] = [
-                    'id' => Str::ulid(),
-                    'comment_id' => $comment_id,
-                    'video_id' => $video_id,
-                    'type' => $type,
-                    'ts_text' => $timestamp,
-                    'ts_num' => $this->timestampToSeconds($timestamp),
-                    'text' => $comment,
-                ];
-            }
-        }
-
-        return $results;
-    }
-
-    private function timestampToSeconds($timestamp): int
-    {
-        $parts = explode(':', $timestamp);
-        $count = count($parts);
-
-        if ($count === 2) {
-            return ($parts[0] * 60) + $parts[1];
-        } elseif ($count === 3) {
-            return ($parts[0] * 3600) + ($parts[1] * 60) + $parts[2];
-        }
-
-        return 0; // 不正なフォーマットの場合
-    }
-
-    public function getTimeStampsFromComments($video_id)
-    {
-        $this->setApiKey();
-
-        $comments = [];
-        $response = null;
-        do {
-            // リクエストパラメータを設定
-            $params = [
-                'videoId' => $video_id,
-                'part' => 'snippet,replies', // コメントのスニペットとリプライを取得
-                'maxResults' => 100,               // 1回のリクエストで取得するコメント数
-                'pageToken' => $response ? $response->getNextPageToken() : '',
-            ];
-
-            try {
-                // コメントスレッドを取得
-                $response = $this->youtube->commentThreads->listCommentThreads('snippet', $params);
-            } catch (Exception $e) {
-                // コメントが無効な場合はスキップ
-                if (strpos($e->getMessage(), 'has disabled comments') !== false) {
-                    Log::info('YouTube API: Comments disabled for video', [
-                        'video_id' => $video_id,
-                    ]);
-                    break; // コメントが無効の場合はループを抜ける
-                } else {
-                    Log::error('YouTube API: Failed to fetch comments', [
-                        'video_id' => $video_id,
-                        'error' => $e->getMessage(),
-                        'code' => $e->getCode(),
-                    ]);
-                    break; // その他のエラーもループを抜ける
+                $commentTsItems = $this->getTimeStampsFromComments($archive['video_id']);
+                foreach ($commentTsItems as $tsItem) {
+                    $archive['ts_items'][] = $tsItem;
                 }
             }
 
-            // レスポンスがない場合はスキップ
-            if (! $response || ! $response->getItems()) {
-                break;
-            }
+            $this->archiveProcessorService->updateDisplayTsItems($archive['ts_items']);
 
-            // 各コメントを処理
-            foreach ($response->getItems() as $item) {
-                $commentId = $item->getId();
-                $snippet = $item->getSnippet();
-                $topLevelComment = $snippet ? $snippet->getTopLevelComment() : null;
-                $topLevelSnippet = $topLevelComment ? $topLevelComment->getSnippet() : null;
-                $textOriginal = $topLevelSnippet ? $topLevelSnippet->getTextOriginal() : '';
+            $rtnArchives[] = $archive;
+        }
 
-                $comments[] = [
-                    'id' => $commentId,
-                    'description' => $textOriginal,
-                ];
+        return $rtnArchives;
+    }
 
-                // // リプライコメントがある場合
-                // $replies = $item->getReplies();
-                // if ($replies && $replies->getComments()) {
-                //     foreach ($replies->getComments() as $reply) {
-                //         $comments[] = $reply['snippet']['textOriginal'];
-                //     }
-                // }
-                // いやリプライにタイムスタンプ置くやつなんておらんやろ
-            }
-            // 次のページトークンを取得
-        } while ($response && $response->getNextPageToken());
+    /**
+     * コメントからタイムスタンプを取得
+     *
+     * @param  string  $videoId  動画ID
+     * @return array タイムスタンプ配列
+     */
+    public function getTimeStampsFromComments(string $videoId): array
+    {
+        $comments = $this->youtubeApiService->getComments($videoId);
 
-        $rtn_ts_items = [];
+        $rtnTsItems = [];
         foreach ($comments as $comment) {
-            $ts_items = $this->getTimeStampsFromText(
-                $video_id,
+            $tsItems = $this->timestampExtractorService->extractTimestamps(
+                $videoId,
                 '2', // comment
                 $comment['description'],
                 $comment['id'],
             );
-            foreach ($ts_items as $ts_item) {
-                $rtn_ts_items[] = $ts_item;
+            foreach ($tsItems as $tsItem) {
+                $rtnTsItems[] = $tsItem;
             }
         }
 
-        return $rtn_ts_items;
-    }
-
-    private function isSingingStream(string $title): bool
-    {
-        // 特定の歌��タイトルに含まれるかを判定する
-        $keywords = ['singing stream', '歌枠', 'カラオケ', 'karaoke'];
-        foreach ($keywords as $keyword) {
-            if (str_contains(strtolower($title), $keyword)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private function updateDisplayTsItems(array &$ts_items): void
-    {
-        if (empty($ts_items)) {
-            return;
-        }
-
-        // comment_idごとの出現回数をカウント
-        $count_by_comment_id = [];
-        foreach ($ts_items as &$item) {
-            $item['is_display'] = '0';
-            $comment_id = $item['comment_id'];
-            $count_by_comment_id[$comment_id] = ($count_by_comment_id[$comment_id] ?? 0) + 1;
-        }
-
-        // 最も多い comment_id を取得
-        $max_count = max($count_by_comment_id);
-        // 1件しかない場合は初期表示なしとする
-        if ($max_count > 1) {
-            $most_frequent_comment_ids = array_keys($count_by_comment_id, $max_count, true);
-            // タイムスタンプが同数の場合も考えられるが先勝ちとする
-            if (count($most_frequent_comment_ids) > 0) {
-                // is_display を更新
-                foreach ($ts_items as &$item) {
-                    $item['is_display'] = ($item['comment_id'] === $most_frequent_comment_ids[0]);
-                }
-            }
-        }
+        return $rtnTsItems;
     }
 }


### PR DESCRIPTION
## 概要

Issue #260 に対応し、YouTubeServiceの肥大化を解消するため、責任を4つのサービスに分離しました。

Closes #260

## 変更内容

### 新規作成したサービスクラス

1. **YouTubeApiService** (`app/Services/YouTubeApiService.php`)
   - YouTube API通信のみを担当
   - チャンネル情報取得
   - アーカイブ一覧取得
   - コメント一覧取得

2. **TimestampExtractorService** (`app/Services/TimestampExtractorService.php`)
   - テキストからのタイムスタンプ抽出
   - タイムスタンプのフォーマット変換（MM:SS, HH:MM:SS → 秒数）
   - 正規表現による解析

3. **VideoAnalyzerService** (`app/Services/VideoAnalyzerService.php`)
   - 歌枠判定ロジック
   - 動画タイトルの分析

4. **ArchiveProcessorService** (`app/Services/ArchiveProcessorService.php`)
   - タイムスタンプの表示/非表示判定
   - comment_idごとの集計処理

### YouTubeServiceのリファクタリング

- **行数**: 348行 → 112行（236行削減、約68%削減）
- **責任の明確化**: 各専門サービスを統合する調整役に特化
- **依存性注入**: 4つのサービスをコンストラクタで注入
- **メソッド構成**:
  - `getChannelByHandle()` → YouTubeApiServiceに委譲
  - `getArchivesAndTsItems()` → 各サービスを統合して処理
  - `getTimeStampsFromComments()` → 各サービスを統合して処理

## 効果

- 各サービスの責任が明確化（Single Responsibility Principle）
- テスタビリティの向上
- コードの再利用性向上
- 将来的な機能追加の容易化
- 保守性の大幅向上

## テスト結果

- ✅ 全192テストが成功
- ✅ 既存の動作を維持
- ✅ コードスタイルチェック通過
- ✅ ビルド成功

## 備考

- 各サービスは独立した責任を持ち、単体でテスト可能
- YouTubeServiceは高レベルの調整役として機能
- API通信、データ抽出、分析、処理が明確に分離され、将来の拡張が容易に

🤖 Generated with [Claude Code](https://claude.com/claude-code)