### PR TITLE
feat: Database Queue対応を追加 #286

### DIFF
--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -6,6 +6,7 @@ use App\Exceptions\NotFoundException;
 use App\Http\Requests\EditTimestampsRequest;
 use App\Http\Requests\FetchCommentsRequest;
 use App\Http\Requests\ToggleDisplayRequest;
+use App\Jobs\RefreshChannelArchivesJob;
 use App\Models\Archive;
 use App\Models\ChangeList;
 use App\Models\Channel;
@@ -152,9 +153,27 @@ class ManageController extends Controller
             abort(403, 'このチャンネルへのアクセス権限がありません');
         }
 
-        $this->refreshArchiveService->refreshArchives($channel);
+        // キュー設定に応じて同期/非同期で実行
+        // sync: 同期実行（従来動作）, database/redis等: 非同期実行
+        $queueConnection = config('queue.default');
 
-        return response()->json('アーカイブを登録しました');
+        if ($queueConnection === 'sync') {
+            // 同期実行（従来動作）
+            $this->refreshArchiveService->refreshArchives($channel);
+
+            return response()->json([
+                'message' => 'アーカイブを登録しました',
+                'async' => false,
+            ]);
+        }
+
+        // 非同期実行
+        RefreshChannelArchivesJob::dispatch($channel, Auth::id());
+
+        return response()->json([
+            'message' => 'アーカイブの更新処理をキューに登録しました。完了までしばらくお待ちください。',
+            'async' => true,
+        ]);
     }
 
     // 動画の表示非表示切り替え

--- a/app/Jobs/RefreshChannelArchivesJob.php
+++ b/app/Jobs/RefreshChannelArchivesJob.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Channel;
+use App\Services\RefreshArchiveService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class RefreshChannelArchivesJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** ジョブのタイムアウト（5分） */
+    public int $timeout = 300;
+
+    /** リトライ回数 */
+    public int $tries = 1;
+
+    public Channel $channel;
+
+    public int $userId;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(Channel $channel, int $userId)
+    {
+        $this->channel = $channel;
+        $this->userId = $userId;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(RefreshArchiveService $refreshArchiveService): void
+    {
+        Log::info('RefreshChannelArchivesJob started', [
+            'channel_id' => $this->channel->channel_id,
+            'handle' => $this->channel->handle,
+            'user_id' => $this->userId,
+        ]);
+
+        try {
+            // キューワーカーはセッションがないため、CLIログインでユーザーを設定
+            $refreshArchiveService->cliLogin((string) $this->userId);
+
+            $count = $refreshArchiveService->refreshArchives($this->channel);
+
+            Log::info('RefreshChannelArchivesJob completed', [
+                'channel_id' => $this->channel->channel_id,
+                'handle' => $this->channel->handle,
+                'archives_count' => $count,
+            ]);
+        } catch (\Exception $e) {
+            Log::error('RefreshChannelArchivesJob failed', [
+                'channel_id' => $this->channel->channel_id,
+                'handle' => $this->channel->handle,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Handle a job failure.
+     */
+    public function failed(?\Throwable $exception): void
+    {
+        Log::error('RefreshChannelArchivesJob permanently failed', [
+            'channel_id' => $this->channel->channel_id,
+            'handle' => $this->channel->handle,
+            'error' => $exception?->getMessage(),
+        ]);
+    }
+}

--- a/database/migrations/2025_12_02_144142_create_jobs_table.php
+++ b/database/migrations/2025_12_02_144142_create_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};

--- a/resources/js/manage/archives.js
+++ b/resources/js/manage/archives.js
@@ -146,6 +146,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
         axios.post('/api/manage/archives', formData)
             .then(function (response) {
+                const data = response.data;
+                // 非同期実行の場合はメッセージを表示
+                if (data.async) {
+                    alert(data.message || 'アーカイブの更新処理をキューに登録しました。完了までしばらくお待ちください。');
+                }
                 // 登録成功後にアーカイブ一覧を再取得
                 fetchArchives();
             })

--- a/tests/Feature/ManageControllerTest.php
+++ b/tests/Feature/ManageControllerTest.php
@@ -2,12 +2,15 @@
 
 namespace Tests\Feature;
 
+use App\Jobs\RefreshChannelArchivesJob;
 use App\Models\Archive;
 use App\Models\ChangeList;
 use App\Models\Channel;
 use App\Models\TsItem;
 use App\Models\User;
+use App\Services\RefreshArchiveService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Tests\TestCase;
 
 class ManageControllerTest extends TestCase
@@ -381,5 +384,63 @@ class ManageControllerTest extends TestCase
             ]);
 
         $response->assertStatus(403);
+    }
+
+    /**
+     * sync設定では同期実行される
+     */
+    public function test_add_archives_runs_synchronously_when_queue_is_sync(): void
+    {
+        config(['queue.default' => 'sync']);
+
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+
+        $mockService = $this->mock(RefreshArchiveService::class);
+        $mockService->shouldReceive('refreshArchives')
+            ->once()
+            ->andReturn(10);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/manage/archives', [
+                'handle' => \Illuminate\Support\Facades\Crypt::encryptString($channel->handle),
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'アーカイブを登録しました',
+                'async' => false,
+            ]);
+    }
+
+    /**
+     * database設定では非同期実行される（ジョブがキューにディスパッチされる）
+     */
+    public function test_add_archives_dispatches_job_when_queue_is_database(): void
+    {
+        // configを変更してからQueue::fake()を呼ぶ
+        config(['queue.default' => 'database']);
+        Queue::fake();
+
+        $channel = Channel::factory()->create(['user_id' => $this->user->id]);
+
+        // デバッグ: 設定値を確認
+        $this->assertEquals('database', config('queue.default'), 'Config should be database');
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/manage/archives', [
+                'handle' => \Illuminate\Support\Facades\Crypt::encryptString($channel->handle),
+            ]);
+
+        // レスポンスの内容を確認
+        $responseData = $response->json();
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'アーカイブの更新処理をキューに登録しました。完了までしばらくお待ちください。',
+                'async' => true,
+            ]);
+
+        // シンプルにジョブがプッシュされたことを確認
+        Queue::assertPushed(RefreshChannelArchivesJob::class);
     }
 }

