### PR TITLE
perf: SongController::fetchTimestamps()のDBレベルページネーション化

### DIFF
--- a/app/Console/Commands/NormalizeTsItemsText.php
+++ b/app/Console/Commands/NormalizeTsItemsText.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Helpers\TextNormalizer;
+use App\Models\TsItem;
+use Illuminate\Console\Command;
+
+class NormalizeTsItemsText extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ts-items:normalize {--chunk=1000 : チャンクサイズ}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'ts_itemsテーブルのnormalized_textカラムを更新';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $chunkSize = (int) $this->option('chunk');
+        $total = TsItem::whereNull('normalized_text')->count();
+
+        if ($total === 0) {
+            $this->info('更新が必要なレコードはありません。');
+
+            return 0;
+        }
+
+        $this->info("更新対象: {$total}件");
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $updated = 0;
+        TsItem::whereNull('normalized_text')
+            ->chunkById($chunkSize, function ($items) use (&$updated, $bar) {
+                foreach ($items as $item) {
+                    $rawText = $item->getAttributes()['text'] ?? null;
+                    $item->normalized_text = TextNormalizer::normalize($rawText);
+                    $item->saveQuietly(); // イベントを発火せずに保存
+                    $updated++;
+                    $bar->advance();
+                }
+            });
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("完了: {$updated}件を更新しました。");
+
+        return 0;
+    }
+}

--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Helpers\QueryHelper;
 use App\Helpers\TextNormalizer;
-use App\Helpers\ValidationHelper;
 use App\Http\Requests\FetchTimestampsRequest;
 use App\Http\Requests\LinkTimestampRequest;
 use App\Http\Requests\MarkAsNotSongRequest;
