### PR TITLE
perf: YouTubeコメント取得の重複呼び出しを防止 (#281)

### DIFF
--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -64,6 +64,14 @@ class RefreshArchiveService
 
         // コメントから取得が必要なvideo_idを事前に特定し、API呼び出しを実行
         $comment_ts_items_map = [];
+
+        // 既にgetArchivesAndTsItems()でコメント取得済みのvideo_idを特定
+        $alreadyFetchedVideoIds = collect($rtn_ts_items)
+            ->where('type', '2')
+            ->pluck('video_id')
+            ->unique()
+            ->toArray();
+
         $results = DB::select("
             SELECT t1.video_id
             FROM archives t1
@@ -86,6 +94,10 @@ class RefreshArchiveService
 
         foreach ($results as $result) {
             $video_id = $result->video_id;
+            // 既にコメント取得済みの動画はスキップ
+            if (in_array($video_id, $alreadyFetchedVideoIds)) {
+                continue;
+            }
             try {
                 // API呼び出しのみ実行し、結果を保存
                 $comment_ts_items_map[$video_id] = $this->youtubeService->getTimeStampsFromComments($video_id);


### PR DESCRIPTION
## Summary
- `getArchivesAndTsItems()`で既にコメントを取得済みの動画に対して、`refreshArchives()`内で再度コメント取得APIを呼び出していた問題を修正
- `rtn_ts_items`にtype='2'（コメント）のアイテムがあるvideo_idを特定し、後続のコメント取得処理でスキップするように変更
- 同じ動画に対する重複API呼び出しを防止し、YouTube API quotaの節約に貢献

## Test plan
- [x] RefreshArchiveServiceTestがすべてパス
- [x] 全体テスト（207件）がすべてパス

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)