### PR TITLE
refactor: FormRequestクラスの作成によるバリデーション分離

### DIFF
--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -3,6 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Exceptions\NotFoundException;
+use App\Http\Requests\EditTimestampsRequest;
+use App\Http\Requests\FetchCommentsRequest;
+use App\Http\Requests\ToggleDisplayRequest;
 use App\Models\Archive;
 use App\Models\ChangeList;
 use App\Models\Channel;
@@ -156,19 +159,16 @@ class ManageController extends Controller
 
     // 動画の表示非表示切り替え
     // comment_id = null の場合に動画と判断する
-    public function toggleDisplay(Request $request)
+    public function toggleDisplay(ToggleDisplayRequest $request)
     {
-        $request->validate([
-            'id' => ['required', 'string'],
-            'is_display' => ['required', 'in:0,1'],
-        ]);
+        $validated = $request->validated();
 
-        $newDisplay = DB::transaction(function () use ($request) {
-            $new_display = ($request->is_display === '1') ? '0' : '1';
+        $newDisplay = DB::transaction(function () use ($validated) {
+            $new_display = ($validated['is_display'] === '1') ? '0' : '1';
             // archivesとchange_listを更新
-            // Archive::where('id', $request->id)->update(['is_display' => $new_display]);
+            // Archive::where('id', $validated['id'])->update(['is_display' => $new_display]);
             // return response()->json($new_display);
-            $archive = Archive::findOrFail($request->id);
+            $archive = Archive::findOrFail($validated['id']);
             $archive->is_display = $new_display;
             $archive->save();
             ChangeList::updateOrCreate(
@@ -186,12 +186,10 @@ class ManageController extends Controller
         return response()->json($newDisplay);
     }
 
-    public function fetchComments(Request $request)
+    public function fetchComments(FetchCommentsRequest $request)
     {
-        $request->validate([
-            'id' => ['required', 'string'],
-        ]);
-        $videoId = Archive::findOrFail($request->id, ['video_id'])->video_id;
+        $validated = $request->validated();
+        $videoId = Archive::findOrFail($validated['id'], ['video_id'])->video_id;
         DB::transaction(function () use ($videoId) {
             // TODO:概要欄の再取得が現状不可能 日々の更新ができるようになれば勝手に更新されるはずなので問題ない？
             $this->refreshArchiveService->refreshTimeStampsFromComments($videoId);
@@ -208,13 +206,9 @@ class ManageController extends Controller
      *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function editTimestamps(Request $request)
+    public function editTimestamps(EditTimestampsRequest $request)
     {
-        $validatedData = $request->validate([
-            '*.id' => 'required|string|exists:ts_items,id',
-            '*.comment_id' => 'required|string|exists:ts_items,comment_id',
-            '*.is_display' => 'required|boolean',
-        ]);
+        $validatedData = $request->validated();
         DB::transaction(function () use ($validatedData) {
             // リクエストで渡されたコメントIDに紐づくarchiveを取得
             $commentIds = array_column($validatedData, 'comment_id');

--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -6,6 +6,9 @@ use App\Helpers\QueryHelper;
 use App\Helpers\TextNormalizer;
 use App\Helpers\ValidationHelper;
 use App\Http\Requests\FetchTimestampsRequest;
+use App\Http\Requests\LinkTimestampRequest;
+use App\Http\Requests\MarkAsNotSongRequest;
+use App\Http\Requests\NormalizedTextRequest;
 use App\Http\Requests\StoreSongRequest;
 use App\Models\Song;
 use App\Models\TimestampSongMapping;
@@ -321,12 +324,9 @@ class SongController extends Controller
     /**
      * タイムスタンプと楽曲を紐づける（マッピングを作成）
      */
-    public function linkTimestamp(Request $request)
+    public function linkTimestamp(LinkTimestampRequest $request)
     {
-        $validated = $request->validate([
-            'normalized_text' => 'required|string',
-            'song_id' => 'required|string|exists:songs,id',
-        ]);
+        $validated = $request->validated();
 
         $this->songMappingService->linkTimestamp($validated['normalized_text'], $validated['song_id']);
 
@@ -336,12 +336,9 @@ class SongController extends Controller
     /**
      * タイムスタンプを「楽曲ではない」とマーク
      */
-    public function markAsNotSong(Request $request)
+    public function markAsNotSong(MarkAsNotSongRequest $request)
     {
-        $validated = $request->validate([
-            'normalized_text' => 'nullable|string|required_without:text',
-            'text' => 'nullable|string|required_without:normalized_text',
-        ]);
+        $validated = $request->validated();
 
         // textが渡された場合は正規化する
         $normalizedText = $validated['normalized_text'] ?? TextNormalizer::normalize($validated['text']);
@@ -354,11 +351,9 @@ class SongController extends Controller
     /**
      * 「楽曲ではない」フラグを解除
      */
-    public function unmarkAsNotSong(Request $request)
+    public function unmarkAsNotSong(NormalizedTextRequest $request)
     {
-        $validated = $request->validate([
-            'normalized_text' => 'required|string',
-        ]);
+        $validated = $request->validated();
 
         $this->songMappingService->unmarkAsNotSong($validated['normalized_text']);
 
@@ -368,11 +363,9 @@ class SongController extends Controller
     /**
      * マッピングを解除
      */
-    public function unlinkTimestamp(Request $request)
+    public function unlinkTimestamp(NormalizedTextRequest $request)
     {
-        $validated = $request->validate([
-            'normalized_text' => 'required|string',
-        ]);
+        $validated = $request->validated();
 
         $this->songMappingService->unlinkTimestamp($validated['normalized_text']);
 

--- a/app/Http/Requests/EditTimestampsRequest.php
+++ b/app/Http/Requests/EditTimestampsRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class EditTimestampsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            '*.id' => 'required|string|exists:ts_items,id',
+            '*.comment_id' => 'required|string|exists:ts_items,comment_id',
+            '*.is_display' => 'required|boolean',
+        ];
+    }
+}

--- a/app/Http/Requests/FetchCommentsRequest.php
+++ b/app/Http/Requests/FetchCommentsRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FetchCommentsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/LinkTimestampRequest.php
+++ b/app/Http/Requests/LinkTimestampRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LinkTimestampRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'normalized_text' => 'required|string',
+            'song_id' => 'required|string|exists:songs,id',
+        ];
+    }
+}

--- a/app/Http/Requests/MarkAsNotSongRequest.php
+++ b/app/Http/Requests/MarkAsNotSongRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MarkAsNotSongRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'normalized_text' => 'nullable|string|required_without:text',
+            'text' => 'nullable|string|required_without:normalized_text',
+        ];
+    }
+}

--- a/app/Http/Requests/NormalizedTextRequest.php
+++ b/app/Http/Requests/NormalizedTextRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * normalized_textを必須とするリクエスト
+ * unmarkAsNotSong, unlinkTimestamp で使用
+ */
+class NormalizedTextRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'normalized_text' => 'required|string',
+        ];
+    }
+}

--- a/app/Http/Requests/ToggleDisplayRequest.php
+++ b/app/Http/Requests/ToggleDisplayRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ToggleDisplayRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'id' => ['required', 'string'],
+            'is_display' => ['required', 'in:0,1'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

コントローラー内のインラインバリデーションをFormRequestクラスに分離しました。

### 作成したFormRequestクラス

| クラス | 用途 |
|--------|------|
| `LinkTimestampRequest` | タイムスタンプと楽曲の紐づけ |
| `MarkAsNotSongRequest` | 「楽曲ではない」マーク |
| `NormalizedTextRequest` | unmarkAsNotSong, unlinkTimestamp共通 |
| `EditTimestampsRequest` | タイムスタンプ編集 |
| `ToggleDisplayRequest` | 表示切り替え |
| `FetchCommentsRequest` | コメント取得 |

### 更新したコントローラー

**SongController**
- `linkTimestamp()` → `LinkTimestampRequest`
- `markAsNotSong()` → `MarkAsNotSongRequest`
- `unmarkAsNotSong()` → `NormalizedTextRequest`
- `unlinkTimestamp()` → `NormalizedTextRequest`

**ManageController**
- `toggleDisplay()` → `ToggleDisplayRequest`
- `fetchComments()` → `FetchCommentsRequest`
- `editTimestamps()` → `EditTimestampsRequest`

### 効果

- コントローラーメソッドの簡潔化
- バリデーションロジックの再利用性向上
- 自動的なエラーレスポンス生成

## Test plan

- [x] `php artisan test`が全て通過する（207 passed）
- [x] 既存のバリデーションテストが引き続き通過する

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)