### PR TITLE
perf: 「その他」カテゴリフィルタリングでREGEXPを使用

### DIFF
--- a/app/Services/TimestampService.php
+++ b/app/Services/TimestampService.php
@@ -9,6 +9,7 @@ use App\Models\Channel;
 use App\Models\TimestampReport;
 use App\Models\TsItem;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class TimestampService
@@ -134,32 +135,51 @@ class TimestampService
         $chars = CharacterCategorizer::getCharsForCategory($index);
 
         if (CharacterCategorizer::isOtherCategory($index)) {
-            // 「その他」カテゴリ: 既知のカテゴリに属さない文字
-            // 注: 多数のNOT LIKE条件が生成されるため、パフォーマンスに影響あり
-            $allKnownChars = [];
-            foreach (CharacterCategorizer::getAllCategories() as $category) {
-                if (! CharacterCategorizer::isOtherCategory($category)) {
-                    $allKnownChars = array_merge($allKnownChars, CharacterCategorizer::getCharsForCategory($category));
-                }
-            }
+            // 「その他」カテゴリ: 既知のカテゴリに属さない文字（主に漢字）
+            $driver = DB::getDriverName();
 
-            $query->where(function ($q) use ($allKnownChars) {
-                $q->where(function ($subQ) use ($allKnownChars) {
-                    // 楽曲名がある場合
-                    $subQ->whereNotNull('songs.title');
-                    foreach ($allKnownChars as $char) {
-                        $escapedChar = QueryHelper::escapeLikeString($char);
-                        $subQ->where('songs.title', 'not like', $escapedChar.'%');
-                    }
-                })->orWhere(function ($subQ) use ($allKnownChars) {
-                    // 楽曲名がない場合、タイムスタンプテキストで判定
-                    $subQ->whereNull('songs.title');
-                    foreach ($allKnownChars as $char) {
-                        $escapedChar = QueryHelper::escapeLikeString($char);
-                        $subQ->where('ts_items.text', 'not like', $escapedChar.'%');
-                    }
+            if ($driver === 'mysql') {
+                // MySQL: REGEXPで効率的にフィルタリング
+                // 既知カテゴリ（アルファベット、数字、ひらがな、カタカナ）以外を抽出
+                $pattern = '^[A-Za-z0-9あ-んア-ンー]';
+                $query->where(function ($q) use ($pattern) {
+                    $q->where(function ($subQ) use ($pattern) {
+                        // 楽曲名がある場合
+                        $subQ->whereNotNull('songs.title')
+                            ->whereRaw('songs.title NOT REGEXP ?', [$pattern]);
+                    })->orWhere(function ($subQ) use ($pattern) {
+                        // 楽曲名がない場合、タイムスタンプテキストで判定
+                        $subQ->whereNull('songs.title')
+                            ->whereRaw('ts_items.text NOT REGEXP ?', [$pattern]);
+                    });
                 });
-            });
+            } else {
+                // SQLite: NOT LIKEアプローチ（互換性優先）
+                $allKnownChars = [];
+                foreach (CharacterCategorizer::getAllCategories() as $category) {
+                    if (! CharacterCategorizer::isOtherCategory($category)) {
+                        $allKnownChars = array_merge($allKnownChars, CharacterCategorizer::getCharsForCategory($category));
+                    }
+                }
+
+                $query->where(function ($q) use ($allKnownChars) {
+                    $q->where(function ($subQ) use ($allKnownChars) {
+                        // 楽曲名がある場合
+                        $subQ->whereNotNull('songs.title');
+                        foreach ($allKnownChars as $char) {
+                            $escapedChar = QueryHelper::escapeLikeString($char);
+                            $subQ->where('songs.title', 'not like', $escapedChar.'%');
+                        }
+                    })->orWhere(function ($subQ) use ($allKnownChars) {
+                        // 楽曲名がない場合、タイムスタンプテキストで判定
+                        $subQ->whereNull('songs.title');
+                        foreach ($allKnownChars as $char) {
+                            $escapedChar = QueryHelper::escapeLikeString($char);
+                            $subQ->where('ts_items.text', 'not like', $escapedChar.'%');
+                        }
+                    });
+                });
+            }
         } elseif (! empty($chars)) {
             // 通常のカテゴリ: 指定された文字で始まるものをフィルタ
             $query->where(function ($q) use ($chars) {


### PR DESCRIPTION
## Summary

- 「その他」カテゴリ（主に漢字）のフィルタリングでMySQL REGEXPを使用するよう最適化
- 約200個のNOT LIKE条件を1つのNOT REGEXP条件に削減

## 変更内容

**app/Services/TimestampService.php**

MySQL環境では以下のパターンで効率的にフィルタリング:
```sql
WHERE column NOT REGEXP '^[A-Za-z0-9あ-んア-ンー]'
```

SQLite（テスト環境）では互換性のため従来のNOT LIKEアプローチを維持。

## パターンの説明

`^[A-Za-z0-9あ-んア-ンー]` で以下を除外:
- アルファベット (A-Z, a-z)
- 数字 (0-9)
- ひらがな (あ-ん)
- カタカナ (ア-ン)
- 長音記号 (ー)

結果として漢字・記号で始まるタイトルのみを抽出。

## Test plan

- [x] 全テストがパス（214テスト）
- [ ] MySQL環境で「その他」カテゴリフィルタが正常動作することを確認

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)