@@ -47,6 +46,7 @@ class SongController extends Controller
 
     /**
      * 全タイムスタンプを取得（マッピング情報付き）
+     * DBレベルでフィルタリング・ページネーションを実行
      */
     public function fetchTimestamps(FetchTimestampsRequest $request)
     {
@@ -54,17 +54,16 @@ class SongController extends Controller
 
         $perPage = $validated['per_page'] ?? 50;
         $search = $validated['search'] ?? '';
-        $unlinkedOnly = ValidationHelper::parseBoolean($validated['unlinked_only'] ?? false);
+        $filter = $validated['filter'] ?? 'all';
         $currentPage = $validated['page'] ?? 1;
 
+        // ベースクエリ: ts_itemsとtimestamp_song_mappingsをLEFT JOIN
         $query = TsItem::with(['archive'])
-            ->whereNotNull('text')
-            ->where('text', '!=', '')
-            // ts_items自体のis_displayが0のものを除外
-            // （change_listの内容はRefreshArchiveServiceによりis_displayに反映済み）
-            ->where('is_display', 1)
-            // archiveのis_displayが0のものを除外
-            // （change_listの内容はRefreshArchiveServiceによりis_displayに反映済み）
+            ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
+            ->select('ts_items.*', 'timestamp_song_mappings.id as mapping_id', 'timestamp_song_mappings.song_id', 'timestamp_song_mappings.is_not_song')
+            ->whereNotNull('ts_items.text')
+            ->where('ts_items.text', '!=', '')
+            ->where('ts_items.is_display', 1)
             ->whereHas('archive', function ($q) {
                 $q->where('is_display', 1);
             });
@@ -72,81 +71,66 @@ class SongController extends Controller
         // 検索条件
         if ($search) {
             $escapedSearch = QueryHelper::escapeLikeString($search);
-            $query->where('text', 'like', "%{$escapedSearch}%");
+            $query->where('ts_items.text', 'like', "%{$escapedSearch}%");
         }
 
-        // 全件取得（ページネーション前）
-        $allTimestamps = $query->get();
+        // フィルター条件
+        switch ($filter) {
+            case 'unlinked':
+                // マッピングなし
+                $query->whereNull('timestamp_song_mappings.id');
+                break;
+            case 'linked':
+                // マッピングあり かつ is_not_song=false
+                $query->whereNotNull('timestamp_song_mappings.id')
+                    ->where('timestamp_song_mappings.is_not_song', false);
+                break;
+            case 'not_song':
+                // マッピングあり かつ is_not_song=true
+                $query->whereNotNull('timestamp_song_mappings.id')
+                    ->where('timestamp_song_mappings.is_not_song', true);
+                break;
+                // 'all' は条件なし
+        }
 
-        // N+1クエリ問題を回避: 全タイムスタンプの正規化テキストを事前に取得
-        $normalizedTexts = $allTimestamps->map(function ($item) {
-            return TextNormalizer::normalize($item->text);
-        })->unique()->values()->toArray();
+        // text昇順でソート
+        $query->orderBy('ts_items.text', 'asc');
 
-        // 一度にすべてのマッピングを取得
+        // DBページネーション
+        $paginated = $query->paginate($perPage, ['*'], 'page', $currentPage);
+
+        // ページネーション結果のタイムスタンプに対してマッピング・楽曲情報を取得
+        $normalizedTexts = $paginated->getCollection()->pluck('normalized_text')->unique()->values()->toArray();
+
         $mappings = TimestampSongMapping::whereIn('normalized_text', $normalizedTexts)
             ->with('song')
             ->get()
             ->keyBy('normalized_text');
 
         // 各タイムスタンプにマッピング情報を追加
-        $timestampsWithMapping = $allTimestamps->map(function ($item) use ($mappings) {
-            $normalizedText = TextNormalizer::normalize($item->text);
-            $mapping = $mappings->get($normalizedText);
+        $items = $paginated->getCollection()->map(function ($item) use ($mappings) {
+            $mapping = $mappings->get($item->normalized_text);
 
-            // モデルを配列に変換して、追加のフィールドをマージ
             $data = $item->toArray();
-            $data['normalized_text'] = $normalizedText;
+            $data['normalized_text'] = $item->normalized_text;
             $data['mapping'] = $mapping ? $mapping->toArray() : null;
             $data['song'] = $mapping && $mapping->song ? $mapping->song->toArray() : null;
             $data['is_not_song'] = $mapping ? $mapping->is_not_song : false;
 
+            // JOINで追加されたカラムを削除
+            unset($data['mapping_id'], $data['song_id']);
+
             return $data;
         });
 
-        // 未連携フィルター（ソート前に適用）
-        if ($unlinkedOnly) {
-            $timestampsWithMapping = $timestampsWithMapping->filter(function ($item) {
-                return ! $item['mapping'];
-            })->values();
-        }
-
-        // 紐づけた楽曲を最後に表示するようにソート
-        // 未紐づけ → 楽曲ではない → 紐づけ済み の順、それぞれtext昇順
-        $sorted = $timestampsWithMapping->sort(function ($a, $b) {
-            $aMapped = ! empty($a['mapping']);
-            $bMapped = ! empty($b['mapping']);
-            $aIsNotSong = $a['is_not_song'];
-            $bIsNotSong = $b['is_not_song'];
-
-            // 優先順位を決定（数値が小さいほど先に表示）
-            // 0: 未紐づけ, 1: 楽曲ではない, 2: 紐づけ済み
-            $aPriority = $aMapped ? ($aIsNotSong ? 1 : 2) : 0;
-            $bPriority = $bMapped ? ($bIsNotSong ? 1 : 2) : 0;
-
-            // 優先順位が異なる場合
-            if ($aPriority !== $bPriority) {
-                return $aPriority - $bPriority;
-            }
-
-            // 同じ優先順位の場合はtextで昇順ソート
-            return strcmp($a['text'], $b['text']);
-        })->values();
-
-        // 手動でページネーション
-        $total = $sorted->count();
-        $lastPage = (int) ceil($total / $perPage);
-        $offset = ($currentPage - 1) * $perPage;
-        $items = $sorted->slice($offset, $perPage)->values();
-
         return response()->json([
-            'data' => $items,
-            'current_page' => $currentPage,
-            'last_page' => $lastPage,
-            'per_page' => $perPage,
-            'total' => $total,
-            'from' => $total > 0 ? $offset + 1 : null,
-            'to' => $total > 0 ? min($offset + $perPage, $total) : null,
+            'data' => $items->values(),
+            'current_page' => $paginated->currentPage(),
+            'last_page' => $paginated->lastPage(),
+            'per_page' => $paginated->perPage(),
+            'total' => $paginated->total(),
+            'from' => $paginated->firstItem(),
+            'to' => $paginated->lastItem(),
         ]);
     }
 

--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -63,6 +63,7 @@ class SongController extends Controller
             ->select('ts_items.*', 'timestamp_song_mappings.id as mapping_id', 'timestamp_song_mappings.song_id', 'timestamp_song_mappings.is_not_song')
             ->whereNotNull('ts_items.text')
             ->where('ts_items.text', '!=', '')
+            ->whereNotNull('ts_items.normalized_text') // マイグレーション後の未更新レコードを除外
             ->where('ts_items.is_display', 1)
             ->whereHas('archive', function ($q) {
                 $q->where('is_display', 1);

--- a/app/Http/Requests/FetchTimestampsRequest.php
+++ b/app/Http/Requests/FetchTimestampsRequest.php
@@ -25,7 +25,7 @@ class FetchTimestampsRequest extends FormRequest
             'per_page' => 'integer|min:1|max:100',
             'page' => 'integer|min:1',
             'search' => 'nullable|string|max:255',
-            'unlinked_only' => 'nullable|in:true,false,1,0',
+            'filter' => 'nullable|in:all,unlinked,linked,not_song',
         ];
     }
 }

--- a/app/Models/TsItem.php
+++ b/app/Models/TsItem.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\TextNormalizer;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -20,9 +21,22 @@ class TsItem extends Model
         'ts_text',
         'ts_num',
         'text',
+        'normalized_text',
         'comment_id',
         'is_display',
     ];
