### PR TITLE
fix: TODOコメントの解消と関連するバグ修正

### DIFF
--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -191,7 +191,8 @@ class ManageController extends Controller
         $validated = $request->validated();
         $videoId = Archive::findOrFail($validated['id'], ['video_id'])->video_id;
         DB::transaction(function () use ($videoId) {
-            // TODO:概要欄の再取得が現状不可能 日々の更新ができるようになれば勝手に更新されるはずなので問題ない？
+            // コメント欄のタイムスタンプのみ再取得
+            // 概要欄のタイムスタンプはrefreshArchives()でアーカイブ更新時に自動取得される
             $this->refreshArchiveService->refreshTimeStampsFromComments($videoId);
         });
         $ts_items = TsItem::where('video_id', $videoId)->orderBy('comment_id')->get();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -41,6 +41,7 @@ class User extends Authenticatable
         'google_token',
         'google_refresh_token',
         'avatar',
+        'email_verified_at',
     ];
 
     /**

--- a/tests/Feature/Auth/GoogleAuthControllerTest.php
+++ b/tests/Feature/Auth/GoogleAuthControllerTest.php
@@ -45,9 +45,8 @@ class GoogleAuthControllerTest extends TestCase
         $this->assertEquals('test', $user->name);
         $this->assertEquals('test@example.com', $user->email);
 
-        // email_verified_atが設定されていることを確認
-        // TODO: email_verified_atがnullになる問題を調査
-        // $this->assertNotNull($user->email_verified_at);
+        // email_verified_atが設定されていることを確認（Google認証済みならメール認証も済みとみなす）
+        $this->assertNotNull($user->email_verified_at);
 
         // ログインしてHOMEにリダイレクトされることを確認
         $response->assertRedirect('/manage');


### PR DESCRIPTION
## Summary

TODOコメントを整理し、関連するバグを修正しました。

### 修正内容

#### 1. User model - email_verified_at の修正
- `email_verified_at`を`$fillable`に追加
- **修正したバグ**: Google OAuth認証時に`email_verified_at`が保存されない問題
- 原因: `updateOrCreate()`でmass assignmentされていたが、`$fillable`に含まれていなかった

#### 2. GoogleAuthControllerTest - TODOの解消
- コメントアウトされていたアサーション`$this->assertNotNull($user->email_verified_at)`を有効化
- テストケースが完全に動作するようになった

#### 3. ManageController - TODOコメントの改善
- 疑問形のTODOコメントを説明的なコメントに変更
```diff
- // TODO:概要欄の再取得が現状不可能 日々の更新ができるようになれば勝手に更新されるはずなので問題ない？
+ // コメント欄のタイムスタンプのみ再取得
+ // 概要欄のタイムスタンプはrefreshArchives()でアーカイブ更新時に自動取得される
```

### 残存するTODOコメント（意図的に残留）

| ファイル | 内容 | 理由 |
|---------|------|------|
| `web.php` | サービス方向性に関するメモ | 将来の機能拡張に関するメモ |

## Test plan

- [x] `php artisan test`が全て通過する（207 passed, 749 assertions）
- [x] GoogleAuthControllerTestのemail_verified_atアサーションが通過する

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)