### PR TITLE
perf: YouTube/Spotify APIのレート制限エラーハンドリングを追加

### DIFF
--- a/app/Services/SpotifyService.php
+++ b/app/Services/SpotifyService.php
@@ -48,6 +48,14 @@ class SpotifyService
             return true;
         }
 
+        // レート制限エラーをチェック
+        if ($response->status() === 429) {
+            Log::warning('Spotify API rate limit exceeded in authenticate', [
+                'status' => $response->status(),
+            ]);
+            throw new \Exception('Spotify APIのレート制限に達しました。しばらく待ってからお試しください。');
+        }
+
         throw new \Exception('Spotify authentication failed with status '.$response->status());
     }
 
@@ -78,7 +86,11 @@ class SpotifyService
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
             ]);
-            throw new \Exception('Spotify API authentication failed. Please check your credentials.');
+            // レート制限エラーの場合はそのまま再スロー
+            if (strpos($e->getMessage(), 'レート制限') !== false) {
+                throw $e;
+            }
+            throw new \Exception('Spotify API認証に失敗しました。認証情報を確認してください。');
         }
 
         // 検索処理
@@ -90,7 +102,11 @@ class SpotifyService
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
             ]);
-            throw new \Exception('Spotify API search failed. Please try again later.');
+            // レート制限エラーの場合はそのまま再スロー
+            if (strpos($e->getMessage(), 'レート制限') !== false) {
+                throw $e;
+            }
+            throw new \Exception('Spotify API検索に失敗しました。しばらくしてから再度お試しください。');
         }
     }
 
@@ -99,6 +115,8 @@ class SpotifyService
      *
      * market=JP を指定することで、日本市場向けのローカライズされた
      * アーティスト名が返される可能性があります。
+     *
+     * @throws \Exception レート制限エラー時
      */
     public function searchTracks($query, $limit = 10)
     {
@@ -117,6 +135,15 @@ class SpotifyService
             return $response->json()['tracks']['items'];
         }
 
+        // レート制限エラーをチェック
+        if ($response->status() === 429) {
+            Log::warning('Spotify API rate limit exceeded in searchTracks', [
+                'query' => $query,
+                'status' => $response->status(),
+            ]);
+            throw new \Exception('Spotify APIのレート制限に達しました。しばらく待ってからお試しください。');
+        }
+
         throw new \Exception('Spotify search request failed with status '.$response->status());
     }
 
@@ -125,6 +152,8 @@ class SpotifyService
      *
      * market=JP を指定することで、日本市場向けのローカライズされた
      * アーティスト名が返される可能性があります。
