### PR TITLE
refactor: normalize.jsの分割とコンポーネント化

### DIFF
--- a/resources/js/songs/components/Pagination.js
+++ b/resources/js/songs/components/Pagination.js
@@ -1,0 +1,100 @@
+import { BUTTON_STYLES } from '../utils/constants.js';
+
+/**
+ * ページネーションコンポーネント
+ */
+export class Pagination {
+    /**
+     * ページネーションボタンを作成
+     * @param {string} label - ボタンラベル
+     * @param {number} targetPage - 遷移先ページ
+     * @param {boolean} isEnabled - ボタンが有効かどうか
+     * @param {Function} onPageChange - ページ変更時のコールバック
+     * @returns {HTMLButtonElement} ボタン要素
+     */
+    static createButton(label, targetPage, isEnabled, onPageChange) {
+        const btn = document.createElement('button');
+        btn.textContent = label;
+        btn.className = isEnabled ? BUTTON_STYLES.btnClass : BUTTON_STYLES.disabledBtnClass;
+        btn.disabled = !isEnabled;
+
+        if (isEnabled) {
+            btn.addEventListener('click', () => {
+                onPageChange(targetPage);
+            });
+        }
+
+        return btn;
+    }
+
+    /**
+     * ページネーションUIを描画
+     * @param {HTMLElement} container - 描画先コンテナ
+     * @param {Object} data - ページネーションデータ
+     * @param {number} data.current_page - 現在のページ
+     * @param {number} data.last_page - 最終ページ
+     * @param {number} data.total - 全件数
+     * @param {Function} onPageChange - ページ変更時のコールバック
+     */
+    static render(container, data, onPageChange) {
+        container.innerHTML = '';
+
+        if (data.last_page <= 1) {
+            // ページが1ページのみの場合も件数を表示
+            if (data.total !== undefined) {
+                const totalInfo = document.createElement('span');
+                totalInfo.textContent = `全${data.total}件`;
+                totalInfo.className = 'px-3 py-1 text-sm font-medium text-gray-600 dark:text-gray-400';
+                container.appendChild(totalInfo);
+            }
+            return;
+        }
+
+        const currentPage = parseInt(data.current_page, 10);
+        const lastPage = parseInt(data.last_page, 10);
+
+        // バリデーション
+        if (Number.isNaN(currentPage) || Number.isNaN(lastPage)) {
+            console.error('Invalid page numbers:', { currentPage, lastPage });
+            return;
+        }
+
+        // 前へ系のボタン
+        const prevButtons = [
+            { label: '最初', targetPage: 1, enableCondition: currentPage > 1 },
+            { label: '-10', targetPage: currentPage - 10, enableCondition: currentPage > 10 },
+            { label: '-5', targetPage: currentPage - 5, enableCondition: currentPage > 5 },
+            { label: '前へ', targetPage: currentPage - 1, enableCondition: currentPage > 1 },
+        ];
+
+        prevButtons.forEach(({ label, targetPage, enableCondition }) => {
+            container.appendChild(this.createButton(label, targetPage, enableCondition, onPageChange));
+        });
+
+        // ページ情報
+        const pageInfo = document.createElement('span');
+        pageInfo.textContent = `${currentPage} / ${lastPage}`;
+        pageInfo.className = 'px-3 py-1 text-sm font-medium';
+        container.appendChild(pageInfo);
+
+        // 件数表示を追加
+        if (data.total !== undefined) {
+            const totalInfo = document.createElement('span');
+            totalInfo.textContent = `(全${data.total}件)`;
+            totalInfo.className = 'px-3 py-1 text-sm text-gray-600 dark:text-gray-400';
+            container.appendChild(totalInfo);
+        }
+
+        // 次へ系のボタン
+        const nextButtons = [
+            { label: '次へ', targetPage: currentPage + 1, enableCondition: currentPage < lastPage },
+            { label: '+5', targetPage: currentPage + 5, enableCondition: currentPage + 5 <= lastPage },
+            { label: '+10', targetPage: currentPage + 10, enableCondition: currentPage + 10 <= lastPage },
+            { label: '最後', targetPage: lastPage, enableCondition: currentPage < lastPage },
+        ];
+
+        nextButtons.forEach(({ label, targetPage, enableCondition }) => {
+            container.appendChild(this.createButton(label, targetPage, enableCondition, onPageChange));
+        });
+    }
+}

--- a/resources/js/songs/components/SimilarSongsDialog.js
+++ b/resources/js/songs/components/SimilarSongsDialog.js
@@ -1,0 +1,121 @@
+/**
+ * 類似曲確認ダイアログコンポーネント
+ */
+export class SimilarSongsDialog {
+    /**
+     * HTMLエスケープ
+     * @param {string} str - エスケープする文字列
+     * @returns {string} エスケープされた文字列
+     */
+    static escapeHtml(str) {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
+    }
+
+    /**
+     * ダイアログを表示
+     * @param {Array} similarSongs - 類似曲の配列
+     * @param {Object} inputData - 入力された楽曲データ
+     * @returns {Promise<{action: string, songId?: string}>} ユーザーの選択結果
+     */
+    static show(similarSongs, inputData) {
+        return new Promise((resolve) => {
+            const escapeHtml = this.escapeHtml;
+
+            // ダイアログのHTMLを動的に作成
+            const dialogHtml = `
+                <div id="similarSongsDialog" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+                    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto">
+                        <h3 class="text-lg font-bold mb-4 text-gray-900 dark:text-white">類似する楽曲マスタが見つかりました</h3>
+
+                        <div class="mb-4 p-3 bg-blue-50 dark:bg-blue-900 rounded">
+                            <p class="text-sm text-gray-700 dark:text-gray-300">
+                                登録しようとしている楽曲: <strong>${escapeHtml(inputData.title)} / ${escapeHtml(inputData.artist)}</strong>
+                            </p>
+                        </div>
+
+                        <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                            類似度の高い楽曲が ${escapeHtml(String(similarSongs.length))} 件見つかりました。既存のマスタを使用するか、新規登録するか選択してください。
+                        </p>
+
+                        <div id="similarSongsList" class="space-y-2 mb-6 max-h-60 overflow-y-auto">
+                            ${similarSongs.map((item, index) => `
+                                <div class="similar-song-item p-3 border rounded cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 dark:border-gray-600" data-song-id="${escapeHtml(item.song.id)}" data-index="${escapeHtml(String(index))}">
+                                    <div class="flex justify-between items-start">
+                                        <div>
+                                            <div class="font-medium text-sm text-gray-900 dark:text-white">${escapeHtml(item.song.title)}</div>
+                                            <div class="text-xs text-gray-500 dark:text-gray-400">${escapeHtml(item.song.artist)}</div>
+                                        </div>
+                                        <div class="text-right">
+                                            <div class="text-xs font-medium text-green-600 dark:text-green-400">類似度: ${escapeHtml(String(item.similarity))}%</div>
+                                            <div class="text-xs text-gray-500 dark:text-gray-400">
+                                                曲名: ${escapeHtml(String(item.title_similarity))}% / アーティスト: ${escapeHtml(String(item.artist_similarity))}%
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            `).join('')}
+                        </div>
+
+                        <div class="flex gap-2 justify-end">
+                            <button id="useExistingSongBtn" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50" disabled>
+                                選択した楽曲を使用
+                            </button>
+                            <button id="forceCreateNewBtn" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                                新規登録
+                            </button>
+                            <button id="cancelDialogBtn" class="px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-400 dark:hover:bg-gray-500">
+                                キャンセル
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            `;
+
+            // ダイアログを追加
+            document.body.insertAdjacentHTML('beforeend', dialogHtml);
+
+            const dialog = document.getElementById('similarSongsDialog');
+            const useExistingBtn = document.getElementById('useExistingSongBtn');
+            const forceCreateBtn = document.getElementById('forceCreateNewBtn');
+            const cancelBtn = document.getElementById('cancelDialogBtn');
+
+            let selectedSongId = null;
+
+            // 楽曲選択
+            dialog.querySelectorAll('.similar-song-item').forEach(item => {
+                item.addEventListener('click', () => {
+                    // 選択状態をリセット
+                    dialog.querySelectorAll('.similar-song-item').forEach(i => {
+                        i.classList.remove('bg-blue-100', 'dark:bg-blue-900', 'border-blue-500');
+                    });
+
+                    // 選択状態を適用
+                    item.classList.add('bg-blue-100', 'dark:bg-blue-900', 'border-blue-500');
+                    selectedSongId = item.dataset.songId;
+                    useExistingBtn.disabled = false;
+                });
+            });
+
+            // 既存楽曲を使用
+            useExistingBtn.addEventListener('click', () => {
+                if (!selectedSongId) return;
+                dialog.remove();
+                resolve({ action: 'use_existing', songId: selectedSongId });
+            });
+
+            // 新規登録
+            forceCreateBtn.addEventListener('click', () => {
+                dialog.remove();
+                resolve({ action: 'force_create' });
+            });
+
+            // キャンセル
+            cancelBtn.addEventListener('click', () => {
+                dialog.remove();
+                resolve({ action: 'cancel' });
+            });
+        });
+    }
+}

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -1,5 +1,10 @@
 import axios from 'axios';
 import toast from '../utils/toast.js';
