### PR TITLE
fix: TimestampExtractorServiceでnormalized_textを設定するよう修正

### DIFF
--- a/app/Services/TimestampExtractorService.php
+++ b/app/Services/TimestampExtractorService.php
@@ -54,6 +54,7 @@ class TimestampExtractorService
                     'ts_text' => $timestamp,
                     'ts_num' => $this->timestampToSeconds($timestamp),
                     'text' => $comment,
+                    'normalized_text' => TextNormalizer::normalize($comment),
                 ];
             }
         }


### PR DESCRIPTION
## Summary

- `TimestampExtractorService::extractTimestamps()`でタイムスタンプ抽出時に`normalized_text`フィールドを設定するよう修正
- `RefreshArchiveService`が`DB::table()->insert()`を使用してバルクインサートを行うため、Eloquentの`saving`イベントがバイパスされ`normalized_text`がNULLになっていた問題を解決

## 根本原因

1. `RefreshArchiveService`は`DB::table('ts_items')->insert()`でバルクインサートを実行
2. これによりEloquentモデルイベント（`saving`）がバイパスされる
3. `TsItem`モデルの`saving`イベントで設定されるはずの`normalized_text`がNULLのまま
4. `TimestampService::getTimestampsWithMapping()`の`whereNotNull('ts_items.normalized_text')`フィルタにより全レコードが除外

## 修正内容

`TimestampExtractorService`でts_itemsの配列を作成する際に、`normalized_text`フィールドを含めるようにした。

## Test plan

- [x] 全テストがパス（214テスト）
- [x] タイムスタンプ再取得後、タイムスタンプ一覧が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)