### PR TITLE
perf: YouTubeチャンネル情報とサムネイル画像のキャッシュを追加

### DIFF
--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -2,12 +2,16 @@
 
 namespace App\Services;
 
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Intervention\Image\Drivers\Gd\Driver;
 use Intervention\Image\ImageManager;
 
 class ImageService
 {
+    /** サムネイル画像のキャッシュ時間（7日間） */
+    private const THUMBNAIL_CACHE_TTL = 60 * 60 * 24 * 7;
+
     protected $imageManager;
 
     public function __construct(Driver $driver)
@@ -15,8 +19,29 @@ class ImageService
         $this->imageManager = new ImageManager($driver);
     }
 
-    public function downloadThumbnail($thumbnailUrl)
+    /**
+     * サムネイル画像をダウンロードしてBase64形式で返す
+     *
+     * 画像は7日間キャッシュされます。
+     *
+     * @param  string  $thumbnailUrl  サムネイル画像のURL
+     * @return string|null Base64エンコードされた画像データ、エラー時はnull
+     */
+    public function downloadThumbnail(string $thumbnailUrl): ?string
     {
+        if (empty($thumbnailUrl)) {
+            return null;
+        }
+
+        // URLからキャッシュキーを生成（URLのハッシュを使用）
+        $cacheKey = 'thumbnail_'.md5($thumbnailUrl);
+
+        // キャッシュから取得を試みる
+        $cached = Cache::get($cacheKey);
+        if ($cached !== null) {
+            return $cached;
+        }
+
         // 画像データを取得
         $response = Http::get($thumbnailUrl);
 
@@ -27,7 +52,12 @@ class ImageService
                 ->resize(30, 30);
 
             // Base64形式にエンコード
-            return $image->toJpeg()->toDataUri();
+            $dataUri = $image->toJpeg()->toDataUri();
+
+            // キャッシュに保存（7日間）
+            Cache::put($cacheKey, $dataUri, self::THUMBNAIL_CACHE_TTL);
+
+            return $dataUri;
         }
 
         return null; // エラー時はnullを返す

--- a/app/Services/YouTubeApiService.php
+++ b/app/Services/YouTubeApiService.php
@@ -8,6 +8,7 @@ use Google\Client as Google_Client;
 use Google\Service\YouTube as Google_Service_YouTube;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
@@ -18,6 +19,9 @@ use Illuminate\Support\Str;
  */
 class YouTubeApiService
 {
+    /** チャンネル情報のキャッシュ時間（24時間） */
+    private const CHANNEL_CACHE_TTL = 60 * 60 * 24;
+
     protected $client;
 
     protected $youtube;
@@ -92,13 +96,26 @@ class YouTubeApiService
     /**
      * ハンドル名からチャンネル情報を取得
      *
+     * チャンネル情報は24時間キャッシュされます。
+     *
      * @param  string  $handle  チャンネルハンドル
+     * @param  bool  $forceRefresh  trueの場合、キャッシュを無視して再取得
      * @return array|null チャンネル情報、見つからない場合null
      *
      * @throws Exception API quota超過またはレート制限時
      */
-    public function getChannelByHandle(string $handle): ?array
+    public function getChannelByHandle(string $handle, bool $forceRefresh = false): ?array
     {
+        $cacheKey = "youtube_channel_{$handle}";
+
+        // 強制再取得でない場合はキャッシュから取得を試みる
+        if (! $forceRefresh) {
+            $cached = Cache::get($cacheKey);
+            if ($cached !== null) {
+                return $cached;
+            }
+        }
+
         $this->setApiKey();
 
         try {
@@ -118,11 +135,16 @@ class YouTubeApiService
             $thumbnails = $snippet ? $snippet->getThumbnails() : null;
             $defaultThumb = $thumbnails ? ($thumbnails->getDefault() ? $thumbnails->getDefault()->getUrl() : null) : null;
 
-            return [
+            $channelInfo = [
                 'title' => $snippet ? $snippet->getTitle() : '',
                 'channel_id' => $channel->getId(),
                 'thumbnail' => $defaultThumb ?? '',
             ];
+
+            // キャッシュに保存（24時間）
+            Cache::put($cacheKey, $channelInfo, self::CHANNEL_CACHE_TTL);
+
+            return $channelInfo;
         }
 
         return null; // 該当するチャンネルが見つからない場合


### PR DESCRIPTION
## Summary
- YouTubeチャンネル情報を24時間キャッシュ
- サムネイル画像を7日間キャッシュ
- Fileキャッシュドライバーを使用

## 変更内容

### YouTubeApiService
- `getChannelByHandle()`に24時間キャッシュを追加
- `forceRefresh`パラメータで強制再取得に対応

### ImageService
- `downloadThumbnail()`に7日間キャッシュを追加
- URLのMD5ハッシュをキャッシュキーとして使用
- 型指定を追加（`string $thumbnailUrl`: `?string`）

## 期待効果
- YouTube API呼び出し回数の削減
- サムネイル画像のダウンロード回数削減
- レスポンス時間の改善

## Test plan
- [x] 全テスト通過確認済み（209 tests）
- [x] Laravel Pintでコードスタイルチェック済み
- [x] フロントエンドビルド確認済み

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)