+import { CONSTANTS } from './utils/constants.js';
+import { timestampApiService } from './services/TimestampApiService.js';
+import { songApiService } from './services/SongApiService.js';
+import { SimilarSongsDialog } from './components/SimilarSongsDialog.js';
+import { Pagination } from './components/Pagination.js';
 
 // axiosの設定: クロスオリジンリクエストでクッキーを送信
 axios.defaults.withCredentials = true;
@@ -17,15 +22,6 @@ class TimestampNormalization {
         this.currentSearchQuery = ''; // 検索条件を保持
         this.searchTimeout = null;
         this.unlinkedOnly = false;
-
-        // 定数定義
-        this.CONSTANTS = {
-            MAX_TIMESTAMP_WIDTH: '200px',
-            MAX_ARCHIVE_TITLE_WIDTH: '150px',
-            MAX_STATUS_LENGTH: 30,
-            MAX_SELECTION_TEXT_LENGTH: 100,
-            YOUTUBE_BASE_URL: 'https://youtu.be/'
-        };
 
         this.init();
     }
@@ -49,32 +45,15 @@ class TimestampNormalization {
 
         // 未連携フィルター
         document.getElementById('unlinkedOnlyBtn').addEventListener('click', () => {
-            this.unlinkedOnly = !this.unlinkedOnly;
-            const btn = document.getElementById('unlinkedOnlyBtn');
-            if (this.unlinkedOnly) {
-                btn.classList.add('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
-                btn.classList.remove('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
-            } else {
-                btn.classList.remove('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
-                btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
-            }
-            this.loadTimestamps(1, this.currentSearchQuery);
+            this.toggleUnlinkedFilter();
         });
 
         // 全選択・全選択解除
-        document.getElementById('selectAllBtn').addEventListener('click', () => {
-            this.selectAll();
-        });
-
-        document.getElementById('deselectAllBtn').addEventListener('click', () => {
-            this.deselectAll();
-        });
+        document.getElementById('selectAllBtn').addEventListener('click', () => this.selectAll());
+        document.getElementById('deselectAllBtn').addEventListener('click', () => this.deselectAll());
 
         // Spotify検索
-        document.getElementById('searchSpotifyBtn').addEventListener('click', () => {
-            this.searchSpotify();
-        });
-
+        document.getElementById('searchSpotifyBtn').addEventListener('click', () => this.searchSpotify());
         document.getElementById('spotifySearch').addEventListener('keypress', (e) => {
             if (e.key === 'Enter') {
                 e.preventDefault();
@@ -120,49 +99,53 @@ class TimestampNormalization {
 
         // タブ切り替え
         document.querySelectorAll('.tab-button').forEach(button => {
-            button.addEventListener('click', (e) => {
-                this.showTab(e.target.id);
-            });
+            button.addEventListener('click', (e) => this.showTab(e.target.id));
         });
 
         // アクション
-        document.getElementById('linkSongBtn').addEventListener('click', () => {
-            this.linkTimestamps();
-        });
+        document.getElementById('linkSongBtn').addEventListener('click', () => this.linkTimestamps());
+        document.getElementById('markAsNotSongBtn').addEventListener('click', () => this.markAsNotSong());
+        document.getElementById('unmarkAsNotSongBtn').addEventListener('click', () => this.unmarkAsNotSong());
+        document.getElementById('unlinkBtn').addEventListener('click', () => this.unlinkTimestamps());
+        document.getElementById('clearSelectionBtn').addEventListener('click', () => this.clearSelection());
+    }
 
-        document.getElementById('markAsNotSongBtn').addEventListener('click', () => {
-            this.markAsNotSong();
-        });
+    toggleUnlinkedFilter() {
+        this.unlinkedOnly = !this.unlinkedOnly;
+        const btn = document.getElementById('unlinkedOnlyBtn');
+        if (this.unlinkedOnly) {
+            btn.classList.add('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
+            btn.classList.remove('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
+        } else {
+            btn.classList.remove('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
+            btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
+        }
+        this.loadTimestamps(1, this.currentSearchQuery);
+    }
 
-        document.getElementById('unmarkAsNotSongBtn').addEventListener('click', () => {
-            this.unmarkAsNotSong();
-        });
-
-        document.getElementById('unlinkBtn').addEventListener('click', () => {
-            this.unlinkTimestamps();
-        });
-
-        document.getElementById('clearSelectionBtn').addEventListener('click', () => {
-            this.clearSelection();
-        });
+    resetUnlinkedFilter() {
+        if (this.unlinkedOnly) {
+            this.unlinkedOnly = false;
+            const btn = document.getElementById('unlinkedOnlyBtn');
+            btn.classList.remove('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
+            btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
+        }
     }
 
     async loadTimestamps(page = 1, search = '') {
         try {
             this.showLoading();
-            const response = await axios.get('/api/songs/timestamps', {
-                params: {
-                    page,
-                    per_page: 50,
-                    search,
-                    unlinked_only: this.unlinkedOnly
-                }
+            const data = await timestampApiService.fetchTimestamps({
+                page,
+                per_page: 50,
+                search,
+                unlinked_only: this.unlinkedOnly
             });
 
-            const parsedPage = parseInt(response.data.current_page, 10);
+            const parsedPage = parseInt(data.current_page, 10);
             this.currentPage = Number.isNaN(parsedPage) ? 1 : parsedPage;
-            this.displayTimestamps(response.data.data);
-            this.displayPagination(response.data);
+            this.displayTimestamps(data.data);
+            this.displayPagination(data);
         } catch (error) {
             console.error('タイムスタンプの取得に失敗しました:', error);
             toast.error('タイムスタンプの取得に失敗しました。');
@@ -180,14 +163,15 @@ class TimestampNormalization {
             return;
         }
 
-        /**
-         * タイムスタンプをソート
-         * - 楽曲マスタに紐づいている場合: "楽曲名 - アーティスト名" でソート
-         * - 未紐づけの場合: 元のテキストでソート
-         * - 日本語対応のlocaleCompareを使用
-         * - 同一ソートキーの場合はIDで二次ソート
-         */
-        const sortedTimestamps = [...timestamps]
+        const sortedTimestamps = this.sortTimestamps(timestamps);
+
+        sortedTimestamps.forEach(ts => {
+            container.appendChild(this.createTimestampElement(ts));
+        });
+    }
+
+    sortTimestamps(timestamps) {
+        return [...timestamps]
             .map(ts => ({
                 timestamp: ts,
                 sortKey: ts.song
@@ -199,192 +183,118 @@ class TimestampNormalization {
                 return comparison !== 0 ? comparison : a.timestamp.id - b.timestamp.id;
             })
             .map(item => item.timestamp);
+    }
 
-        sortedTimestamps.forEach(ts => {
-            const div = document.createElement('div');
-            const isSelected = this.selectedTimestamps.some(t => t.id === ts.id);
+    createTimestampElement(ts) {
+        const div = document.createElement('div');
+        const isSelected = this.selectedTimestamps.some(t => t.id === ts.id);
 
-            div.className = `p-2 border rounded flex items-center gap-2 ${
-                isSelected ? 'bg-blue-100 dark:bg-blue-900 border-blue-500' : 'border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
-            }`;
+        div.className = `p-2 border rounded flex items-center gap-2 ${
+            isSelected ? 'bg-blue-100 dark:bg-blue-900 border-blue-500' : 'border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+        }`;
 
-            // チェックボックス
-            const checkbox = document.createElement('input');
-            checkbox.type = 'checkbox';
-            checkbox.checked = isSelected;
-            checkbox.className = 'flex-shrink-0';
-            checkbox.addEventListener('change', (e) => {
-                e.stopPropagation();
-                this.toggleTimestampSelection(ts);
-            });
-
-            const contentDiv = document.createElement('div');
-            contentDiv.className = 'flex-1 cursor-pointer min-w-0 flex items-center gap-2 overflow-hidden';
-            contentDiv.addEventListener('click', () => {
-                this.toggleTimestampSelection(ts);
-            });
-
-            // タイムスタンプテキスト（最大200px、他の要素より優先的に表示）
-            const textDiv = document.createElement('div');
-            textDiv.className = 'font-medium text-sm truncate flex-shrink-0';
-            textDiv.style.maxWidth = this.CONSTANTS.MAX_TIMESTAMP_WIDTH;
-            textDiv.textContent = ts.text;
-            textDiv.title = ts.text; // ホバーで全文表示
-
-            contentDiv.appendChild(textDiv);
-
-            // 動画タイトル
-            const archiveTitle = document.createElement('span');
-            archiveTitle.textContent = ts.archive?.title || '';
-            archiveTitle.className = 'text-xs text-gray-500 dark:text-gray-400 truncate';
-            archiveTitle.style.maxWidth = this.CONSTANTS.MAX_ARCHIVE_TITLE_WIDTH;
-            archiveTitle.title = ts.archive?.title || '';
-            contentDiv.appendChild(archiveTitle);
-
-            // ステータス
-            const statusDiv = document.createElement('div');
-            statusDiv.className = 'text-xs flex-shrink-0';
-
-            if (ts.is_not_song) {
-                statusDiv.className += ' text-red-600 dark:text-red-400';
-                statusDiv.textContent = '楽曲ではない';
-            } else if (ts.song) {
-                statusDiv.className += ' text-green-600 dark:text-green-400';
-                const statusText = `${ts.song.title} / ${ts.song.artist}`;
-                statusDiv.textContent = statusText.length > this.CONSTANTS.MAX_STATUS_LENGTH
-                    ? statusText.substring(0, this.CONSTANTS.MAX_STATUS_LENGTH) + '...'
-                    : statusText;
-                statusDiv.title = `${ts.song.title} / ${ts.song.artist}`;
-            } else {
-                statusDiv.className += ' text-gray-400';
-                statusDiv.textContent = '未紐づけ';
-            }
-
-            contentDiv.appendChild(statusDiv);
-
-            // コピーボタン
-            const copyBtn = document.createElement('button');
-            copyBtn.className = 'p-1.5 text-gray-600 dark:text-gray-400 bg-gray-200 dark:bg-gray-700 rounded hover:bg-gray-300 dark:hover:bg-gray-600 flex-shrink-0 transition-colors';
-            copyBtn.title = 'コピー';
-            copyBtn.innerHTML = `
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                </svg>
-            `;
-
-            const originalIcon = copyBtn.innerHTML;
-            const checkIcon = `
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-            `;
-
-            copyBtn.addEventListener('click', (e) => {
-                e.stopPropagation();
-                navigator.clipboard.writeText(ts.text);
-                copyBtn.innerHTML = checkIcon;
-                copyBtn.title = 'コピー済';
-                setTimeout(() => {
-                    copyBtn.innerHTML = originalIcon;
-                    copyBtn.title = 'コピー';
-                }, 1000);
-            });
-
-            div.appendChild(checkbox);
-            div.appendChild(contentDiv);
-            div.appendChild(copyBtn);
-
-            container.appendChild(div);
+        // チェックボックス
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.checked = isSelected;
+        checkbox.className = 'flex-shrink-0';
+        checkbox.addEventListener('change', (e) => {
+            e.stopPropagation();
+            this.toggleTimestampSelection(ts);
         });
+
+        const contentDiv = document.createElement('div');
+        contentDiv.className = 'flex-1 cursor-pointer min-w-0 flex items-center gap-2 overflow-hidden';
+        contentDiv.addEventListener('click', () => this.toggleTimestampSelection(ts));
+
+        // タイムスタンプテキスト
+        const textDiv = document.createElement('div');
+        textDiv.className = 'font-medium text-sm truncate flex-shrink-0';
+        textDiv.style.maxWidth = CONSTANTS.MAX_TIMESTAMP_WIDTH;
+        textDiv.textContent = ts.text;
+        textDiv.title = ts.text;
+        contentDiv.appendChild(textDiv);
+
+        // 動画タイトル
+        const archiveTitle = document.createElement('span');
+        archiveTitle.textContent = ts.archive?.title || '';
+        archiveTitle.className = 'text-xs text-gray-500 dark:text-gray-400 truncate';
+        archiveTitle.style.maxWidth = CONSTANTS.MAX_ARCHIVE_TITLE_WIDTH;
+        archiveTitle.title = ts.archive?.title || '';
+        contentDiv.appendChild(archiveTitle);
+
+        // ステータス
+        const statusDiv = this.createStatusElement(ts);
+        contentDiv.appendChild(statusDiv);
+
+        // コピーボタン
+        const copyBtn = this.createCopyButton(ts.text);
+
+        div.appendChild(checkbox);
+        div.appendChild(contentDiv);
+        div.appendChild(copyBtn);
+
+        return div;
+    }
+
+    createStatusElement(ts) {
+        const statusDiv = document.createElement('div');
+        statusDiv.className = 'text-xs flex-shrink-0';
+
+        if (ts.is_not_song) {
+            statusDiv.className += ' text-red-600 dark:text-red-400';
+            statusDiv.textContent = '楽曲ではない';
+        } else if (ts.song) {
+            statusDiv.className += ' text-green-600 dark:text-green-400';
+            const statusText = `${ts.song.title} / ${ts.song.artist}`;
+            statusDiv.textContent = statusText.length > CONSTANTS.MAX_STATUS_LENGTH
+                ? statusText.substring(0, CONSTANTS.MAX_STATUS_LENGTH) + '...'
+                : statusText;
+            statusDiv.title = `${ts.song.title} / ${ts.song.artist}`;
+        } else {
+            statusDiv.className += ' text-gray-400';
+            statusDiv.textContent = '未紐づけ';
+        }
+
+        return statusDiv;
+    }
+
+    createCopyButton(text) {
+        const copyBtn = document.createElement('button');
+        copyBtn.className = 'p-1.5 text-gray-600 dark:text-gray-400 bg-gray-200 dark:bg-gray-700 rounded hover:bg-gray-300 dark:hover:bg-gray-600 flex-shrink-0 transition-colors';
+        copyBtn.title = 'コピー';
+        copyBtn.innerHTML = `
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+        `;
+
+        const originalIcon = copyBtn.innerHTML;
+        const checkIcon = `
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+        `;
+
+        copyBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            navigator.clipboard.writeText(text);
+            copyBtn.innerHTML = checkIcon;
+            copyBtn.title = 'コピー済';
+            setTimeout(() => {
+                copyBtn.innerHTML = originalIcon;
+                copyBtn.title = 'コピー';
+            }, 1000);
+        });
+
+        return copyBtn;
     }
 
     displayPagination(data) {
         const container = document.getElementById('timestampPagination');
-        container.innerHTML = '';
-
-        if (data.last_page <= 1) {
-            // ページが1ページのみの場合も件数を表示
-            if (data.total !== undefined) {
-                const totalInfo = document.createElement('span');
-                totalInfo.textContent = `全${data.total}件`;
-                totalInfo.className = 'px-3 py-1 text-sm font-medium text-gray-600 dark:text-gray-400';
-                container.appendChild(totalInfo);
-            }
-            return;
-        }
-
-        const currentPage = parseInt(data.current_page, 10);
-        const lastPage = parseInt(data.last_page, 10);
-
-        // バリデーション
-        if (Number.isNaN(currentPage) || Number.isNaN(lastPage)) {
-            console.error('Invalid page numbers:', { currentPage, lastPage });
-            return;
-        }
-
-        // ボタンのスタイル
-        const btnClass = 'px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 text-sm';
-        const disabledBtnClass = 'px-3 py-1 bg-gray-100 dark:bg-gray-800 rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed text-sm';
-
-        // ボタン作成ヘルパー関数
-        const createButton = (label, targetPage, isEnabled) => {
-            const btn = document.createElement('button');
-            btn.textContent = label;
-            btn.className = isEnabled ? btnClass : disabledBtnClass;
-            btn.disabled = !isEnabled;
-
-            if (isEnabled) {
-                btn.addEventListener('click', () => {
-                    this.loadTimestamps(targetPage, this.currentSearchQuery);
-                    // ページ切り替え時に一覧の先頭へスクロール
-                    document.getElementById('timestampsList').scrollTop = 0;
-                });
-            }
-
-            return btn;
-        };
-
-        // ボタン定義
-        const buttons = [
-            { label: '最初', targetPage: 1, showCondition: true, enableCondition: currentPage > 1 },
-            { label: '-10', targetPage: currentPage - 10, showCondition: true, enableCondition: currentPage > 10 },
-            { label: '-5', targetPage: currentPage - 5, showCondition: true, enableCondition: currentPage > 5 },
-            { label: '前へ', targetPage: currentPage - 1, showCondition: true, enableCondition: currentPage > 1 },
-        ];
-
-        // ボタンを追加
-        buttons.forEach(({ label, targetPage, showCondition, enableCondition }) => {
-            if (showCondition) {
-                container.appendChild(createButton(label, targetPage, enableCondition));
-            }
-        });
-
-        // ページ情報
-        const pageInfo = document.createElement('span');
-        pageInfo.textContent = `${currentPage} / ${lastPage}`;
-        pageInfo.className = 'px-3 py-1 text-sm font-medium';
-        container.appendChild(pageInfo);
-
-        // 件数表示を追加
-        if (data.total !== undefined) {
-            const totalInfo = document.createElement('span');
-            totalInfo.textContent = `(全${data.total}件)`;
-            totalInfo.className = 'px-3 py-1 text-sm text-gray-600 dark:text-gray-400';
-            container.appendChild(totalInfo);
-        }
-
-        // 次へ系のボタン
-        const nextButtons = [
-            { label: '次へ', targetPage: currentPage + 1, showCondition: true, enableCondition: currentPage < lastPage },
-            { label: '+5', targetPage: currentPage + 5, showCondition: true, enableCondition: currentPage + 5 <= lastPage },
-            { label: '+10', targetPage: currentPage + 10, showCondition: true, enableCondition: currentPage + 10 <= lastPage },
-            { label: '最後', targetPage: lastPage, showCondition: true, enableCondition: currentPage < lastPage },
-        ];
-
-        nextButtons.forEach(({ label, targetPage, showCondition, enableCondition }) => {
-            if (showCondition) {
-                container.appendChild(createButton(label, targetPage, enableCondition));
-            }
+        Pagination.render(container, data, (page) => {
+            this.loadTimestamps(page, this.currentSearchQuery);
+            document.getElementById('timestampsList').scrollTop = 0;
         });
     }
 
@@ -407,7 +317,6 @@ class TimestampNormalization {
     }
 
     selectAll() {
-        // 現在表示中のタイムスタンプを全て選択
         const timestampItems = document.querySelectorAll('#timestampsList > div');
         timestampItems.forEach((item) => {
             const checkbox = item.querySelector('input[type="checkbox"]');
@@ -429,64 +338,73 @@ class TimestampNormalization {
         const textSpan = document.getElementById('selectedText');
         const normalizedSpan = document.getElementById('selectedNormalized');
 
-        // 常に表示
         container.classList.remove('hidden');
 
         if (this.selectedTimestamps.length === 0) {
-            countSpan.textContent = '未選択';
-            textSpan.textContent = 'タイムスタンプを選択してください';
-            normalizedSpan.textContent = '';
-            document.getElementById('linkSongBtn').disabled = true;
-            document.getElementById('markAsNotSongBtn').disabled = true;
-            document.getElementById('unmarkAsNotSongBtn').disabled = true;
-            document.getElementById('unlinkBtn').disabled = true;
-
-            // 動画ボタンを無効化
-            this.updateVideoButton(false);
+            this.displayNoSelection(countSpan, textSpan, normalizedSpan);
         } else if (this.selectedTimestamps.length === 1) {
-            const ts = this.selectedTimestamps[0];
-            countSpan.textContent = '1件選択中';
-            textSpan.textContent = ts.text;
-            textSpan.title = ts.text; // ホバーで全文表示
-            normalizedSpan.textContent = `正規化: ${ts.normalized_text}`;
-            document.getElementById('markAsNotSongBtn').disabled = false;
-            document.getElementById('unmarkAsNotSongBtn').disabled = !ts.is_not_song;
-            document.getElementById('unlinkBtn').disabled = !ts.mapping;
-
-            // 動画情報の表示
-            if (ts.archive?.video_id) {
-                this.updateVideoButton(true, ts.archive.video_id, ts.ts_num, ts.archive.title || '');
-            } else {
-                this.updateVideoButton(false, null, null, '動画情報なし');
-            }
+            this.displaySingleSelection(countSpan, textSpan, normalizedSpan);
         } else {
-            countSpan.textContent = `${this.selectedTimestamps.length}件選択中`;
-            const joinedText = this.selectedTimestamps.map(t => t.text).join(', ');
-            // 長い文字列は切り詰める
-            if (joinedText.length > this.CONSTANTS.MAX_SELECTION_TEXT_LENGTH) {
-                textSpan.textContent = joinedText.substring(0, this.CONSTANTS.MAX_SELECTION_TEXT_LENGTH) + '...';
-                textSpan.title = joinedText; // ホバーで全文表示
-            } else {
-                textSpan.textContent = joinedText;
-                textSpan.title = joinedText;
-            }
-            normalizedSpan.textContent = '';
-            document.getElementById('markAsNotSongBtn').disabled = false;
-            // 選択されたタイムスタンプの中に is_not_song=true があるかチェック
-            const hasNotSong = this.selectedTimestamps.some(ts => ts.is_not_song);
-            document.getElementById('unmarkAsNotSongBtn').disabled = !hasNotSong;
-            document.getElementById('unlinkBtn').disabled = false;
-
-            // 動画ボタンを無効化
-            this.updateVideoButton(false);
+            this.displayMultipleSelection(countSpan, textSpan, normalizedSpan);
         }
 
-        // Spotify選択楽曲情報の表示
+        this.updateSpotifySelectedDisplay();
+        document.getElementById('linkSongBtn').disabled = !(this.selectedTimestamps.length > 0 && this.selectedSong);
+    }
+
+    displayNoSelection(countSpan, textSpan, normalizedSpan) {
+        countSpan.textContent = '未選択';
+        textSpan.textContent = 'タイムスタンプを選択してください';
+        normalizedSpan.textContent = '';
+        document.getElementById('linkSongBtn').disabled = true;
+        document.getElementById('markAsNotSongBtn').disabled = true;
+        document.getElementById('unmarkAsNotSongBtn').disabled = true;
+        document.getElementById('unlinkBtn').disabled = true;
+        this.updateVideoButton(false);
+    }
+
+    displaySingleSelection(countSpan, textSpan, normalizedSpan) {
+        const ts = this.selectedTimestamps[0];
+        countSpan.textContent = '1件選択中';
+        textSpan.textContent = ts.text;
+        textSpan.title = ts.text;
+        normalizedSpan.textContent = `正規化: ${ts.normalized_text}`;
+        document.getElementById('markAsNotSongBtn').disabled = false;
+        document.getElementById('unmarkAsNotSongBtn').disabled = !ts.is_not_song;
+        document.getElementById('unlinkBtn').disabled = !ts.mapping;
+
+        if (ts.archive?.video_id) {
+            this.updateVideoButton(true, ts.archive.video_id, ts.ts_num, ts.archive.title || '');
+        } else {
+            this.updateVideoButton(false, null, null, '動画情報なし');
+        }
+    }
+
+    displayMultipleSelection(countSpan, textSpan, normalizedSpan) {
+        countSpan.textContent = `${this.selectedTimestamps.length}件選択中`;
+        const joinedText = this.selectedTimestamps.map(t => t.text).join(', ');
+
+        if (joinedText.length > CONSTANTS.MAX_SELECTION_TEXT_LENGTH) {
+            textSpan.textContent = joinedText.substring(0, CONSTANTS.MAX_SELECTION_TEXT_LENGTH) + '...';
+        } else {
+            textSpan.textContent = joinedText;
+        }
+        textSpan.title = joinedText;
+        normalizedSpan.textContent = '';
+        document.getElementById('markAsNotSongBtn').disabled = false;
+
+        const hasNotSong = this.selectedTimestamps.some(ts => ts.is_not_song);
+        document.getElementById('unmarkAsNotSongBtn').disabled = !hasNotSong;
+        document.getElementById('unlinkBtn').disabled = false;
+        this.updateVideoButton(false);
+    }
+
+    updateSpotifySelectedDisplay() {
         const spotifySelectedDiv = document.getElementById('spotifySelected');
         if (this.selectedSpotifyTrack) {
             spotifySelectedDiv.classList.remove('hidden');
             const spotifyInfoDiv = document.getElementById('spotifySelectedInfo');
-            spotifyInfoDiv.textContent = '';  // クリア
+            spotifyInfoDiv.textContent = '';
 
             const titleSpan = document.createElement('span');
             titleSpan.className = 'font-medium';
@@ -503,9 +421,6 @@ class TimestampNormalization {
         } else {
             spotifySelectedDiv.classList.add('hidden');
         }
-
-        // 楽曲と紐づけボタンの有効化
-        document.getElementById('linkSongBtn').disabled = !(this.selectedTimestamps.length > 0 && this.selectedSong);
     }
 
     clearSelection() {
@@ -527,69 +442,61 @@ class TimestampNormalization {
         container.innerHTML = '<p class="text-gray-500 text-sm">検索中...</p>';
 
         try {
-            const response = await axios.get('/api/songs/search-spotify', {
-                params: { query, limit: 10 }
-            });
-
-            const tracks = response.data;
+            const tracks = await songApiService.searchSpotify(query, 10);
 
             if (tracks.length === 0) {
                 container.innerHTML = '<p class="text-gray-500 text-sm">検索結果がありません。</p>';
                 return;
             }
 
-            container.innerHTML = '';
-            tracks.forEach(track => {
-                const div = document.createElement('div');
-                const isSelected = this.selectedSpotifyTrack?.id === track.id;
-                div.className = `p-2 border rounded cursor-pointer ${
-                    isSelected
-                        ? 'bg-blue-100 dark:bg-blue-900 border-blue-500'
-                        : 'border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
-                }`;
-
-                const songInfo = document.createElement('div');
-                songInfo.className = 'text-sm truncate';
-
-                const titleSpan = document.createElement('span');
-                titleSpan.className = 'font-medium';
-                titleSpan.textContent = track.name;
-
-                const artistNames = track.artists.map(a => a.name).join(', ');
-                const separatorSpan = document.createElement('span');
-                separatorSpan.className = 'text-gray-500 dark:text-gray-400';
-                separatorSpan.textContent = ' / ' + artistNames;
-
-                songInfo.appendChild(titleSpan);
-                songInfo.appendChild(separatorSpan);
-                songInfo.title = `${track.name} / ${artistNames}`;
-
-                div.appendChild(songInfo);
-
-                div.addEventListener('click', () => {
-                    this.selectSpotifyTrack(track);
-                });
-
-                container.appendChild(div);
-            });
+            this.displaySpotifyTracks(container, tracks);
         } catch (error) {
             console.error('Spotify検索に失敗しました:', error);
             container.innerHTML = '<p class="text-red-500 text-sm">検索に失敗しました。</p>';
         }
     }
 
+    displaySpotifyTracks(container, tracks) {
+        container.innerHTML = '';
+        tracks.forEach(track => {
+            const div = document.createElement('div');
+            const isSelected = this.selectedSpotifyTrack?.id === track.id;
+            div.className = `p-2 border rounded cursor-pointer ${
+                isSelected
+                    ? 'bg-blue-100 dark:bg-blue-900 border-blue-500'
+                    : 'border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+            }`;
+
+            const songInfo = document.createElement('div');
+            songInfo.className = 'text-sm truncate';
+
+            const titleSpan = document.createElement('span');
+            titleSpan.className = 'font-medium';
+            titleSpan.textContent = track.name;
+
+            const artistNames = track.artists.map(a => a.name).join(', ');
+            const separatorSpan = document.createElement('span');
+            separatorSpan.className = 'text-gray-500 dark:text-gray-400';
+            separatorSpan.textContent = ' / ' + artistNames;
+
+            songInfo.appendChild(titleSpan);
+            songInfo.appendChild(separatorSpan);
+            songInfo.title = `${track.name} / ${artistNames}`;
+
+            div.appendChild(songInfo);
+            div.addEventListener('click', () => this.selectSpotifyTrack(track));
+
+            container.appendChild(div);
+        });
+    }
+
     async selectSpotifyTrack(track) {
         this.selectedSpotifyTrack = track;
 
-        // 楽曲マスタに登録
-        const title = track.name;
-        const artist = track.artists.map(a => a.name).join(', ');
-        const spotifyTrackId = track.id;
-
         await this.registerSong({
-            title,
-            artist,
-            spotify_track_id: spotifyTrackId,
+            title: track.name,
+            artist: track.artists.map(a => a.name).join(', '),
+            spotify_track_id: track.id,
             spotify_data: track
         });
     }
@@ -606,67 +513,21 @@ class TimestampNormalization {
         await this.registerSong({ title, artist });
     }
 
-    /**
-     * 楽曲マスタを登録（完全一致・類似度チェック対応）
-     */
     async registerSong(songData, options = {}) {
         try {
             this.showLoading();
-            const response = await axios.post('/api/songs', {
-                ...songData,
-                ...options
-            });
+            const response = await songApiService.createSong(songData, options);
 
-            const { status, song, similar_songs, input } = response.data;
+            const { status, song, similar_songs, input } = response;
 
             if (status === 'exact_match' || status === 'existing_used') {
-                // 完全一致または既存マスタ使用
-                this.selectedSong = song;
-                this.updateSelectionDisplay();
-                toast.info(`既存の楽曲マスタを使用します: ${song.title} / ${song.artist}`);
-
-                // フォームをリセット
-                if (document.getElementById('createSongForm')) {
-                    document.getElementById('createSongForm').reset();
-                }
-
-                // タイムスタンプが選択されていれば紐づける
-                if (this.selectedTimestamps.length > 0) {
-                    await this.linkTimestamps();
-                }
-
-                // Spotify検索結果を再描画（Spotifyから登録の場合）
-                if (songData.spotify_track_id) {
-                    this.searchSpotify();
-                }
-
+                await this.handleExactMatch(song, songData);
             } else if (status === 'similar_found') {
-                // 類似曲が見つかった場合
                 this.hideLoading();
-                await this.showSimilarSongsDialog(similar_songs, input);
-
+                await this.handleSimilarFound(similar_songs, input, songData);
             } else if (status === 'created') {
-                // 新規登録
-                this.selectedSong = song;
-                this.updateSelectionDisplay();
-                toast.success(`楽曲マスタに登録しました: ${song.title} / ${song.artist}`);
-
-                // フォームをリセット
-                if (document.getElementById('createSongForm')) {
-                    document.getElementById('createSongForm').reset();
-                }
-
-                // タイムスタンプが選択されていれば紐づける
-                if (this.selectedTimestamps.length > 0) {
-                    await this.linkTimestamps();
-                }
-
-                // Spotify検索結果を再描画（Spotifyから登録の場合）
-                if (songData.spotify_track_id) {
-                    this.searchSpotify();
-                }
+                await this.handleCreated(song, songData);
             }
-
         } catch (error) {
             console.error('楽曲マスタの登録に失敗しました:', error);
             toast.error('登録に失敗しました。');
@@ -675,147 +536,62 @@ class TimestampNormalization {
         }
     }
 
-    /**
-     * 類似曲確認ダイアログを表示
-     */
-    async showSimilarSongsDialog(similarSongs, inputData) {
-        return new Promise((resolve) => {
-            // HTMLエスケープ関数
-            const escapeHtml = (str) => {
-                const div = document.createElement('div');
-                div.textContent = str;
-                return div.innerHTML;
-            };
+    async handleExactMatch(song, songData) {
+        this.selectedSong = song;
+        this.updateSelectionDisplay();
+        toast.info(`既存の楽曲マスタを使用します: ${song.title} / ${song.artist}`);
 
-            // ダイアログのHTMLを動的に作成
-            const dialogHtml = `
-                <div id="similarSongsDialog" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-                    <div class="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto">
-                        <h3 class="text-lg font-bold mb-4 text-gray-900 dark:text-white">類似する楽曲マスタが見つかりました</h3>
+        if (document.getElementById('createSongForm')) {
+            document.getElementById('createSongForm').reset();
+        }
 
-                        <div class="mb-4 p-3 bg-blue-50 dark:bg-blue-900 rounded">
-                            <p class="text-sm text-gray-700 dark:text-gray-300">
-                                登録しようとしている楽曲: <strong>${escapeHtml(inputData.title)} / ${escapeHtml(inputData.artist)}</strong>
-                            </p>
-                        </div>
+        if (this.selectedTimestamps.length > 0) {
+            await this.linkTimestamps();
+        }
 
-                        <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                            類似度の高い楽曲が ${escapeHtml(String(similarSongs.length))} 件見つかりました。既存のマスタを使用するか、新規登録するか選択してください。
-                        </p>
+        if (songData.spotify_track_id) {
+            this.searchSpotify();
+        }
+    }
 
-                        <div id="similarSongsList" class="space-y-2 mb-6 max-h-60 overflow-y-auto">
-                            ${similarSongs.map((item, index) => `
-                                <div class="similar-song-item p-3 border rounded cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700 dark:border-gray-600" data-song-id="${escapeHtml(item.song.id)}" data-index="${escapeHtml(String(index))}">
-                                    <div class="flex justify-between items-start">
-                                        <div>
-                                            <div class="font-medium text-sm text-gray-900 dark:text-white">${escapeHtml(item.song.title)}</div>
-                                            <div class="text-xs text-gray-500 dark:text-gray-400">${escapeHtml(item.song.artist)}</div>
-                                        </div>
-                                        <div class="text-right">
-                                            <div class="text-xs font-medium text-green-600 dark:text-green-400">類似度: ${escapeHtml(String(item.similarity))}%</div>
-                                            <div class="text-xs text-gray-500 dark:text-gray-400">
-                                                曲名: ${escapeHtml(String(item.title_similarity))}% / アーティスト: ${escapeHtml(String(item.artist_similarity))}%
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            `).join('')}
-                        </div>
+    async handleSimilarFound(similarSongs, input, songData) {
+        const result = await SimilarSongsDialog.show(similarSongs, input);
 
-                        <div class="flex gap-2 justify-end">
-                            <button id="useExistingSongBtn" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50" disabled>
-                                選択した楽曲を使用
-                            </button>
-                            <button id="forceCreateNewBtn" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
-                                新規登録
-                            </button>
-                            <button id="cancelDialogBtn" class="px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-200 rounded hover:bg-gray-400 dark:hover:bg-gray-500">
-                                キャンセル
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            `;
+        if (result.action === 'use_existing') {
+            this.showLoading();
+            await this.registerSong(input, { use_existing_id: result.songId });
+        } else if (result.action === 'force_create') {
+            this.showLoading();
+            await this.registerSong(input, { force_create: true });
+        }
+    }
 
-            // ダイアログを追加
-            document.body.insertAdjacentHTML('beforeend', dialogHtml);
+    async handleCreated(song, songData) {
+        this.selectedSong = song;
+        this.updateSelectionDisplay();
+        toast.success(`楽曲マスタに登録しました: ${song.title} / ${song.artist}`);
 
-            const dialog = document.getElementById('similarSongsDialog');
-            const useExistingBtn = document.getElementById('useExistingSongBtn');
-            const forceCreateBtn = document.getElementById('forceCreateNewBtn');
-            const cancelBtn = document.getElementById('cancelDialogBtn');
+        if (document.getElementById('createSongForm')) {
+            document.getElementById('createSongForm').reset();
+        }
 
-            let selectedSongId = null;
+        if (this.selectedTimestamps.length > 0) {
+            await this.linkTimestamps();
+        }
 
-            // 楽曲選択
-            dialog.querySelectorAll('.similar-song-item').forEach(item => {
-                item.addEventListener('click', () => {
-                    // 選択状態をリセット
-                    dialog.querySelectorAll('.similar-song-item').forEach(i => {
-                        i.classList.remove('bg-blue-100', 'dark:bg-blue-900', 'border-blue-500');
-                    });
-
-                    // 選択状態を適用
-                    item.classList.add('bg-blue-100', 'dark:bg-blue-900', 'border-blue-500');
-                    selectedSongId = item.dataset.songId;
-                    useExistingBtn.disabled = false;
-                });
-            });
-
-            // 既存楽曲を使用
-            useExistingBtn.addEventListener('click', async () => {
-                if (!selectedSongId) return;
-
-                dialog.remove();
-                this.showLoading();
-
-                try {
-                    await this.registerSong(inputData, { use_existing_id: selectedSongId });
-                    resolve();
-                } catch (error) {
-                    console.error('楽曲の使用に失敗しました:', error);
-                    toast.error('楽曲の使用に失敗しました。');
-                } finally {
-                    this.hideLoading();
-                }
-            });
-
-            // 新規登録
-            forceCreateBtn.addEventListener('click', async () => {
-                dialog.remove();
-                this.showLoading();
-
-                try {
-                    await this.registerSong(inputData, { force_create: true });
-                    resolve();
-                } catch (error) {
-                    console.error('新規登録に失敗しました:', error);
-                    toast.error('新規登録に失敗しました。');
-                } finally {
-                    this.hideLoading();
-                }
-            });
-
-            // キャンセル
-            cancelBtn.addEventListener('click', () => {
-                dialog.remove();
-                resolve();
-            });
-        });
+        if (songData.spotify_track_id) {
+            this.searchSpotify();
+        }
     }
 
     async loadSongs(search = '') {
         try {
-            const response = await axios.get('/api/songs', {
-                params: { search }
-            });
+            const response = await songApiService.fetchSongs(search);
 
-            // APIレスポンスの形式に応じて分岐
-            if (response.data.data) {
-                this.displaySongs(response.data.data, response.data.total);
+            if (response.data) {
+                this.displaySongs(response.data, response.total);
             } else {
-                // 後方互換性のため、直接配列が返された場合も対応
-                this.displaySongs(response.data, response.data.length);
+                this.displaySongs(response, response.length);
             }
         } catch (error) {
             console.error('楽曲マスタの取得に失敗しました:', error);
@@ -831,8 +607,6 @@ class TimestampNormalization {
         }
 
         container.innerHTML = '';
-
-        // 件数表示を更新
         this.updateSongsCount(total !== null ? total : songs.length);
 
         if (!Array.isArray(songs)) {
@@ -847,69 +621,73 @@ class TimestampNormalization {
         }
 
         songs.forEach(song => {
-            const div = document.createElement('div');
-            const isSelected = this.selectedSong?.id === song.id;
-            div.className = `p-2 border rounded cursor-pointer flex items-center justify-between ${
-                isSelected
-                    ? 'bg-blue-100 dark:bg-blue-900 border-blue-500'
-                    : 'border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
-            }`;
-
-            const contentDiv = document.createElement('div');
-            contentDiv.className = 'flex-1';
-
-            const songInfo = document.createElement('div');
-            songInfo.className = 'text-sm truncate';
-
-            const titleSpan = document.createElement('span');
-            titleSpan.className = 'font-medium';
-            titleSpan.textContent = song.title;
-
-            const separatorSpan = document.createElement('span');
-            separatorSpan.className = 'text-gray-500 dark:text-gray-400';
-            separatorSpan.textContent = ' / ' + song.artist;
-
-            songInfo.appendChild(titleSpan);
-            songInfo.appendChild(separatorSpan);
-            songInfo.title = `${song.title} / ${song.artist}`;
-
-            contentDiv.appendChild(songInfo);
-
-            // 削除ボタン
-            const deleteBtn = document.createElement('button');
-            deleteBtn.className = 'px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700';
-            deleteBtn.textContent = '削除';
-            deleteBtn.addEventListener('click', async (e) => {
-                e.stopPropagation();
-                if (confirm(`楽曲マスタを削除しますか?\n${song.title} / ${song.artist}`)) {
-                    await this.deleteSong(song.id);
-                }
-            });
-
-            div.appendChild(contentDiv);
-            div.appendChild(deleteBtn);
-
-            div.addEventListener('click', () => {
-                this.selectedSong = song;
-                this.displaySongs(songs, total);
-                this.updateSelectionDisplay();
-            });
-
-            container.appendChild(div);
+            container.appendChild(this.createSongElement(song, songs, total));
         });
+    }
+
+    createSongElement(song, songs, total) {
+        const div = document.createElement('div');
+        const isSelected = this.selectedSong?.id === song.id;
+        div.className = `p-2 border rounded cursor-pointer flex items-center justify-between ${
+            isSelected
+                ? 'bg-blue-100 dark:bg-blue-900 border-blue-500'
+                : 'border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+        }`;
+
+        const contentDiv = document.createElement('div');
+        contentDiv.className = 'flex-1';
+
+        const songInfo = document.createElement('div');
+        songInfo.className = 'text-sm truncate';
+
+        const titleSpan = document.createElement('span');
+        titleSpan.className = 'font-medium';
+        titleSpan.textContent = song.title;
+
+        const separatorSpan = document.createElement('span');
+        separatorSpan.className = 'text-gray-500 dark:text-gray-400';
+        separatorSpan.textContent = ' / ' + song.artist;
+
+        songInfo.appendChild(titleSpan);
+        songInfo.appendChild(separatorSpan);
+        songInfo.title = `${song.title} / ${song.artist}`;
+
+        contentDiv.appendChild(songInfo);
+
+        // 削除ボタン
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700';
+        deleteBtn.textContent = '削除';
+        deleteBtn.addEventListener('click', async (e) => {
+            e.stopPropagation();
+            if (confirm(`楽曲マスタを削除しますか?\n${song.title} / ${song.artist}`)) {
+                await this.deleteSong(song.id);
+            }
+        });
+
+        div.appendChild(contentDiv);
+        div.appendChild(deleteBtn);
+
+        div.addEventListener('click', () => {
+            this.selectedSong = song;
+            this.displaySongs(songs, total);
+            this.updateSelectionDisplay();
+        });
+
+        return div;
     }
 
     updateSongsCount(count) {
         const countDiv = document.getElementById('songsCount');
-        if (!countDiv) return;
-
-        countDiv.textContent = `${count}件`;
+        if (countDiv) {
+            countDiv.textContent = `${count}件`;
+        }
     }
 
     async deleteSong(songId) {
         try {
             this.showLoading();
-            await axios.delete(`/api/songs/${songId}`);
+            await songApiService.deleteSong(songId);
             toast.success('楽曲マスタを削除しました。');
             await this.loadSongs();
             await this.loadTimestamps(this.currentPage, this.currentSearchQuery);
@@ -935,29 +713,16 @@ class TimestampNormalization {
         try {
             this.showLoading();
 
-            // 選択された各タイムスタンプを紐づける
             for (const ts of this.selectedTimestamps) {
-                await axios.post('/api/songs/link', {
-                    normalized_text: ts.normalized_text,
-                    song_id: this.selectedSong.id
-                });
+                await timestampApiService.linkTimestamp(ts.normalized_text, this.selectedSong.id);
             }
 
             toast.success(`${this.selectedTimestamps.length}件のタイムスタンプを紐づけました。`);
 
-            // タイムスタンプの選択をクリア、楽曲の選択は維持
             this.selectedTimestamps = [];
             this.selectedSpotifyTrack = null;
-            // this.selectedSong は維持
 
-            // 紐づけた結果を確認できるように「未連携のみ」フィルタを解除
-            if (this.unlinkedOnly) {
-                this.unlinkedOnly = false;
-                const btn = document.getElementById('unlinkedOnlyBtn');
-                btn.classList.remove('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
-                btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
-            }
-
+            this.resetUnlinkedFilter();
             await this.loadTimestamps(this.currentPage, this.currentSearchQuery);
             this.updateSelectionDisplay();
         } catch (error) {
@@ -982,22 +747,13 @@ class TimestampNormalization {
             this.showLoading();
 
             for (const ts of this.selectedTimestamps) {
-                await axios.post('/api/songs/mark-not-song', {
-                    normalized_text: ts.normalized_text
-                });
+                await timestampApiService.markAsNotSong(ts.normalized_text);
             }
 
             toast.success('楽曲ではないとマークしました。');
             this.selectedTimestamps = [];
 
-            // マークした結果を確認できるように「未連携のみ」フィルタを解除
-            if (this.unlinkedOnly) {
-                this.unlinkedOnly = false;
-                const btn = document.getElementById('unlinkedOnlyBtn');
-                btn.classList.remove('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
-                btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
-            }
-
+            this.resetUnlinkedFilter();
             await this.loadTimestamps(this.currentPage, this.currentSearchQuery);
             this.updateSelectionDisplay();
         } catch (error) {
@@ -1014,7 +770,6 @@ class TimestampNormalization {
             return;
         }
 
-        // is_not_songのタイムスタンプのみをフィルタ
         const notSongTimestamps = this.selectedTimestamps.filter(ts => ts.is_not_song);
 
         if (notSongTimestamps.length === 0) {
@@ -1030,9 +785,7 @@ class TimestampNormalization {
             this.showLoading();
 
             for (const ts of notSongTimestamps) {
-                await axios.post('/api/songs/unmark-not-song', {
-                    normalized_text: ts.normalized_text
-                });
+                await timestampApiService.unmarkAsNotSong(ts.normalized_text);
             }
 
             toast.success('「楽曲ではない」マークを解除しました。');
@@ -1062,17 +815,11 @@ class TimestampNormalization {
             this.showLoading();
 
             for (const ts of this.selectedTimestamps) {
-                await axios.delete('/api/songs/unlink', {
-                    data: { normalized_text: ts.normalized_text }
-                });
+                await timestampApiService.unlinkTimestamp(ts.normalized_text);
             }
 
             toast.success('紐づけを解除しました。');
             this.selectedTimestamps = [];
-
-            // 紐づけを解除したタイムスタンプは未連携になるため、
-            // 「未連携のみ」フィルタがオンでも表示される
-            // （フィルタは維持）
 
             await this.loadTimestamps(this.currentPage, this.currentSearchQuery);
             this.updateSelectionDisplay();
@@ -1085,7 +832,6 @@ class TimestampNormalization {
     }
 
     showTab(tabId) {
-        // すべてのタブボタンとコンテンツをリセット
         document.querySelectorAll('.tab-button').forEach(btn => {
             btn.classList.remove('border-green-500', 'text-green-600', 'border-blue-500', 'text-blue-600', 'border-purple-500', 'text-purple-600');
             btn.classList.add('border-transparent', 'text-gray-500');
@@ -1095,7 +841,6 @@ class TimestampNormalization {
             content.classList.add('hidden');
         });
 
-        // アクティブなタブを設定
         const activeTab = document.getElementById(tabId);
         if (tabId === 'spotifyTab') {
             activeTab.classList.remove('border-transparent', 'text-gray-500');
@@ -1120,38 +865,23 @@ class TimestampNormalization {
         document.getElementById('loadingModal').classList.add('hidden');
     }
 
-    /**
-     * 動画URLを生成する
-     * @param {string} videoId - 動画ID
-     * @param {number|null} tsNum - タイムスタンプ秒数
-     * @returns {string|null} 生成されたURL、またはvideoIdがない場合はnull
-     */
     generateVideoUrl(videoId, tsNum) {
         if (!videoId) return null;
         const timeParam = tsNum ? `?t=${tsNum}s` : '';
-        return `${this.CONSTANTS.YOUTUBE_BASE_URL}${videoId}${timeParam}`;
+        return `${CONSTANTS.YOUTUBE_BASE_URL}${videoId}${timeParam}`;
     }
 
-    /**
-     * 動画ボタンの状態を更新する
-     * @param {boolean} enabled - ボタンを有効化するか
-     * @param {string|null} videoId - 動画ID
-     * @param {number|null} tsNum - タイムスタンプ秒数
-     * @param {string} title - 動画タイトル
-     */
     updateVideoButton(enabled, videoId = null, tsNum = null, title = '') {
         const videoTitle = document.getElementById('videoTitle');
         const videoLinkBtn = document.getElementById('videoLinkBtn');
 
         videoTitle.textContent = title;
         videoTitle.title = title;
-        // 初期状態でtruncateクラスを適用（必ず初期化）
         videoTitle.classList.add('truncate');
         videoTitle.style.maxWidth = '300px';
         videoLinkBtn.disabled = !enabled;
         videoLinkBtn.setAttribute('aria-disabled', enabled ? 'false' : 'true');
 
-        // 既存のイベントリスナーをクリア
         videoLinkBtn.onclick = null;
 
         if (enabled && videoId) {
@@ -1167,7 +897,6 @@ class TimestampNormalization {
 
                 const newWindow = window.open(videoUrl, '_blank');
 
-                // ポップアップブロック検出
                 if (!newWindow || newWindow.closed || typeof newWindow.closed === 'undefined') {
                     toast.warning('ポップアップがブロックされました。ブラウザの設定を確認してください。');
                 }

--- a/resources/js/songs/services/SongApiService.js
+++ b/resources/js/songs/services/SongApiService.js
@@ -1,0 +1,64 @@
+import axios from 'axios';
+
+/**
+ * 楽曲API通信サービス
+ */
+export class SongApiService {
+    /**
+     * 楽曲マスタ一覧を取得
+     * @param {string} search - 検索クエリ
+     * @returns {Promise<Object>} 楽曲一覧データ
+     */
+    async fetchSongs(search = '') {
+        const response = await axios.get('/api/songs', {
+            params: { search }
+        });
+        return response.data;
+    }
+
+    /**
+     * 楽曲マスタを登録
+     * @param {Object} songData - 楽曲データ
+     * @param {string} songData.title - 楽曲名
+     * @param {string} songData.artist - アーティスト名
+     * @param {string} songData.spotify_track_id - Spotify Track ID
+     * @param {Object} songData.spotify_data - Spotifyデータ
+     * @param {Object} options - オプション
+     * @param {boolean} options.force_create - 強制新規登録
+     * @param {string} options.use_existing_id - 既存楽曲ID
+     * @returns {Promise<Object>} 登録結果
+     */
+    async createSong(songData, options = {}) {
+        const response = await axios.post('/api/songs', {
+            ...songData,
+            ...options
+        });
+        return response.data;
+    }
+
+    /**
+     * 楽曲マスタを削除
+     * @param {string} songId - 楽曲ID
+     * @returns {Promise<Object>} 削除結果
+     */
+    async deleteSong(songId) {
+        const response = await axios.delete(`/api/songs/${songId}`);
+        return response.data;
+    }
+
+    /**
+     * Spotify APIで楽曲を検索
+     * @param {string} query - 検索クエリ
+     * @param {number} limit - 取得件数
+     * @returns {Promise<Array>} 検索結果
+     */
+    async searchSpotify(query, limit = 10) {
+        const response = await axios.get('/api/songs/search-spotify', {
+            params: { query, limit }
+        });
+        return response.data;
+    }
+}
+
+// シングルトンインスタンスをエクスポート
+export const songApiService = new SongApiService();

--- a/resources/js/songs/services/TimestampApiService.js
+++ b/resources/js/songs/services/TimestampApiService.js
@@ -1,0 +1,75 @@
+import axios from 'axios';
+
+/**
+ * タイムスタンプAPI通信サービス
+ */
+export class TimestampApiService {
+    /**
+     * タイムスタンプ一覧を取得
+     * @param {Object} params - 取得パラメータ
+     * @param {number} params.page - ページ番号
+     * @param {number} params.per_page - 1ページあたりの件数
+     * @param {string} params.search - 検索クエリ
+     * @param {boolean} params.unlinked_only - 未連携のみ
+     * @returns {Promise<Object>} タイムスタンプ一覧データ
+     */
+    async fetchTimestamps({ page = 1, per_page = 50, search = '', unlinked_only = false }) {
+        const response = await axios.get('/api/songs/timestamps', {
+            params: { page, per_page, search, unlinked_only }
+        });
+        return response.data;
+    }
+
+    /**
+     * タイムスタンプと楽曲を紐づける
+     * @param {string} normalizedText - 正規化されたテキスト
+     * @param {string} songId - 楽曲ID
+     * @returns {Promise<Object>} レスポンスデータ
+     */
+    async linkTimestamp(normalizedText, songId) {
+        const response = await axios.post('/api/songs/link', {
+            normalized_text: normalizedText,
+            song_id: songId
+        });
+        return response.data;
+    }
+
+    /**
+     * タイムスタンプを「楽曲ではない」とマーク
+     * @param {string} normalizedText - 正規化されたテキスト
+     * @returns {Promise<Object>} レスポンスデータ
+     */
+    async markAsNotSong(normalizedText) {
+        const response = await axios.post('/api/songs/mark-not-song', {
+            normalized_text: normalizedText
+        });
+        return response.data;
+    }
+
+    /**
+     * 「楽曲ではない」マークを解除
+     * @param {string} normalizedText - 正規化されたテキスト
+     * @returns {Promise<Object>} レスポンスデータ
+     */
+    async unmarkAsNotSong(normalizedText) {
+        const response = await axios.post('/api/songs/unmark-not-song', {
+            normalized_text: normalizedText
+        });
+        return response.data;
+    }
+
+    /**
+     * タイムスタンプの紐づけを解除
+     * @param {string} normalizedText - 正規化されたテキスト
+     * @returns {Promise<Object>} レスポンスデータ
+     */
+    async unlinkTimestamp(normalizedText) {
+        const response = await axios.delete('/api/songs/unlink', {
+            data: { normalized_text: normalizedText }
+        });
+        return response.data;
+    }
+}
+
+// シングルトンインスタンスをエクスポート
+export const timestampApiService = new TimestampApiService();

--- a/resources/js/songs/utils/constants.js
+++ b/resources/js/songs/utils/constants.js
@@ -1,0 +1,15 @@
+/**
+ * 楽曲正規化機能の定数定義
+ */
+export const CONSTANTS = {
+    MAX_TIMESTAMP_WIDTH: '200px',
+    MAX_ARCHIVE_TITLE_WIDTH: '150px',
+    MAX_STATUS_LENGTH: 30,
+    MAX_SELECTION_TEXT_LENGTH: 100,
+    YOUTUBE_BASE_URL: 'https://youtu.be/'
+};
+
+export const BUTTON_STYLES = {
+    btnClass: 'px-3 py-1 bg-gray-200 dark:bg-gray-700 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 text-sm',
+    disabledBtnClass: 'px-3 py-1 bg-gray-100 dark:bg-gray-800 rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed text-sm'
+};


### PR DESCRIPTION
## Summary
- normalize.js（1186行）を複数のモジュールに分割
- APIロジック、UIコンポーネント、定数を独立したファイルに分離
- メインクラスをオーケストレーション層として簡素化

## 変更点
### 新規ファイル
- `services/TimestampApiService.js`: タイムスタンプAPI通信（78行）
- `services/SongApiService.js`: 楽曲API通信（65行）
- `components/SimilarSongsDialog.js`: 類似曲確認ダイアログ（109行）
- `components/Pagination.js`: ページネーションコンポーネント（99行）
- `utils/constants.js`: 定数定義（15行）

### リファクタリング
- メインクラス: 1186行 → 913行（API通信とコンポーネントを外部化）
- 責任の分離による保守性向上
- 再利用可能なコンポーネントの作成

## Test plan
- [x] npmビルド成功
- [x] 全テストパス（207件）
- [x] Laravel Pintコードスタイルチェック通過
- [x] フロントエンドビルド成功

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)