### PR TITLE
fix: 正規化画面のSpotify検索入力欄を復元

### DIFF
--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -120,6 +120,15 @@
 
                         <!-- Spotify検索結果 -->
                         <div id="spotifyResults" class="tab-content">
+                            <div class="flex gap-2 mb-3">
+                                <input type="text" id="spotifySearch" placeholder="楽曲名 アーティスト名" class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                <button id="searchSpotifyBtn" class="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500">
+                                    検索
+                                </button>
+                                <button id="clearSpotifySearchBtn" class="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600">
+                                    クリア
+                                </button>
+                            </div>
                             <div id="spotifyTracks" class="space-y-2 max-h-64 overflow-y-auto">
                                 <p class="text-gray-500 dark:text-gray-400 text-sm">検索ボタンをクリックして楽曲を検索してください</p>
                             </div>


### PR DESCRIPTION
## 問題
#321 のUI改善時にSpotify検索の入力欄とボタンを誤って削除してしまい、タイムスタンプが表示されなくなっていた。

## 原因
JavaScriptでSpotify検索の要素にイベントリスナーを追加しようとした際にDOM要素が存在せずエラーが発生し、以降の初期化処理（タイムスタンプの読み込み等）が実行されなかった。

## 修正内容
- Spotify検索の入力欄とボタンをSpotifyタブ内に復元
- 結果としてより直感的なUI配置に改善（検索はタブ内に集約）

🤖 Generated with [Claude Code](https://claude.com/claude-code)