### PR TITLE
perf: SongSearchServiceの正規化カラム追加 #289

### DIFF
--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Helpers\TextNormalizer;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -19,11 +20,26 @@ class Song extends Model
         'artist',
         'spotify_track_id',
         'spotify_data',
+        'normalized_title',
+        'normalized_artist',
     ];
 
     protected $casts = [
         'spotify_data' => 'array',
     ];
+
+    protected static function booted(): void
+    {
+        // 保存時に正規化カラムを自動設定
+        static::saving(function (Song $song) {
+            if ($song->isDirty('title') || $song->normalized_title === null) {
+                $song->normalized_title = TextNormalizer::normalize($song->title);
+            }
+            if ($song->isDirty('artist') || $song->normalized_artist === null) {
+                $song->normalized_artist = TextNormalizer::normalize($song->artist);
+            }
+        });
+    }
 
     public function mappings()
     {

--- a/app/Services/SongSearchService.php
+++ b/app/Services/SongSearchService.php
@@ -18,6 +18,8 @@ class SongSearchService
     /**
      * 類似する楽曲を検索
      *
+     * 正規化カラムを使用してDBレベルで候補を絞り込み、PHP側で類似度を計算。
+     *
      * @param  string  $normalizedTitle  正規化済みタイトル
      * @param  string  $normalizedArtist  正規化済みアーティスト名
      * @param  float  $threshold  類似度の閾値（デフォルト: 0.75）
@@ -25,21 +27,21 @@ class SongSearchService
      */
     public function findSimilarSongs(string $normalizedTitle, string $normalizedArtist, float $threshold = 0.75): array
     {
-        // パフォーマンス最適化：部分一致で候補を絞り込んでから類似度計算
-        // 正規化後のタイトル・アーティストの最初の3文字で絞り込み
+        // 正規化カラムを使用して候補を絞り込み（DBレベル最適化）
         $titlePrefix = mb_substr($normalizedTitle, 0, 3);
         $artistPrefix = mb_substr($normalizedArtist, 0, 3);
 
         $candidateSongs = Song::where(function ($query) use ($titlePrefix, $artistPrefix) {
-            $query->where('title', 'like', "{$titlePrefix}%")
-                ->orWhere('artist', 'like', "{$artistPrefix}%");
+            $query->where('normalized_title', 'like', "{$titlePrefix}%")
+                ->orWhere('normalized_artist', 'like', "{$artistPrefix}%");
         })->limit(100)->get();
 
         $similarSongs = [];
 
         foreach ($candidateSongs as $song) {
-            $songNormalizedTitle = TextNormalizer::normalize($song->title);
-            $songNormalizedArtist = TextNormalizer::normalize($song->artist);
+            // 正規化カラムを直接使用（normalize()呼び出し不要）
+            $songNormalizedTitle = $song->normalized_title ?? TextNormalizer::normalize($song->title);
+            $songNormalizedArtist = $song->normalized_artist ?? TextNormalizer::normalize($song->artist);
 
             // タイトルとアーティスト名の類似度を計算
             $titleSimilarity = $this->similarityService->calculateSimilarity($normalizedTitle, $songNormalizedTitle);
@@ -70,7 +72,7 @@ class SongSearchService
      * 正規化後のタイトル・アーティスト名で一致する楽曲を検索
      *
      * 1. まずtimestamp_song_mappingsを類似検索して、既存マッピング経由で楽曲を探す
-     * 2. マッピングで見つからない場合、楽曲マスタをchunkで検索（メモリ削減）
+     * 2. マッピングで見つからない場合、正規化カラムを使用してDBレベルで検索
      *
      * @param  string  $normalizedTitle  正規化済みタイトル
      * @param  string  $normalizedArtist  正規化済みアーティスト名
@@ -88,21 +90,9 @@ class SongSearchService
             return $mapping->song;
         }
 
-        // 2. フォールバック: 楽曲マスタを直接検索（chunkでメモリ削減）
-        $foundSong = null;
-        Song::chunk(100, function ($songs) use ($normalizedTitle, $normalizedArtist, &$foundSong) {
-            foreach ($songs as $song) {
-                $songNormalizedTitle = TextNormalizer::normalize($song->title);
-                $songNormalizedArtist = TextNormalizer::normalize($song->artist);
-
-                if ($songNormalizedTitle === $normalizedTitle && $songNormalizedArtist === $normalizedArtist) {
-                    $foundSong = $song;
-
-                    return false; // チャンク処理を中断
-                }
-            }
-        });
-
-        return $foundSong;
+        // 2. 正規化カラムを使用してDBレベルで検索（効率化）
+        return Song::where('normalized_title', $normalizedTitle)
+            ->where('normalized_artist', $normalizedArtist)
+            ->first();
     }
 }

--- a/database/migrations/2025_12_02_150000_add_normalized_columns_to_songs_table.php
+++ b/database/migrations/2025_12_02_150000_add_normalized_columns_to_songs_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Helpers\TextNormalizer;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->string('normalized_title')->after('title')->nullable();
+            $table->string('normalized_artist')->after('artist')->nullable();
+
+            $table->index('normalized_title');
+            $table->index('normalized_artist');
+        });
+
+        // 既存データに正規化済みの値を設定
+        DB::table('songs')->orderBy('id')->chunk(100, function ($songs) {
+            foreach ($songs as $song) {
+                DB::table('songs')
+                    ->where('id', $song->id)
+                    ->update([
+                        'normalized_title' => TextNormalizer::normalize($song->title),
+                        'normalized_artist' => TextNormalizer::normalize($song->artist),
+                    ]);
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->dropIndex(['normalized_title']);
+            $table->dropIndex(['normalized_artist']);
+            $table->dropColumn(['normalized_title', 'normalized_artist']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- songsテーブルにnormalized_title/normalized_artistカラムを追加
- SongモデルでsavingイベントでTextNormalizerを自動実行
- SongSearchServiceで正規化カラムを使用したDBレベル検索に変更

## 変更内容
### マイグレーション
- `normalized_title`カラム追加（インデックス付き）
- `normalized_artist`カラム追加（インデックス付き）
- 既存データのマイグレーション処理

### Songモデル
- savingイベントで自動的に正規化カラムを設定

### SongSearchService
- `findSimilarSongs`: 正規化カラムを使用したLIKE検索
- `findExactMatch`: chunkループを廃止しDBレベル検索に変更

## 効果
- 楽曲検索時のTextNormalizer::normalize()呼び出しを削減
- DBレベルでインデックスを使用した効率的な検索が可能に

## 本番運用時の追加設定
`php artisan migrate`の実行が必要

## Test plan
- [x] 全テストがパス（209 passed）
- [x] SongControllerTestがパス（37 passed）

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)