### PR TITLE
fix: 「-」のみのタイムスタンプを「楽曲ではない」マーク時のエラーを修正

### DIFF
--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -326,7 +326,20 @@ class SongController extends Controller
         $validated = $request->validated();
 
         // textが渡された場合は正規化する
-        $normalizedText = $validated['normalized_text'] ?? TextNormalizer::normalize($validated['text']);
+        // 正規化結果が空文字列になる場合（例: "-"のみ）は元のテキストを使用
+        if (isset($validated['normalized_text']) && $validated['normalized_text'] !== '') {
+            $normalizedText = $validated['normalized_text'];
+        } else {
+            $originalText = $validated['text'] ?? '';
+            $normalizedText = TextNormalizer::normalize($originalText);
+            if ($normalizedText === '') {
+                $normalizedText = mb_strtolower(trim($originalText), 'UTF-8');
+            }
+        }
+
+        if ($normalizedText === '') {
+            return response()->json(['message' => 'テキストが空です。'], 422);
+        }
 
         $this->songMappingService->markAsNotSong($normalizedText);
 

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -729,7 +729,10 @@ class TimestampNormalization {
             this.showLoading();
 
             for (const ts of this.selectedTimestamps) {
-                await timestampApiService.markAsNotSong(ts.normalized_text);
+                // normalized_textが空の場合は元のtextも送信
+                const normalizedText = ts.normalized_text || null;
+                const text = !ts.normalized_text ? ts.text : null;
+                await timestampApiService.markAsNotSong(normalizedText, text);
             }
 
             toast.success('楽曲ではないとマークしました。');

--- a/resources/js/songs/services/TimestampApiService.js
+++ b/resources/js/songs/services/TimestampApiService.js
@@ -37,12 +37,18 @@ export class TimestampApiService {
     /**
      * タイムスタンプを「楽曲ではない」とマーク
      * @param {string} normalizedText - 正規化されたテキスト
+     * @param {string} [text] - 元のテキスト（正規化前）
      * @returns {Promise<Object>} レスポンスデータ
      */
-    async markAsNotSong(normalizedText) {
-        const response = await axios.post('/api/songs/mark-not-song', {
-            normalized_text: normalizedText
-        });
+    async markAsNotSong(normalizedText, text = null) {
+        const data = {};
+        if (normalizedText) {
+            data.normalized_text = normalizedText;
+        }
+        if (text) {
+            data.text = text;
+        }
+        const response = await axios.post('/api/songs/mark-not-song', data);
         return response.data;
     }
 

--- a/tests/Feature/SongControllerTest.php
+++ b/tests/Feature/SongControllerTest.php
@@ -663,6 +663,42 @@ class SongControllerTest extends TestCase
     }
 
     /**
+     * 「楽曲ではない」マークのテスト（正規化結果が空になるテキスト）
+     */
+    public function test_mark_as_not_song_with_dash_only_text(): void
+    {
+        $rawText = '-';  // 正規化すると空になるテキスト
+
+        $response = $this->actingAs($this->user)->postJson(route('songs.markAsNotSong'), [
+            'text' => $rawText,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => '楽曲ではないとマークしました。',
+        ]);
+
+        // 正規化結果が空の場合は元のテキストが使用される
+        $this->assertDatabaseHas('timestamp_song_mappings', [
+            'normalized_text' => '-',
+            'is_not_song' => 1,
+            'song_id' => null,
+        ]);
+    }
+
+    /**
+     * 「楽曲ではない」マークのテスト（空文字列はエラー）
+     */
+    public function test_mark_as_not_song_with_empty_text_returns_error(): void
+    {
+        $response = $this->actingAs($this->user)->postJson(route('songs.markAsNotSong'), [
+            'text' => '',
+        ]);
+
+        $response->assertStatus(422);
+    }
+
+    /**
      * 「楽曲ではない」マーク解除のテスト
      */
     public function test_unmark_as_not_song(): void


### PR DESCRIPTION
## Summary
- 正規化結果が空文字列になる場合（例: "-"のみ）は元のテキストを使用するよう修正
- フロントエンドでnormalized_textが空の場合は元のtextも送信

## 変更内容
- `SongController::markAsNotSong()`: 正規化結果が空の場合は元のテキストを使用
- `TimestampApiService.js`: textパラメータも送信できるよう拡張
- `normalize.js`: normalized_textが空の場合はtextを送信

## Test plan
- [x] 全テストがパス（225件）
- [x] 「-」のみのテキストで「楽曲ではない」マークができるテストを追加
- [x] 空文字列の場合は422エラーを返すテストを追加

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)