+
+    protected static function booted(): void
+    {
+        static::saving(function (TsItem $tsItem) {
+            // textが変更された場合、または normalized_text が null の場合に正規化
+            if ($tsItem->isDirty('text') || $tsItem->attributes['normalized_text'] === null) {
+                // アクセサを経由せず生のtext値を取得して正規化
+                $rawText = $tsItem->attributes['text'] ?? null;
+                $tsItem->normalized_text = TextNormalizer::normalize($rawText);
+            }
+        });
+    }
 
     public function archive()
     {
@@ -39,14 +53,15 @@ class TsItem extends Model
      */
     public function getTextAttribute($value)
     {
-        return \App\Helpers\TextNormalizer::trimFullwidthSpace($value);
+        return TextNormalizer::trimFullwidthSpace($value);
     }
 
     /**
-     * タイムスタンプテキストを正規化して取得
+     * 正規化テキストを取得（カラムがnullの場合は動的計算）
      */
-    public function getNormalizedTextAttribute()
+    public function getNormalizedTextAttribute($value)
     {
-        return \App\Helpers\TextNormalizer::normalize($this->text);
+        // カラムに値があればそれを返す、なければ動的に計算
+        return $value ?? TextNormalizer::normalize($this->text);
     }
 }

--- a/app/Models/TsItem.php
+++ b/app/Models/TsItem.php
@@ -29,11 +29,19 @@ class TsItem extends Model
     protected static function booted(): void
     {
         static::saving(function (TsItem $tsItem) {
-            // textが変更された場合、または normalized_text が null の場合に正規化
-            if ($tsItem->isDirty('text') || $tsItem->attributes['normalized_text'] === null) {
+            // textが変更された場合、または normalized_text が未設定/nullの場合に正規化
+            $normalizedTextIsNull = ! array_key_exists('normalized_text', $tsItem->attributes)
+                || $tsItem->attributes['normalized_text'] === null;
+
+            if ($tsItem->isDirty('text') || $normalizedTextIsNull) {
                 // アクセサを経由せず生のtext値を取得して正規化
                 $rawText = $tsItem->attributes['text'] ?? null;
-                $tsItem->normalized_text = TextNormalizer::normalize($rawText);
+                $normalized = TextNormalizer::normalize($rawText);
+
+                // 正規化結果が現在の値と異なる場合のみ更新（無限ループ回避）
+                if (($tsItem->attributes['normalized_text'] ?? null) !== $normalized) {
+                    $tsItem->attributes['normalized_text'] = $normalized;
+                }
             }
         });
     }
@@ -61,7 +69,7 @@ class TsItem extends Model
      */
     public function getNormalizedTextAttribute($value)
     {
-        // カラムに値があればそれを返す、なければ動的に計算
-        return $value ?? TextNormalizer::normalize($this->text);
+        // カラムに値があればそれを返す、なければ動的に計算（生の値を使用）
+        return $value ?? TextNormalizer::normalize($this->attributes['text'] ?? null);
     }
 }

