### PR TITLE
refactor: manage/archives.jsのalertをtoast通知に置き換え

### DIFF
--- a/resources/js/manage/archives.js
+++ b/resources/js/manage/archives.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import DOMPurify from 'dompurify';
 import { escapeHTML, toggleButtonDisabled, formatDate } from "../utils";
+import toast from '../utils/toast.js';
 
 document.addEventListener('DOMContentLoaded', function () {
     const registerForm = document.getElementById('archiveRegisterForm');
@@ -149,7 +150,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 const data = response.data;
                 // 非同期実行の場合はメッセージを表示
                 if (data.async) {
-                    alert(data.message || 'アーカイブの更新処理をキューに登録しました。完了までしばらくお待ちください。');
+                    toast.info(data.message || 'アーカイブの更新処理をキューに登録しました。完了までしばらくお待ちください。');
                 }
                 // 登録成功後にアーカイブ一覧を再取得
                 fetchArchives();
@@ -255,9 +256,9 @@ document.addEventListener('DOMContentLoaded', function () {
                     }
                     timestampsElement.innerHTML = getTsItems(ts_items);
                     if (ts_items.length > 0) {
-                        alert("コメント取得完了");
+                        toast.success("コメント取得完了");
                     } else {
-                        alert("抽出できるコメントがありませんでした");
+                        toast.warning("抽出できるコメントがありませんでした");
                     }
                 })
                 .catch(error => {
@@ -310,7 +311,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 // Ajaxリクエスト
                 axios.patch('/api/manage/archives/edit-timestamps', updateTsItems)
                     .then(response => {
-                        alert(response.data.message);
+                        toast.success(response.data.message);
                         // 通常モードに戻す
                         toggleTsItemsStyle(target, isEdit);
                     })
@@ -351,7 +352,7 @@ document.addEventListener('DOMContentLoaded', function () {
             });
             // 通常モードに戻す
             // 編集時しか表示しないので固定値
-            alert('タイムスタンプの編集をキャンセルしました');
+            toast.info('タイムスタンプの編集をキャンセルしました');
             toggleTsItemsStyle(target, '1');
 
             // エラーメッセージをクリア


### PR DESCRIPTION
## Summary
- manage/archives.jsで使用している`alert()`を既存の`toast`通知に置き換え

## 変更内容
- 非同期処理通知: `toast.info()`
- コメント取得完了: `toast.success()`
- コメント取得失敗: `toast.warning()`
- タイムスタンプ編集完了: `toast.success()`
- キャンセル通知: `toast.info()`

## Test plan
- [x] 全テストがパス（225件）
- [x] ビルド成功

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)