--- a/tests/Unit/Jobs/RefreshChannelArchivesJobTest.php
+++ b/tests/Unit/Jobs/RefreshChannelArchivesJobTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\RefreshChannelArchivesJob;
+use App\Models\Channel;
+use App\Models\User;
+use App\Services\RefreshArchiveService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class RefreshChannelArchivesJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * ジョブがキューにディスパッチされることを確認
+     */
+    public function test_job_is_dispatched_to_queue(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create(['api_key' => 'test-api-key']);
+        $channel = Channel::factory()->create(['user_id' => $user->id]);
+
+        RefreshChannelArchivesJob::dispatch($channel, $user->id);
+
+        Queue::assertPushed(RefreshChannelArchivesJob::class, function ($job) use ($channel, $user) {
+            return $job->channel->id === $channel->id
+                && $job->userId === $user->id;
+        });
+    }
+
+    /**
+     * ジョブが正しいプロパティを持つことを確認
+     */
+    public function test_job_has_correct_properties(): void
+    {
+        $user = User::factory()->create(['api_key' => 'test-api-key']);
+        $channel = Channel::factory()->create(['user_id' => $user->id]);
+
+        $job = new RefreshChannelArchivesJob($channel, $user->id);
+
+        $this->assertEquals(300, $job->timeout);
+        $this->assertEquals(1, $job->tries);
+    }
+
+    /**
+     * ジョブが実行時にRefreshArchiveServiceを呼び出すことを確認
+     */
+    public function test_job_calls_refresh_archive_service(): void
+    {
+        $user = User::factory()->create(['api_key' => 'test-api-key']);
+        $channel = Channel::factory()->create(['user_id' => $user->id]);
+
+        $mockService = $this->mock(RefreshArchiveService::class);
+        $mockService->shouldReceive('cliLogin')
+            ->once()
+            ->with((string) $user->id);
+        $mockService->shouldReceive('refreshArchives')
+            ->once()
+            ->with(\Mockery::on(function ($arg) use ($channel) {
+                return $arg->id === $channel->id;
+            }))
+            ->andReturn(10);
+
+        $job = new RefreshChannelArchivesJob($channel, $user->id);
+        $job->handle($mockService);
+    }
+}


### PR DESCRIPTION
## Summary
- RefreshChannelArchivesJobを作成
- ManageController::addArchives()でキュー設定に応じて同期/非同期実行を切り替え
- jobsテーブルのマイグレーションを追加
- フロントエンドで非同期レスポンスに対応

## 動作
- `QUEUE_CONNECTION=sync`（デフォルト）: 従来通り同期実行
- `QUEUE_CONNECTION=database`: アーカイブ更新処理がバックグラウンドで実行

## 本番運用時の追加設定
Database Queueを使用する場合は以下の設定が必要:

1. `.env`に`QUEUE_CONNECTION=database`を設定
2. `php artisan migrate`でjobsテーブルを作成
3. `php artisan queue:work`でワーカーを起動

## Test plan
- [x] 全テストがパス（214 passed）
- [x] sync設定で同期実行されることを確認
- [x] database設定でジョブがキューにディスパッチされることを確認

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)