--- a/database/migrations/2025_11_30_061511_add_normalized_text_to_ts_items_table.php
+++ b/database/migrations/2025_11_30_061511_add_normalized_text_to_ts_items_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ts_items', function (Blueprint $table) {
+            $table->string('normalized_text')->nullable()->after('text');
+            $table->index('normalized_text', 'ts_items_normalized_text_idx');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ts_items', function (Blueprint $table) {
+            $table->dropIndex('ts_items_normalized_text_idx');
+            $table->dropColumn('normalized_text');
+        });
+    }
+};

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -21,7 +21,7 @@ class TimestampNormalization {
         this.currentPage = 1;
         this.currentSearchQuery = ''; // 検索条件を保持
         this.searchTimeout = null;
-        this.unlinkedOnly = false;
+        this.currentFilter = 'all'; // all, unlinked, linked, not_song
 
         this.init();
     }
@@ -43,9 +43,11 @@ class TimestampNormalization {
             }, 500);
         });
 
-        // 未連携フィルター
-        document.getElementById('unlinkedOnlyBtn').addEventListener('click', () => {
-            this.toggleUnlinkedFilter();
+        // フィルターボタン
+        document.querySelectorAll('.filter-btn').forEach(btn => {
+            btn.addEventListener('click', (e) => {
+                this.setFilter(e.target.dataset.filter);
+            });
         });
 
         // 全選択・全選択解除
@@ -110,26 +112,23 @@ class TimestampNormalization {
         document.getElementById('clearSelectionBtn').addEventListener('click', () => this.clearSelection());
     }
 
-    toggleUnlinkedFilter() {
-        this.unlinkedOnly = !this.unlinkedOnly;
-        const btn = document.getElementById('unlinkedOnlyBtn');
-        if (this.unlinkedOnly) {
-            btn.classList.add('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
-            btn.classList.remove('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
-        } else {
-            btn.classList.remove('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
-            btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
-        }
+    setFilter(filter) {
+        this.currentFilter = filter;
+        this.updateFilterButtons();
         this.loadTimestamps(1, this.currentSearchQuery);
     }
 
-    resetUnlinkedFilter() {
-        if (this.unlinkedOnly) {
-            this.unlinkedOnly = false;
-            const btn = document.getElementById('unlinkedOnlyBtn');
-            btn.classList.remove('bg-blue-600', 'text-white', 'hover:bg-blue-700', 'dark:hover:bg-blue-700');
-            btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
-        }
+    updateFilterButtons() {
+        document.querySelectorAll('.filter-btn').forEach(btn => {
+            const isActive = btn.dataset.filter === this.currentFilter;
+            if (isActive) {
+                btn.classList.add('bg-blue-600', 'text-white');
+                btn.classList.remove('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
+            } else {
+                btn.classList.remove('bg-blue-600', 'text-white');
+                btn.classList.add('bg-gray-200', 'dark:bg-gray-700', 'hover:bg-gray-300', 'dark:hover:bg-gray-600');
+            }
+        });
     }
 
     async loadTimestamps(page = 1, search = '') {
@@ -139,7 +138,7 @@ class TimestampNormalization {
                 page,
                 per_page: 50,
                 search,
-                unlinked_only: this.unlinkedOnly
+                filter: this.currentFilter
             });
 
             const parsedPage = parseInt(data.current_page, 10);
@@ -163,26 +162,10 @@ class TimestampNormalization {
             return;
         }
 
-        const sortedTimestamps = this.sortTimestamps(timestamps);
-
-        sortedTimestamps.forEach(ts => {
+        // DBでソート済みなのでそのまま表示
+        timestamps.forEach(ts => {
             container.appendChild(this.createTimestampElement(ts));
         });
-    }
-
-    sortTimestamps(timestamps) {
-        return [...timestamps]
-            .map(ts => ({
-                timestamp: ts,
-                sortKey: ts.song
-                    ? `${ts.song.title || ''} - ${ts.song.artist || ''}`.trim()
-                    : (ts.text || '')
-            }))
-            .sort((a, b) => {
-                const comparison = a.sortKey.localeCompare(b.sortKey, 'ja');
-                return comparison !== 0 ? comparison : a.timestamp.id - b.timestamp.id;
-            })
-            .map(item => item.timestamp);
     }
 
     createTimestampElement(ts) {
@@ -722,7 +705,6 @@ class TimestampNormalization {
             this.selectedTimestamps = [];
             this.selectedSpotifyTrack = null;
 
-            this.resetUnlinkedFilter();
             await this.loadTimestamps(this.currentPage, this.currentSearchQuery);
             this.updateSelectionDisplay();
         } catch (error) {
@@ -753,7 +735,6 @@ class TimestampNormalization {
             toast.success('楽曲ではないとマークしました。');
             this.selectedTimestamps = [];
 
-            this.resetUnlinkedFilter();
             await this.loadTimestamps(this.currentPage, this.currentSearchQuery);
             this.updateSelectionDisplay();
         } catch (error) {

--- a/resources/js/songs/services/TimestampApiService.js
+++ b/resources/js/songs/services/TimestampApiService.js
@@ -10,12 +10,12 @@ export class TimestampApiService {
      * @param {number} params.page - ページ番号
      * @param {number} params.per_page - 1ページあたりの件数
      * @param {string} params.search - 検索クエリ
-     * @param {boolean} params.unlinked_only - 未連携のみ
+     * @param {string} params.filter - フィルター (all, unlinked, linked, not_song)
      * @returns {Promise<Object>} タイムスタンプ一覧データ
      */
-    async fetchTimestamps({ page = 1, per_page = 50, search = '', unlinked_only = false }) {
+    async fetchTimestamps({ page = 1, per_page = 50, search = '', filter = 'all' }) {
         const response = await axios.get('/api/songs/timestamps', {
-            params: { page, per_page, search, unlinked_only }
+            params: { page, per_page, search, filter }
         });
         return response.data;
     }

--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -37,11 +37,24 @@
                 <!-- タイムスタンプ一覧 -->
                 <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
                     <div class="p-6 text-gray-900 dark:text-gray-100">
-                        <div class="flex justify-between items-center mb-3">
-                            <h3 class="text-lg font-semibold">タイムスタンプ一覧</h3>
-                            <button id="unlinkedOnlyBtn" class="px-3 py-1 bg-gray-200 dark:bg-gray-700 text-sm rounded hover:bg-gray-300 dark:hover:bg-gray-600">
-                                未連携のみ
-                            </button>
+                        <div class="flex flex-col gap-2 mb-3">
+                            <div class="flex justify-between items-center">
+                                <h3 class="text-lg font-semibold">タイムスタンプ一覧</h3>
+                            </div>
+                            <div class="flex gap-1 flex-wrap" id="filterButtons">
+                                <button data-filter="all" class="filter-btn px-3 py-1 text-sm rounded bg-blue-600 text-white">
+                                    すべて
+                                </button>
+                                <button data-filter="unlinked" class="filter-btn px-3 py-1 text-sm rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600">
+                                    未紐づけ
+                                </button>
+                                <button data-filter="linked" class="filter-btn px-3 py-1 text-sm rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600">
+                                    紐づけ済み
+                                </button>
+                                <button data-filter="not_song" class="filter-btn px-3 py-1 text-sm rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600">
+                                    楽曲ではない
+                                </button>
+                            </div>
                         </div>
 
                         <!-- 全選択・全選択解除ボタンと動画情報 -->

--- a/tests/Feature/SongControllerTest.php
+++ b/tests/Feature/SongControllerTest.php
@@ -110,9 +110,9 @@ class SongControllerTest extends TestCase
     }
 
     /**
-     * タイムスタンプ一覧取得のテスト（未連携フィルター）
+     * タイムスタンプ一覧取得のテスト（フィルター: unlinked）
      */
-    public function test_fetch_timestamps_with_unlinked_only_filter(): void
+    public function test_fetch_timestamps_with_unlinked_filter(): void
     {
         $channel = Channel::factory()->create();
         $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
@@ -138,7 +138,78 @@ class SongControllerTest extends TestCase
             ->create();
 
         $response = $this->actingAs($this->user)->getJson(route('songs.fetchTimestamps', [
-            'unlinked_only' => true,
+            'filter' => 'unlinked',
+        ]));
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $response->json('total'));
+    }
+
+    /**
+     * タイムスタンプ一覧取得のテスト（フィルター: linked）
+     */
+    public function test_fetch_timestamps_with_linked_filter(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 未連携タイムスタンプ
+        TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Unlinked Song',
+            'is_display' => 1,
+        ]);
+
+        // 連携済みタイムスタンプ
+        $linked = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Linked Song',
+            'is_display' => 1,
+        ]);
+
+        $song = Song::factory()->create();
+        TimestampSongMapping::factory()
+            ->withSong($song)
+            ->withText($linked->text)
+            ->create();
+
+        $response = $this->actingAs($this->user)->getJson(route('songs.fetchTimestamps', [
+            'filter' => 'linked',
+        ]));
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $response->json('total'));
+    }
+
+    /**
+     * タイムスタンプ一覧取得のテスト（フィルター: not_song）
+     */
+    public function test_fetch_timestamps_with_not_song_filter(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 未連携タイムスタンプ
+        TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Unlinked Song',
+            'is_display' => 1,
+        ]);
+
+        // 「楽曲ではない」タイムスタンプ
+        $notSong = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Not A Song',
+            'is_display' => 1,
+        ]);
+
+        TimestampSongMapping::factory()
+            ->withText($notSong->text)
+            ->notSong()
+            ->create();
+
+        $response = $this->actingAs($this->user)->getJson(route('songs.fetchTimestamps', [
+            'filter' => 'not_song',
         ]));
 
         $response->assertStatus(200);


### PR DESCRIPTION
## Summary
- #280 の対応
- ts_itemsテーブルにnormalized_textカラムを追加（JOINのため）
- TsItemモデルにboot処理追加（保存時の自動正規化）
- 既存データ更新用のArtisanコマンド追加 (`php artisan ts-items:normalize`)
- SongController::fetchTimestamps()をDBレベルJOIN/フィルタリング/ページネーションに変更
- フロントエンドのフィルターUIを4ボタン（すべて/未紐づけ/紐づけ済み/楽曲ではない）に変更
- 手動ソート処理を削除（DB側でソート）
- テストケースを新filterパラメータに対応

## デプロイ後に必要な作業
1. マイグレーション実行: `php artisan migrate`
2. 既存データの正規化: `php artisan ts-items:normalize`

## Test plan
- [x] 全テスト通過 (209 passed)
- [ ] 本番環境でマイグレーション実行
- [ ] 本番環境で既存データ正規化実行
- [ ] フィルターボタンの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)