### PR TITLE
perf: パフォーマンス向上用インデックスを追加 (#290)

### DIFF
--- a/database/migrations/2025_11_30_000001_add_performance_indexes.php
+++ b/database/migrations/2025_11_30_000001_add_performance_indexes.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // archives テーブルのインデックス追加
+        Schema::table('archives', function (Blueprint $table) {
+            // アーカイブ一覧取得で頻用、channel_idとis_displayの複合インデックス
+            $table->index(['channel_id', 'is_display'], 'archives_channel_is_display_idx');
+            // orderBy('published_at', 'desc') が頻出
+            $table->index('published_at', 'archives_published_at_idx');
+        });
+
+        // ts_items テーブルのインデックス追加
+        Schema::table('ts_items', function (Blueprint $table) {
+            // WHERE is_display=1 が多用、テーブルスキャン回避
+            $table->index('is_display', 'ts_items_is_display_idx');
+            // change_list との JOIN で必須
+            $table->index(['video_id', 'comment_id', 'is_display'], 'ts_items_video_comment_display_idx');
+        });
+
+        // channels テーブルのインデックス追加
+        Schema::table('channels', function (Blueprint $table) {
+            // Auth::user()->channels() で毎回フィルター
+            $table->index('user_id', 'channels_user_id_idx');
+        });
+
+        // timestamp_song_mappings テーブルのインデックス追加
+        Schema::table('timestamp_song_mappings', function (Blueprint $table) {
+            // song削除時の cascading delete で必要
+            $table->index(['song_id', 'created_at'], 'tsm_song_created_idx');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('archives', function (Blueprint $table) {
+            $table->dropIndex('archives_channel_is_display_idx');
+            $table->dropIndex('archives_published_at_idx');
+        });
+
+        Schema::table('ts_items', function (Blueprint $table) {
+            $table->dropIndex('ts_items_is_display_idx');
+            $table->dropIndex('ts_items_video_comment_display_idx');
+        });
+
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropIndex('channels_user_id_idx');
+        });
+
+        Schema::table('timestamp_song_mappings', function (Blueprint $table) {
+            $table->dropIndex('tsm_song_created_idx');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
DB性能向上のための推奨インデックスを追加するマイグレーションを作成。

追加インデックス:
- **archives**: [channel_id, is_display] - アーカイブ一覧取得の高速化
- **archives**: published_at - ソート処理の高速化
- **ts_items**: is_display - 表示フィルターの高速化
- **ts_items**: [video_id, comment_id, is_display] - change_listとのJOIN最適化
- **channels**: user_id - ユーザーのチャンネル取得の高速化
- **timestamp_song_mappings**: [song_id, created_at] - 削除時のカスケード処理最適化

## Test plan
- [x] 全体テスト（207件）がすべてパス
- [ ] 本番環境での EXPLAIN ANALYZE による検証を推奨

## 注意事項
- インデックス追加は本番環境でのロック時間に注意が必要
- 大規模データセットでのテスト推奨

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)