### PR TITLE
feat: タイムスタンプ単位でchange_listを管理できるように拡張

### DIFF
--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -234,6 +234,9 @@ class ManageController extends Controller
     public function editTimestamps(EditTimestampsRequest $request)
     {
         $validatedData = $request->validated();
+        if (empty($validatedData)) {
+            throw new \InvalidArgumentException('タイムスタンプデータが空です');
+        }
         DB::transaction(function () use ($validatedData) {
             // リクエストで渡されたタイムスタンプIDに紐づくarchiveを取得
             $firstItemId = $validatedData[0]['id'];

--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -235,9 +235,9 @@ class ManageController extends Controller
     {
         $validatedData = $request->validated();
         DB::transaction(function () use ($validatedData) {
-            // リクエストで渡されたコメントIDに紐づくarchiveを取得
-            $commentIds = array_column($validatedData, 'comment_id');
-            $tsItem = TsItem::where('comment_id', $commentIds[0])
+            // リクエストで渡されたタイムスタンプIDに紐づくarchiveを取得
+            $firstItemId = $validatedData[0]['id'];
+            $tsItem = TsItem::where('id', $firstItemId)
                 ->with(['archive'])->first();
             if (! $tsItem) {
                 throw new NotFoundException('tsItem is not found');
@@ -268,18 +268,34 @@ class ManageController extends Controller
                 TsItem::whereIn('id', $hideItemIds)->update(['is_display' => '0']);
             }
 
-            // ChangeList作成（コメント単位で実行）
-            $lastCommentId = '';
-            foreach ($validatedData as $item) {
-                if ($lastCommentId !== $item['comment_id']) {
+            // コメントごとにグループ化
+            $groupedByComment = collect($validatedData)->groupBy('comment_id');
+
+            foreach ($groupedByComment as $commentId => $items) {
+                // コメント内の全タイムスタンプのis_displayを取得
+                $displayValues = $items->pluck('is_display')->unique();
+
+                if ($displayValues->count() === 1) {
+                    // 全て同じ設定→コメント単位でchange_listを作成
                     ChangeList::create([
                         'channel_id' => $channelId,
                         'video_id' => $videoId,
-                        'comment_id' => $item['comment_id'],
-                        'is_display' => $item['is_display'],
+                        'comment_id' => $commentId,
+                        'ts_item_id' => null,
+                        'is_display' => $displayValues->first(),
                     ]);
+                } else {
+                    // 異なる設定がある→タイムスタンプ単位でchange_listを作成
+                    foreach ($items as $item) {
+                        ChangeList::create([
+                            'channel_id' => $channelId,
+                            'video_id' => $videoId,
+                            'comment_id' => $commentId,
+                            'ts_item_id' => $item['id'],
+                            'is_display' => $item['is_display'],
+                        ]);
+                    }
                 }
-                $lastCommentId = $item['comment_id'];
             }
         });
 

--- a/app/Models/ChangeList.php
+++ b/app/Models/ChangeList.php
@@ -16,6 +16,7 @@ class ChangeList extends Model
         'channel_id',
         'video_id',
         'comment_id',
+        'ts_item_id',
         'is_display',
     ];
 

--- a/app/Services/ChangeListService.php
+++ b/app/Services/ChangeListService.php
@@ -11,6 +11,7 @@ class ChangeListService
 {
     /**
      * change_listの情報をts_itemsに反映
+     * 優先度: タイムスタンプ単位 > コメント単位
      *
      * Note: This method should be called within a database transaction.
      * Uses optimized MySQL query for production, Eloquent for testing.
@@ -20,32 +21,62 @@ class ChangeListService
         $driver = DB::getDriverName();
 
         if ($driver === 'mysql') {
-            // Use optimized MySQL query for production
+            // Step 1: タイムスタンプ単位（ts_item_id IS NOT NULL）を適用
+            DB::statement('
+                UPDATE ts_items t1
+                INNER JOIN change_list t2
+                  ON t2.ts_item_id = t1.id
+                SET t1.is_display = t2.is_display
+                WHERE t1.is_display <> t2.is_display
+                  AND t2.channel_id = ?
+            ', [$channelId]);
+
+            // Step 2: コメント単位（ts_item_id IS NULL AND comment_id IS NOT NULL）を適用
+            // タイムスタンプ単位の設定がないts_itemsにのみ適用
             DB::statement('
                 UPDATE ts_items t1
                 INNER JOIN change_list t2
                   ON t2.video_id = t1.video_id
                   AND t2.comment_id = t1.comment_id
+                  AND t2.ts_item_id IS NULL
+                LEFT JOIN change_list t3
+                  ON t3.ts_item_id = t1.id
                 SET t1.is_display = t2.is_display
-                WHERE t1.is_display <> t2.is_display
+                WHERE t3.id IS NULL
+                  AND t1.is_display <> t2.is_display
                   AND t2.channel_id = ?
             ', [$channelId]);
         } else {
             // Use Eloquent for SQLite/PostgreSQL (testability)
-            // N+1問題を回避するため、チャンクごとにバルク更新
+
+            // Step 1: タイムスタンプ単位（ts_item_id IS NOT NULL）の適用
+            $tsItemChangeLists = ChangeList::where('channel_id', $channelId)
+                ->whereNotNull('ts_item_id')
+                ->get();
+
+            $tsItemIdsWithOverride = $tsItemChangeLists->pluck('ts_item_id')->toArray();
+
+            $displayGroups = $tsItemChangeLists->groupBy('is_display');
+            foreach ($displayGroups as $isDisplay => $groupedChangeLists) {
+                $tsItemIds = $groupedChangeLists->pluck('ts_item_id')->toArray();
+                TsItem::whereIn('id', $tsItemIds)
+                    ->where('is_display', '!=', $isDisplay)
+                    ->update(['is_display' => $isDisplay]);
+            }
+
+            // Step 2: コメント単位（ts_item_id IS NULL）の適用
+            // タイムスタンプ単位で設定されていないts_itemsにのみ適用
             ChangeList::where('channel_id', $channelId)
                 ->whereNotNull('comment_id')
-                ->chunk(100, function ($changeLists) {
-                    // is_displayの値でグループ化
+                ->whereNull('ts_item_id')
+                ->chunk(100, function ($changeLists) use ($tsItemIdsWithOverride) {
                     $displayGroups = $changeLists->groupBy('is_display');
 
                     foreach ($displayGroups as $isDisplay => $groupedChangeLists) {
-                        // video_id + comment_id のペアを収集
                         $conditions = $groupedChangeLists->map(function ($cl) {
                             return ['video_id' => $cl->video_id, 'comment_id' => $cl->comment_id];
                         })->toArray();
 
-                        // 各ペアに対してOR条件でマッチするレコードを一括更新
                         TsItem::where(function ($query) use ($conditions) {
                             foreach ($conditions as $condition) {
                                 $query->orWhere(function ($q) use ($condition) {
@@ -54,6 +85,7 @@ class ChangeListService
                                 });
                             }
                         })
+                            ->whereNotIn('id', $tsItemIdsWithOverride)
                             ->where('is_display', '!=', $isDisplay)
                             ->update(['is_display' => $isDisplay]);
                     }
@@ -106,9 +138,9 @@ class ChangeListService
     /**
      * 不要なchange_listレコードを削除
      * 以下の条件に該当するレコードを削除:
-     * a. タイムスタンプ(comment_id IS NOT NULL)でts_itemsに紐づかないレコード
-     * b. アーカイブ(comment_id IS NULL)でarchivesに紐づかないレコード
-     * c. ts_itemsにもarchivesにも紐づかないレコード
+     * a. タイムスタンプ単位(ts_item_id IS NOT NULL)でts_itemsに紐づかないレコード
+     * b. コメント単位(ts_item_id IS NULL AND comment_id IS NOT NULL)でts_itemsに紐づかないレコード
+     * c. アーカイブ単位(comment_id IS NULL)でarchivesに紐づかないレコード
      *
      * Note: This method should be called within a database transaction.
      * Uses optimized MySQL query for production, Eloquent for testing.
@@ -121,40 +153,51 @@ class ChangeListService
             // Use optimized MySQL query for production
             DB::statement('
                 DELETE t1 FROM change_list t1
-                LEFT JOIN ts_items t2 ON t2.video_id = t1.video_id AND t2.comment_id = t1.comment_id
+                LEFT JOIN ts_items t2_ts ON t2_ts.id = t1.ts_item_id
+                LEFT JOIN ts_items t2_comment ON t2_comment.video_id = t1.video_id
+                    AND t2_comment.comment_id = t1.comment_id
+                    AND t1.ts_item_id IS NULL
                 LEFT JOIN archives t3 ON t3.video_id = t1.video_id AND t1.comment_id IS NULL
                 WHERE t1.channel_id = ?
                     AND
                     (
-                        (
-                            t2.id IS NULL AND t1.comment_id IS NOT NULL
-                        )
-                        OR (
-                            t3.id IS NULL AND t1.comment_id IS NULL
-                        )
-                        OR (
-                            t2.id IS NULL AND t3.id IS NULL
-                        )
+                        (t1.ts_item_id IS NOT NULL AND t2_ts.id IS NULL)
+                        OR (t1.ts_item_id IS NULL AND t1.comment_id IS NOT NULL AND t2_comment.id IS NULL)
+                        OR (t1.comment_id IS NULL AND t3.id IS NULL)
                     )
             ', [$channelId]);
         } else {
             // Use Eloquent for SQLite/PostgreSQL (testability)
-            // N+1問題を回避するため、チャンクごとに一括チェック
             $idsToDelete = [];
 
             ChangeList::where('channel_id', $channelId)
                 ->chunk(100, function ($changeLists) use (&$idsToDelete) {
-                    // タイムスタンプ用のchange_list（comment_id IS NOT NULL）
-                    $timestampChangeLists = $changeLists->whereNotNull('comment_id');
-                    // アーカイブ用のchange_list（comment_id IS NULL）
+                    // タイムスタンプ単位のchange_list（ts_item_id IS NOT NULL）
+                    $tsItemChangeLists = $changeLists->whereNotNull('ts_item_id');
+                    // コメント単位のchange_list（ts_item_id IS NULL AND comment_id IS NOT NULL）
+                    $commentChangeLists = $changeLists->whereNull('ts_item_id')->whereNotNull('comment_id');
+                    // アーカイブ単位のchange_list（comment_id IS NULL）
                     $archiveChangeLists = $changeLists->whereNull('comment_id');
 
-                    // タイムスタンプの存在確認を一括で行う
-                    if ($timestampChangeLists->isNotEmpty()) {
-                        $videoIds = $timestampChangeLists->pluck('video_id')->unique()->toArray();
-                        $commentIds = $timestampChangeLists->pluck('comment_id')->unique()->toArray();
+                    // タイムスタンプ単位の存在確認
+                    if ($tsItemChangeLists->isNotEmpty()) {
+                        $tsItemIds = $tsItemChangeLists->pluck('ts_item_id')->unique()->toArray();
+                        $existingTsItemIds = TsItem::whereIn('id', $tsItemIds)
+                            ->pluck('id')
+                            ->toArray();
 
-                        // 存在するts_itemsのvideo_id + comment_idペアを取得
+                        foreach ($tsItemChangeLists as $changeList) {
+                            if (! in_array($changeList->ts_item_id, $existingTsItemIds)) {
+                                $idsToDelete[] = $changeList->id;
+                            }
+                        }
+                    }
+
+                    // コメント単位の存在確認
+                    if ($commentChangeLists->isNotEmpty()) {
+                        $videoIds = $commentChangeLists->pluck('video_id')->unique()->toArray();
+                        $commentIds = $commentChangeLists->pluck('comment_id')->unique()->toArray();
+
                         $existingTsItems = TsItem::whereIn('video_id', $videoIds)
                             ->whereIn('comment_id', $commentIds)
                             ->select('video_id', 'comment_id')
@@ -162,7 +205,7 @@ class ChangeListService
                             ->map(fn ($item) => $item->video_id.'|'.$item->comment_id)
                             ->toArray();
 
-                        foreach ($timestampChangeLists as $changeList) {
+                        foreach ($commentChangeLists as $changeList) {
                             $key = $changeList->video_id.'|'.$changeList->comment_id;
                             if (! in_array($key, $existingTsItems)) {
                                 $idsToDelete[] = $changeList->id;
@@ -170,11 +213,9 @@ class ChangeListService
                         }
                     }
 
-                    // アーカイブの存在確認を一括で行う
+                    // アーカイブ単位の存在確認
                     if ($archiveChangeLists->isNotEmpty()) {
                         $videoIds = $archiveChangeLists->pluck('video_id')->unique()->toArray();
-
-                        // 存在するarchivesのvideo_idを取得
                         $existingArchiveVideoIds = Archive::whereIn('video_id', $videoIds)
                             ->pluck('video_id')
                             ->toArray();
@@ -187,7 +228,6 @@ class ChangeListService
                     }
                 });
 
-            // Bulk delete for better performance
             if (! empty($idsToDelete)) {
                 ChangeList::whereIn('id', $idsToDelete)->delete();
             }

--- a/database/migrations/2025_12_04_150017_add_ts_item_id_to_change_list_table.php
+++ b/database/migrations/2025_12_04_150017_add_ts_item_id_to_change_list_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // ts_item_idカラムを追加
+        Schema::table('change_list', function (Blueprint $table) {
+            if (DB::getDriverName() === 'sqlite') {
+                $table->string('ts_item_id', 26)->nullable();
+            } else {
+                $table->string('ts_item_id', 26)->nullable()->after('comment_id');
+            }
+        });
+
+        // タイムスタンプ単位の検索用インデックスを追加
+        Schema::table('change_list', function (Blueprint $table) {
+            $table->index(['video_id', 'ts_item_id'], 'change_list_video_id_ts_item_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('change_list', function (Blueprint $table) {
+            $table->dropIndex('change_list_video_id_ts_item_id_index');
+        });
+
+        Schema::table('change_list', function (Blueprint $table) {
+            $table->dropColumn('ts_item_id');
+        });
+    }
+};

--- a/resources/js/manage/archives.js
+++ b/resources/js/manage/archives.js
@@ -326,12 +326,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
         // タイムスタンプ押下時（編集モードのみ）
         // 子要素のクリックでも反応させる
+        // Shiftキー押下時はコメント単位、通常クリックはタイムスタンプ単位でトグル
         if (target.classList.contains('timestamp')) {
-            toggleTsItemGrayout(target);
+            toggleTsItemGrayout(target, event.shiftKey);
         } else {
             const parent = target.closest('.timestamp');
             if (parent) {
-                toggleTsItemGrayout(parent);
+                toggleTsItemGrayout(parent, event.shiftKey);
             }
         }
 
@@ -451,6 +452,20 @@ function toggleTsItemsStyle(btn, currentIsEdit) {
         // キャンセルボタンの表示
         camcelBtn.classList.toggle('hidden', !newIsEditFlg);
     }
+    // 編集モードのヒント表示/非表示
+    let hintElement = timestampsElement.querySelector('.edit-hint');
+    if (newIsEditFlg) {
+        if (!hintElement) {
+            hintElement = document.createElement('div');
+            hintElement.className = 'edit-hint text-xs text-gray-500 mb-2 bg-yellow-50 p-1 rounded';
+            hintElement.textContent = 'クリック: 個別切替 / Shift+クリック: コメント一括切替';
+            timestampsElement.insertBefore(hintElement, timestampsElement.firstChild);
+        }
+    } else {
+        if (hintElement) {
+            hintElement.remove();
+        }
+    }
     // TS項目のモード変更
     tsItems.forEach(tsItem => {
         tsItem.classList.toggle('border-[0.5px]', newIsEditFlg);
@@ -466,9 +481,10 @@ function toggleTsItemsStyle(btn, currentIsEdit) {
 
 /**
  * TS項目クリック時の表示切替
- * フラグの変更などは内部で実施してくれるので、グレイアウトを反転させたいTS項目を指定して実行するだけでよい
+ * shiftKey=true: コメント単位でトグル（同じcomment_idを持つ全タイムスタンプ）
+ * shiftKey=false: タイムスタンプ単位でトグル（クリックした項目のみ）
  */
-function toggleTsItemGrayout(tsItem) {
+function toggleTsItemGrayout(tsItem, shiftKey = false) {
     // 編集モードでなければ終了（リンクが非表示の場合は通常モードなので終了）
     const linkElement = tsItem.querySelector('a');
     if (!linkElement || !linkElement.classList.contains('hidden')) { return; }
@@ -476,26 +492,33 @@ function toggleTsItemGrayout(tsItem) {
     // 現在の表示状態を取得し、状態を反転させてそれに合わせてclassを更新する
     const newIsDisplayFlg = !tsItem.classList.contains('is-display');
 
-    // 対象の data-comment を取得
-    const commentId = tsItem.dataset.comment;
+    if (shiftKey) {
+        // Shiftキー押下時: コメント単位でトグル（既存の動作）
+        const commentId = tsItem.dataset.comment;
+        const container = tsItem.closest('.timestamps');
+        if (!container) { return; }
 
-    // tsItemの親である .timestamps 要素を取得
-    const container = tsItem.closest('.timestamps');
-    if (!container) { return; }
+        const matchingItems = container.querySelectorAll(`.timestamp[data-comment="${commentId}"]`);
+        matchingItems.forEach(item => {
+            updateTsItemStyle(item, newIsDisplayFlg);
+        });
+    } else {
+        // 通常クリック: タイムスタンプ単位でトグル（新機能）
+        updateTsItemStyle(tsItem, newIsDisplayFlg);
+    }
+}
 
-    // container内の、同じ data-comment を持つ timestamp 要素を取得
-    const matchingItems = container.querySelectorAll(`.timestamp[data-comment="${commentId}"]`);
-
-    // tsItemのclassを更新
-    matchingItems.forEach(item => {
-        // 表示時
-        item.classList.toggle('is-display', newIsDisplayFlg);
-        item.classList.toggle('text-gray-700', newIsDisplayFlg);
-        // 非表示時
-        item.classList.toggle('text-gray-500', !newIsDisplayFlg);
-        item.classList.toggle('pl-4', !newIsDisplayFlg);
-        item.classList.toggle('bg-gray-200', !newIsDisplayFlg);
-    });
+/**
+ * タイムスタンプ項目のスタイルを更新
+ */
+function updateTsItemStyle(item, isDisplay) {
+    // 表示時
+    item.classList.toggle('is-display', isDisplay);
+    item.classList.toggle('text-gray-700', isDisplay);
+    // 非表示時
+    item.classList.toggle('text-gray-500', !isDisplay);
+    item.classList.toggle('pl-4', !isDisplay);
+    item.classList.toggle('bg-gray-200', !isDisplay);
 }
 
 function getTsItems(tsItems) {

--- a/tests/Feature/ManageControllerTest.php
+++ b/tests/Feature/ManageControllerTest.php
@@ -443,4 +443,107 @@ class ManageControllerTest extends TestCase
         // シンプルにジョブがプッシュされたことを確認
         Queue::assertPushed(RefreshChannelArchivesJob::class);
     }
+
+    /**
+     * 同一コメント内のタイムスタンプに異なる表示設定をした場合、タイムスタンプ単位でchange_listが作成される
+     */
+    public function test_edit_timestamps_creates_ts_item_level_change_list(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 同じコメント内に3つのタイムスタンプを作成
+        $tsItems = TsItem::factory()->count(3)->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-123',
+            'is_display' => 1,
+        ]);
+
+        // 最初の2つは表示、3つ目は非表示に設定（異なる設定を混在させる）
+        $requestData = [
+            ['id' => $tsItems[0]->id, 'comment_id' => $tsItems[0]->comment_id, 'is_display' => true],
+            ['id' => $tsItems[1]->id, 'comment_id' => $tsItems[1]->comment_id, 'is_display' => true],
+            ['id' => $tsItems[2]->id, 'comment_id' => $tsItems[2]->comment_id, 'is_display' => false],
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/edit-timestamps', $requestData);
+
+        $response->assertStatus(200);
+
+        // ts_itemsの表示状態が更新されている
+        $this->assertDatabaseHas('ts_items', ['id' => $tsItems[0]->id, 'is_display' => 1]);
+        $this->assertDatabaseHas('ts_items', ['id' => $tsItems[1]->id, 'is_display' => 1]);
+        $this->assertDatabaseHas('ts_items', ['id' => $tsItems[2]->id, 'is_display' => 0]);
+
+        // タイムスタンプ単位でchange_listが作成されている（ts_item_idが設定されている）
+        $this->assertDatabaseHas('change_list', [
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-123',
+            'ts_item_id' => $tsItems[0]->id,
+            'is_display' => 1,
+        ]);
+        $this->assertDatabaseHas('change_list', [
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-123',
+            'ts_item_id' => $tsItems[1]->id,
+            'is_display' => 1,
+        ]);
+        $this->assertDatabaseHas('change_list', [
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-123',
+            'ts_item_id' => $tsItems[2]->id,
+            'is_display' => 0,
+        ]);
+
+        // コメント単位のchange_list（ts_item_id=null）が作成されていない
+        $this->assertDatabaseMissing('change_list', [
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-123',
+            'ts_item_id' => null,
+        ]);
+    }
+
+    /**
+     * 同一コメント内のタイムスタンプが全て同じ表示設定の場合、コメント単位でchange_listが作成される
+     */
+    public function test_edit_timestamps_creates_comment_level_change_list_when_all_same(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 同じコメント内に3つのタイムスタンプを作成
+        $tsItems = TsItem::factory()->count(3)->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-456',
+            'is_display' => 1,
+        ]);
+
+        // 全て非表示に設定
+        $requestData = $tsItems->map(fn ($item) => [
+            'id' => $item->id,
+            'comment_id' => $item->comment_id,
+            'is_display' => false,
+        ])->toArray();
+
+        $response = $this->actingAs($this->user)
+            ->patchJson('/api/manage/archives/edit-timestamps', $requestData);
+
+        $response->assertStatus(200);
+
+        // コメント単位でchange_listが作成されている（ts_item_id=null）
+        $this->assertDatabaseHas('change_list', [
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-456',
+            'ts_item_id' => null,
+            'is_display' => 0,
+        ]);
+
+        // タイムスタンプ単位のchange_list（ts_item_idが設定されている）が作成されていない
+        $count = ChangeList::where('video_id', $archive->video_id)
+            ->where('comment_id', 'comment-456')
+            ->whereNotNull('ts_item_id')
+            ->count();
+        $this->assertEquals(0, $count);
+    }
 }

--- a/tests/Unit/Services/ChangeListServiceTest.php
+++ b/tests/Unit/Services/ChangeListServiceTest.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Archive;
+use App\Models\ChangeList;
+use App\Models\Channel;
+use App\Models\TsItem;
+use App\Services\ChangeListService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ChangeListServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ChangeListService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new ChangeListService;
+    }
+
+    /**
+     * applyChangeListToTsItems: タイムスタンプ単位の設定がコメント単位より優先される
+     */
+    public function test_apply_change_list_to_ts_items_prioritizes_ts_item_level(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 同じコメント内に2つのタイムスタンプを作成（両方とも表示状態）
+        $tsItem1 = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-priority-test',
+            'is_display' => 1,
+        ]);
+        $tsItem2 = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-priority-test',
+            'is_display' => 1,
+        ]);
+
+        // コメント単位で非表示に設定
+        ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-priority-test',
+            'ts_item_id' => null,
+            'is_display' => 0,
+        ]);
+
+        // tsItem1だけタイムスタンプ単位で表示に設定（優先される）
+        ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-priority-test',
+            'ts_item_id' => $tsItem1->id,
+            'is_display' => 1,
+        ]);
+
+        $this->service->applyChangeListToTsItems($channel->channel_id);
+
+        // tsItem1はタイムスタンプ単位の設定（is_display=1）が優先される
+        $this->assertDatabaseHas('ts_items', [
+            'id' => $tsItem1->id,
+            'is_display' => 1,
+        ]);
+
+        // tsItem2はコメント単位の設定（is_display=0）が適用される
+        $this->assertDatabaseHas('ts_items', [
+            'id' => $tsItem2->id,
+            'is_display' => 0,
+        ]);
+    }
+
+    /**
+     * applyChangeListToTsItems: タイムスタンプ単位の設定のみが存在する場合
+     */
+    public function test_apply_change_list_to_ts_items_with_ts_item_level_only(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        $tsItem = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-ts-only',
+            'is_display' => 1,
+        ]);
+
+        // タイムスタンプ単位で非表示に設定
+        ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-ts-only',
+            'ts_item_id' => $tsItem->id,
+            'is_display' => 0,
+        ]);
+
+        $this->service->applyChangeListToTsItems($channel->channel_id);
+
+        $this->assertDatabaseHas('ts_items', [
+            'id' => $tsItem->id,
+            'is_display' => 0,
+        ]);
+    }
+
+    /**
+     * applyChangeListToTsItems: コメント単位の設定のみが存在する場合
+     */
+    public function test_apply_change_list_to_ts_items_with_comment_level_only(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        $tsItem = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-comment-only',
+            'is_display' => 1,
+        ]);
+
+        // コメント単位で非表示に設定
+        ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-comment-only',
+            'ts_item_id' => null,
+            'is_display' => 0,
+        ]);
+
+        $this->service->applyChangeListToTsItems($channel->channel_id);
+
+        $this->assertDatabaseHas('ts_items', [
+            'id' => $tsItem->id,
+            'is_display' => 0,
+        ]);
+    }
+
+    /**
+     * applyChangeListToArchives: アーカイブ単位の設定が適用される
+     */
+    public function test_apply_change_list_to_archives(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create([
+            'channel_id' => $channel->channel_id,
+            'is_display' => 1,
+        ]);
+
+        // アーカイブ単位で非表示に設定
+        ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => null,
+            'ts_item_id' => null,
+            'is_display' => 0,
+        ]);
+
+        $this->service->applyChangeListToArchives($channel->channel_id);
+
+        $this->assertDatabaseHas('archives', [
+            'id' => $archive->id,
+            'is_display' => 0,
+        ]);
+    }
+
+    /**
+     * deleteObsoleteChangeLists: タイムスタンプ単位の孤立レコードが削除される
+     */
+    public function test_delete_obsolete_change_lists_removes_orphan_ts_item_records(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 存在しないts_item_idを持つchange_listレコード
+        $orphanChangeList = ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-orphan',
+            'ts_item_id' => 'non-existent-ts-item-id-12345',
+            'is_display' => 0,
+        ]);
+
+        $this->service->deleteObsoleteChangeLists($channel->channel_id);
+
+        $this->assertDatabaseMissing('change_list', [
+            'id' => $orphanChangeList->id,
+        ]);
+    }
+
+    /**
+     * deleteObsoleteChangeLists: コメント単位の孤立レコードが削除される
+     */
+    public function test_delete_obsolete_change_lists_removes_orphan_comment_records(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 存在しないcomment_idを持つchange_listレコード
+        $orphanChangeList = ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'non-existent-comment-id',
+            'ts_item_id' => null,
+            'is_display' => 0,
+        ]);
+
+        $this->service->deleteObsoleteChangeLists($channel->channel_id);
+
+        $this->assertDatabaseMissing('change_list', [
+            'id' => $orphanChangeList->id,
+        ]);
+    }
+
+    /**
+     * deleteObsoleteChangeLists: 有効なレコードは削除されない
+     */
+    public function test_delete_obsolete_change_lists_keeps_valid_records(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        $tsItem = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'valid-comment',
+        ]);
+
+        // 有効なタイムスタンプ単位のchange_list
+        $validTsItemChangeList = ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'valid-comment',
+            'ts_item_id' => $tsItem->id,
+            'is_display' => 0,
+        ]);
+
+        // 有効なコメント単位のchange_list
+        $validCommentChangeList = ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'valid-comment',
+            'ts_item_id' => null,
+            'is_display' => 0,
+        ]);
+
+        // 有効なアーカイブ単位のchange_list
+        $validArchiveChangeList = ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => null,
+            'ts_item_id' => null,
+            'is_display' => 0,
+        ]);
+
+        $this->service->deleteObsoleteChangeLists($channel->channel_id);
+
+        // すべての有効なレコードが残っている
+        $this->assertDatabaseHas('change_list', ['id' => $validTsItemChangeList->id]);
+        $this->assertDatabaseHas('change_list', ['id' => $validCommentChangeList->id]);
+        $this->assertDatabaseHas('change_list', ['id' => $validArchiveChangeList->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- change_listテーブルに`ts_item_id`カラムを追加し、タイムスタンプ個別の表示/非表示設定を可能に
- コメント単位の設定より、タイムスタンプ単位の設定が優先される仕様
- 管理画面で通常クリック=個別トグル、Shift+クリック=コメント一括トグルに変更
- 編集モード時にUIヒントを表示

## 変更内容
- `database/migrations`: `ts_item_id`カラムとインデックスを追加
- `ChangeList.php`: `ts_item_id`をfillableに追加
- `ManageController.php`: タイムスタンプ単位/コメント単位の両方に対応、空配列チェックを追加
- `ChangeListService.php`: タイムスタンプ単位 > コメント単位の優先度で適用
- `archives.js`: クリック動作の変更とヒント表示を追加

## Test plan
- [x] 既存テスト全てパス（223テスト）
- [x] タイムスタンプ単位でchange_listが作成されるテストを追加
- [x] コメント単位でchange_listが作成されるテストを追加
- [x] ChangeListServiceのユニットテストを追加（優先度ロジック、孤立レコード削除）
- [ ] 管理画面でタイムスタンプを個別クリックして非表示にできる
- [ ] Shift+クリックでコメント単位で一括非表示にできる
- [ ] データ更新時にタイムスタンプ単位の設定がコメント単位より優先される

🤖 Generated with [Claude Code](https://claude.com/claude-code)