### PR TITLE
fix: ManageController::addChannel()のAPIエラーハンドリング改善

### DIFF
--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -20,6 +20,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class ManageController extends Controller
 {
@@ -90,8 +91,12 @@ class ManageController extends Controller
         try {
             $channel = $this->youtubeService->getChannelByHandle($request->handle);
         } catch (Exception $e) {
-            error_log($e->getMessage());
-            throw new Exception('youtubeとの接続でエラーが発生しました');
+            Log::error('YouTube API error in addChannel', [
+                'handle' => $request->handle,
+                'error' => $e->getMessage(),
+            ]);
+            // サービス層からのユーザーフレンドリーなメッセージをそのまま使用
+            throw $e;
         }
         if (! $channel || ! isset($channel['title']) || ! $channel['title']) {
             throw new NotFoundException('チャンネルが存在しません');


### PR DESCRIPTION
## Summary

- `error_log()`を`Log::error()`に変更
- サービス層からのユーザーフレンドリーなエラーメッセージをそのまま使用

## 変更内容

**app/Http/Controllers/ManageController.php**

Before:
```php
} catch (Exception $e) {
    error_log($e->getMessage());
    throw new Exception('youtubeとの接続でエラーが発生しました');
}
```

After:
```php
} catch (Exception $e) {
    Log::error('YouTube API error in addChannel', [
        'handle' => $request->handle,
        'error' => $e->getMessage(),
    ]);
    // サービス層からのユーザーフレンドリーなメッセージをそのまま使用
    throw $e;
}
```

## 効果

PR #297で追加されたYouTubeApiServiceのユーザーフレンドリーなエラーメッセージ（quota超過、レート制限など）がユーザーに表示されるようになります。

## Test plan

- [x] 全テストがパス（214テスト）

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)