+     *
+     * @throws \Exception レート制限エラー時
      */
     public function getTrack($trackId)
     {
@@ -138,6 +167,15 @@ class SpotifyService
 
         if ($response->successful()) {
             return $response->json();
+        }
+
+        // レート制限エラーをチェック
+        if ($response->status() === 429) {
+            Log::warning('Spotify API rate limit exceeded in getTrack', [
+                'track_id' => $trackId,
+                'status' => $response->status(),
+            ]);
+            throw new \Exception('Spotify APIのレート制限に達しました。しばらく待ってからお試しください。');
         }
 
         throw new \Exception('Spotify get track request failed with status '.$response->status());

--- a/app/Services/YouTubeApiService.php
+++ b/app/Services/YouTubeApiService.php
@@ -28,6 +28,45 @@ class YouTubeApiService
     }
 
     /**
+     * YouTube APIエラーを処理
+     *
+     * このメソッドは常に例外を再スローします。
+     * quota超過/レート制限エラーはユーザーに分かりやすいメッセージに変換されます。
+     *
+     * @param  Exception  $e  例外
+     * @param  string  $method  呼び出し元メソッド名
+     * @param  array  $context  追加コンテキスト
+     *
+     * @throws Exception 常に例外を再スロー
+     */
+    protected function handleApiError(Exception $e, string $method, array $context = []): never
+    {
+        $message = $e->getMessage();
+
+        // quota超過またはレート制限エラーをチェック
+        if (strpos($message, 'quotaExceeded') !== false) {
+            Log::warning("YouTube API quota exceeded in {$method}", array_merge($context, [
+                'error' => $message,
+            ]));
+            throw new Exception('YouTube APIの利用制限に達しました。明日以降にお試しください。');
+        }
+
+        if (strpos($message, 'rateLimitExceeded') !== false) {
+            Log::warning("YouTube API rate limit exceeded in {$method}", array_merge($context, [
+                'error' => $message,
+            ]));
+            throw new Exception('YouTube APIのレート制限に達しました。しばらく待ってからお試しください。');
+        }
+
+        // その他のエラーはログを残して再スロー
+        Log::error("YouTube API error in {$method}", array_merge($context, [
+            'error' => $message,
+            'code' => $e->getCode(),
+        ]));
+        throw $e;
+    }
+
+    /**
      * APIキーを設定してYouTube APIクライアントを初期化
      *
      * @throws Exception APIキーが設定されていない、または無効な場合
@@ -55,14 +94,20 @@ class YouTubeApiService
      *
      * @param  string  $handle  チャンネルハンドル
      * @return array|null チャンネル情報、見つからない場合null
+     *
+     * @throws Exception API quota超過またはレート制限時
      */
     public function getChannelByHandle(string $handle): ?array
     {
         $this->setApiKey();
 
-        $response = $this->youtube->channels->listChannels('snippet', [
-            'forHandle' => $handle,
-        ]);
+        try {
+            $response = $this->youtube->channels->listChannels('snippet', [
+                'forHandle' => $handle,
+            ]);
+        } catch (Exception $e) {
+            $this->handleApiError($e, 'getChannelByHandle', ['handle' => $handle]);
+        }
 
         // 検索結果が存在するかを確認
         if (count($response->getItems()) > 0) {
@@ -88,6 +133,8 @@ class YouTubeApiService
      *
      * @param  string  $channelId  チャンネルID
      * @return array アーカイブ配列
+     *
+     * @throws Exception API quota超過またはレート制限時
      */
     public function getArchives(string $channelId): array
     {
@@ -101,11 +148,15 @@ class YouTubeApiService
         $response = null;
         $archives = [];
         do {
-            $response = $this->youtube->playlistItems->listPlaylistItems('snippet', [
-                'playlistId' => $playlistId,
-                'maxResults' => $maxResults,
-                'pageToken' => $response ? $response->getNextPageToken() : '',
-            ]);
+            try {
+                $response = $this->youtube->playlistItems->listPlaylistItems('snippet', [
+                    'playlistId' => $playlistId,
+                    'maxResults' => $maxResults,
+                    'pageToken' => $response ? $response->getNextPageToken() : '',
+                ]);
+            } catch (Exception $e) {
+                $this->handleApiError($e, 'getArchives', ['channel_id' => $channelId]);
+            }
 
             if (is_array($response->getItems())) {
                 foreach ($response->getItems() as $item) {
@@ -142,6 +193,8 @@ class YouTubeApiService
      *
      * @param  string  $videoId  動画ID
      * @return array コメント配列
+     *
+     * @throws Exception API quota超過またはレート制限時
      */
     public function getComments(string $videoId): array
     {
@@ -162,20 +215,29 @@ class YouTubeApiService
                 // コメントスレッドを取得
                 $response = $this->youtube->commentThreads->listCommentThreads('snippet', $params);
             } catch (Exception $e) {
-                // コメントが無効な場合はスキップ
-                if (strpos($e->getMessage(), 'has disabled comments') !== false) {
+                $message = $e->getMessage();
+
+                // コメントが無効な場合はスキップ（正常な動作）
+                if (strpos($message, 'has disabled comments') !== false) {
                     Log::info('YouTube API: Comments disabled for video', [
                         'video_id' => $videoId,
                     ]);
-                    break; // コメントが無効の場合はループを抜ける
-                } else {
-                    Log::error('YouTube API: Failed to fetch comments', [
-                        'video_id' => $videoId,
-                        'error' => $e->getMessage(),
-                        'code' => $e->getCode(),
-                    ]);
-                    break; // その他のエラーもループを抜ける
+                    break;
                 }
+
+                // quota/レート制限エラーは例外をスロー（handleApiErrorは常に例外をスロー）
+                if (strpos($message, 'quotaExceeded') !== false ||
+                    strpos($message, 'rateLimitExceeded') !== false) {
+                    $this->handleApiError($e, 'getComments', ['video_id' => $videoId]);
+                }
+
+                // その他のエラーはログを残してスキップ
+                Log::warning('YouTube API: Failed to fetch comments', [
+                    'video_id' => $videoId,
+                    'error' => $message,
+                    'code' => $e->getCode(),
+                ]);
+                break;
             }
 
             // レスポンスがない場合はスキップ


### PR DESCRIPTION
## Summary
- YouTubeApiServiceに`handleApiError()`メソッドを追加し、quota超過/レート制限エラーをユーザーに分かりやすいメッセージで伝える
- SpotifyServiceにHTTP 429（レート制限）エラーのハンドリングを追加
- エラーメッセージを日本語化

## 変更内容

### YouTubeApiService
- `handleApiError()`メソッドを追加
  - `quotaExceeded`: 「YouTube APIの利用制限に達しました。明日以降にお試しください。」
  - `rateLimitExceeded`: 「YouTube APIのレート制限に達しました。しばらく待ってからお試しください。」
- `getChannelByHandle()`, `getArchives()`, `getComments()`にtry-catchを追加

### SpotifyService
- HTTP 429エラー時に適切なメッセージを表示
- `searchWithAuth()`のエラーメッセージを日本語化

## Test plan
- [x] 全テスト通過確認済み（209 tests）
- [x] Laravel Pintでコードスタイルチェック済み
- [x] フロントエンドビルド確認済み

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)