### PR TITLE
feat: カバー曲（歌ってみた）を0:00タイムスタンプとして自動追加

### DIFF
--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Helpers\TextNormalizer;
 use App\Models\Archive;
 use App\Models\Channel;
 use App\Models\TsItem;
@@ -9,6 +10,7 @@ use App\Models\User;
 use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class RefreshArchiveService
 {
@@ -128,8 +130,11 @@ class RefreshArchiveService
         }
         unset($ts_items);
 
+        // カバー曲（歌ってみた）のts_itemsを生成
+        $cover_ts_items = $this->extractCoverSongTsItems($rtn_archives);
+
         // 全てのDB操作を1つのトランザクションで実行（原子性を保証）
-        DB::transaction(function () use ($channel, $rtn_archives, $rtn_ts_items, $comment_ts_items_map) {
+        DB::transaction(function () use ($channel, $rtn_archives, $rtn_ts_items, $comment_ts_items_map, $cover_ts_items) {
             // 2.一度関連情報を削除（cascadeでTsItemsも消える）
             Archive::where('channel_id', $channel->channel_id)->delete();
 
@@ -143,6 +148,14 @@ class RefreshArchiveService
             }
             if ($rtn_ts_items) {
                 $chunked = array_chunk($rtn_ts_items, 100);
+                foreach ($chunked as $chunk) {
+                    DB::table('ts_items')->insert($chunk);
+                }
+            }
+
+            // 4.1.1.カバー曲のts_itemsを登録
+            if ($cover_ts_items) {
+                $chunked = array_chunk($cover_ts_items, 100);
                 foreach ($chunked as $chunk) {
                     DB::table('ts_items')->insert($chunk);
                 }
@@ -217,5 +230,72 @@ class RefreshArchiveService
     public function getChannelCountForUser(int $userId): int
     {
         return $this->channelQueryService->getChannelCountForUser($userId);
+    }
+
+    /**
+     * カバー曲（歌ってみた）動画かどうかを判定
+     *
+     * タイトルに「歌ってみた」「cover」「カバー」が含まれる場合はカバー曲と判定
+     */
+    public function isCoverSong(string $title): bool
+    {
+        $lowerTitle = mb_strtolower($title);
+
+        // 検出キーワード
+        $keywords = ['歌ってみた', 'cover', 'カバー'];
+
+        foreach ($keywords as $keyword) {
+            if (mb_strpos($lowerTitle, mb_strtolower($keyword)) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * カバー曲用のts_itemを作成
+     *
+     * @param  array  $archive  アーカイブ情報（video_id, title が必要）
+     * @return array ts_item配列
+     */
+    public function createCoverSongTsItem(array $archive): array
+    {
+        $title = $archive['title'];
+
+        return [
+            'id' => Str::ulid(),
+            'comment_id' => $archive['video_id'], // 概要欄と同様にvideo_idを設定
+            'video_id' => $archive['video_id'],
+            'type' => '3', // カバー曲
+            'ts_text' => '0:00',
+            'ts_num' => 0,
+            'text' => $title,
+            'normalized_text' => TextNormalizer::normalize($title),
+            'is_display' => true,
+        ];
+    }
+
+    /**
+     * アーカイブ配列からカバー曲のts_itemsを生成
+     *
+     * @param  array  $archives  アーカイブ配列
+     * @return array カバー曲のts_items配列
+     */
+    public function extractCoverSongTsItems(array $archives): array
+    {
+        $coverTsItems = [];
+        $now = now();
+
+        foreach ($archives as $archive) {
+            if ($this->isCoverSong($archive['title'])) {
+                $tsItem = $this->createCoverSongTsItem($archive);
+                $tsItem['created_at'] = $now;
+                $tsItem['updated_at'] = $now;
+                $coverTsItems[] = $tsItem;
+            }
+        }
+
+        return $coverTsItems;
     }
 }

--- a/database/migrations/2025_12_05_182511_add_cover_song_type_to_ts_items.php
+++ b/database/migrations/2025_12_05_182511_add_cover_song_type_to_ts_items.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * ts_items.type に '3' (カバー曲/歌ってみた) を追加
+     * 1: 概要欄, 2: コメント, 3: カバー曲
+     */
+    public function up(): void
+    {
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'mysql') {
+            // MySQLの場合: enumに '3' を追加
+            DB::statement("ALTER TABLE ts_items MODIFY COLUMN type ENUM('1', '2', '3') NOT NULL");
+        }
+        // SQLiteの場合: enumはTEXTとして扱われるため、変更不要
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'mysql') {
+            // MySQLの場合: enumを元に戻す（type='3'のレコードは先に削除が必要）
+            DB::statement("ALTER TABLE ts_items MODIFY COLUMN type ENUM('1', '2') NOT NULL");
+        }
+    }
+};

--- a/database/migrations/2025_12_05_182511_add_cover_song_type_to_ts_items.php
+++ b/database/migrations/2025_12_05_182511_add_cover_song_type_to_ts_items.php
@@ -18,8 +18,37 @@ return new class extends Migration
         if ($driver === 'mysql') {
             // MySQLの場合: enumに '3' を追加
             DB::statement("ALTER TABLE ts_items MODIFY COLUMN type ENUM('1', '2', '3') NOT NULL");
+        } else {
+            // SQLiteの場合: テーブル再作成でCHECK制約を更新
+            // SQLiteはALTER TABLE MODIFY COLUMNをサポートしないため
+            // 外部キー制約を一時的に無効化
+            DB::statement('PRAGMA foreign_keys=OFF');
+
+            DB::statement('CREATE TABLE ts_items_new (
+                id VARCHAR(26) PRIMARY KEY,
+                video_id VARCHAR(11) NOT NULL,
+                comment_id VARCHAR(255),
+                type VARCHAR(255) NOT NULL CHECK (type IN (\'1\', \'2\', \'3\')),
+                ts_text VARCHAR(8) NOT NULL,
+                ts_num INTEGER NOT NULL,
+                text VARCHAR(255) NOT NULL,
+                normalized_text VARCHAR(255),
+                is_display BOOLEAN DEFAULT 1,
+                created_at TIMESTAMP,
+                updated_at TIMESTAMP,
+                FOREIGN KEY (video_id) REFERENCES archives(video_id) ON DELETE CASCADE
+            )');
+
+            DB::statement('INSERT INTO ts_items_new SELECT * FROM ts_items');
+            DB::statement('DROP TABLE ts_items');
+            DB::statement('ALTER TABLE ts_items_new RENAME TO ts_items');
+
+            // インデックスを再作成
+            DB::statement('CREATE INDEX ts_items_video_id_ts_num_index ON ts_items (video_id, ts_num)');
+
+            // 外部キー制約を再度有効化
+            DB::statement('PRAGMA foreign_keys=ON');
         }
-        // SQLiteの場合: enumはTEXTとして扱われるため、変更不要
     }
 
     /**
@@ -32,6 +61,32 @@ return new class extends Migration
         if ($driver === 'mysql') {
             // MySQLの場合: enumを元に戻す（type='3'のレコードは先に削除が必要）
             DB::statement("ALTER TABLE ts_items MODIFY COLUMN type ENUM('1', '2') NOT NULL");
+        } else {
+            // SQLiteの場合: テーブル再作成
+            DB::statement('PRAGMA foreign_keys=OFF');
+
+            DB::statement('CREATE TABLE ts_items_new (
+                id VARCHAR(26) PRIMARY KEY,
+                video_id VARCHAR(11) NOT NULL,
+                comment_id VARCHAR(255),
+                type VARCHAR(255) NOT NULL CHECK (type IN (\'1\', \'2\')),
+                ts_text VARCHAR(8) NOT NULL,
+                ts_num INTEGER NOT NULL,
+                text VARCHAR(255) NOT NULL,
+                normalized_text VARCHAR(255),
+                is_display BOOLEAN DEFAULT 1,
+                created_at TIMESTAMP,
+                updated_at TIMESTAMP,
+                FOREIGN KEY (video_id) REFERENCES archives(video_id) ON DELETE CASCADE
+            )');
+
+            DB::statement('INSERT INTO ts_items_new SELECT * FROM ts_items WHERE type IN (\'1\', \'2\')');
+            DB::statement('DROP TABLE ts_items');
+            DB::statement('ALTER TABLE ts_items_new RENAME TO ts_items');
+
+            DB::statement('CREATE INDEX ts_items_video_id_ts_num_index ON ts_items (video_id, ts_num)');
+
+            DB::statement('PRAGMA foreign_keys=ON');
         }
     }
 };

--- a/tests/Unit/Services/RefreshArchiveServiceTest.php
+++ b/tests/Unit/Services/RefreshArchiveServiceTest.php
@@ -725,4 +725,236 @@ class RefreshArchiveServiceTest extends TestCase
 
         $this->service->refreshTimeStampsFromComments($videoId);
     }
+
+    /**
+     * isCoverSong: 「歌ってみた」を含むタイトルを検出
+     */
+    public function test_is_cover_song_detects_utatte_mita(): void
+    {
+        $this->assertTrue($this->service->isCoverSong('【歌ってみた】夜に駆ける / YOASOBI'));
+        $this->assertTrue($this->service->isCoverSong('夜に駆ける 歌ってみた'));
+    }
+
+    /**
+     * isCoverSong: 「cover」を含むタイトルを検出（大文字小文字無視）
+     */
+    public function test_is_cover_song_detects_cover(): void
+    {
+        $this->assertTrue($this->service->isCoverSong('【Cover】夜に駆ける'));
+        $this->assertTrue($this->service->isCoverSong('夜に駆ける cover'));
+        $this->assertTrue($this->service->isCoverSong('夜に駆ける COVER'));
+    }
+
+    /**
+     * isCoverSong: 「カバー」を含むタイトルを検出
+     */
+    public function test_is_cover_song_detects_katakana_cover(): void
+    {
+        $this->assertTrue($this->service->isCoverSong('夜に駆ける【カバー】'));
+        $this->assertTrue($this->service->isCoverSong('カバー曲集'));
+    }
+
+    /**
+     * isCoverSong: 関連キーワードを含まないタイトルはfalse
+     */
+    public function test_is_cover_song_returns_false_for_normal_title(): void
+    {
+        $this->assertFalse($this->service->isCoverSong('【歌枠】歌います！'));
+        $this->assertFalse($this->service->isCoverSong('雑談配信'));
+        $this->assertFalse($this->service->isCoverSong('ゲーム実況'));
+    }
+
+    /**
+     * createCoverSongTsItem: カバー曲用のts_itemが正しく生成される
+     */
+    public function test_create_cover_song_ts_item(): void
+    {
+        $archive = [
+            'video_id' => 'video123',
+            'title' => '【歌ってみた】夜に駆ける / YOASOBI',
+        ];
+
+        $tsItem = $this->service->createCoverSongTsItem($archive);
+
+        $this->assertEquals('video123', $tsItem['video_id']);
+        $this->assertEquals('video123', $tsItem['comment_id']);
+        $this->assertEquals('3', $tsItem['type']);
+        $this->assertEquals('0:00', $tsItem['ts_text']);
+        $this->assertEquals(0, $tsItem['ts_num']);
+        $this->assertEquals('【歌ってみた】夜に駆ける / YOASOBI', $tsItem['text']);
+        $this->assertTrue($tsItem['is_display']);
+        $this->assertNotEmpty($tsItem['id']);
+        $this->assertNotEmpty($tsItem['normalized_text']);
+    }
+
+    /**
+     * extractCoverSongTsItems: カバー曲のみがts_itemsとして抽出される
+     */
+    public function test_extract_cover_song_ts_items(): void
+    {
+        $archives = [
+            ['video_id' => 'video1', 'title' => '【歌ってみた】夜に駆ける'],
+            ['video_id' => 'video2', 'title' => '【歌枠】歌います！'],
+            ['video_id' => 'video3', 'title' => '【Cover】群青'],
+            ['video_id' => 'video4', 'title' => '雑談配信'],
+        ];
+
+        $coverTsItems = $this->service->extractCoverSongTsItems($archives);
+
+        // video1とvideo3のみがカバー曲として抽出される
+        $this->assertCount(2, $coverTsItems);
+
+        $videoIds = array_column($coverTsItems, 'video_id');
+        $this->assertContains('video1', $videoIds);
+        $this->assertContains('video3', $videoIds);
+        $this->assertNotContains('video2', $videoIds);
+        $this->assertNotContains('video4', $videoIds);
+    }
+
+    /**
+     * refreshArchives: カバー曲動画が0:00のts_itemとして登録される
+     */
+    public function test_refresh_archives_registers_cover_songs(): void
+    {
+        $channel = Channel::factory()->create(['channel_id' => 'UC123456789']);
+
+        // YouTubeServiceのモック設定
+        $this->youtubeService
+            ->shouldReceive('getArchivesAndTsItems')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => Str::uuid()->toString(),
+                    'video_id' => 'cover_video',
+                    'channel_id' => $channel->channel_id,
+                    'title' => '【歌ってみた】夜に駆ける / YOASOBI',
+                    'thumbnail' => 'https://example.com/thumb.jpg',
+                    'is_public' => true,
+                    'is_display' => true,
+                    'published_at' => now(),
+                    'comments_updated_at' => now(),
+                    'description' => '',
+                    'ts_items' => [], // 概要欄にタイムスタンプなし
+                ],
+                [
+                    'id' => Str::uuid()->toString(),
+                    'video_id' => 'normal_video',
+                    'channel_id' => $channel->channel_id,
+                    'title' => '【歌枠】歌います！',
+                    'thumbnail' => 'https://example.com/thumb2.jpg',
+                    'is_public' => true,
+                    'is_display' => true,
+                    'published_at' => now(),
+                    'comments_updated_at' => now(),
+                    'description' => '',
+                    'ts_items' => [
+                        [
+                            'id' => Str::uuid()->toString(),
+                            'video_id' => 'normal_video',
+                            'type' => '1',
+                            'ts_text' => '1:00',
+                            'ts_num' => 60,
+                            'text' => 'Test Song',
+                            'is_display' => true,
+                        ],
+                    ],
+                ],
+            ]);
+
+        $this->service->refreshArchives($channel);
+
+        // カバー曲動画に0:00のts_itemが登録されていることを確認
+        $this->assertDatabaseHas('ts_items', [
+            'video_id' => 'cover_video',
+            'type' => '3',
+            'ts_text' => '0:00',
+            'ts_num' => 0,
+            'text' => '【歌ってみた】夜に駆ける / YOASOBI',
+        ]);
+
+        // 通常動画にはカバー曲のts_itemがないことを確認
+        $this->assertDatabaseMissing('ts_items', [
+            'video_id' => 'normal_video',
+            'type' => '3',
+        ]);
+
+        // 通常動画の概要欄タイムスタンプは登録されていることを確認
+        $this->assertDatabaseHas('ts_items', [
+            'video_id' => 'normal_video',
+            'type' => '1',
+            'text' => 'Test Song',
+        ]);
+    }
+
+    /**
+     * refreshArchives: カバー曲動画でも概要欄のタイムスタンプがあれば両方登録される
+     */
+    public function test_refresh_archives_registers_both_cover_and_timestamps(): void
+    {
+        $channel = Channel::factory()->create(['channel_id' => 'UC123456789']);
+
+        // YouTubeServiceのモック設定
+        $this->youtubeService
+            ->shouldReceive('getArchivesAndTsItems')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => Str::uuid()->toString(),
+                    'video_id' => 'cover_video',
+                    'channel_id' => $channel->channel_id,
+                    'title' => '【Cover】カバー曲集',
+                    'thumbnail' => 'https://example.com/thumb.jpg',
+                    'is_public' => true,
+                    'is_display' => true,
+                    'published_at' => now(),
+                    'comments_updated_at' => now(),
+                    'description' => '',
+                    'ts_items' => [
+                        [
+                            'id' => Str::uuid()->toString(),
+                            'video_id' => 'cover_video',
+                            'type' => '1',
+                            'ts_text' => '1:00',
+                            'ts_num' => 60,
+                            'text' => '夜に駆ける',
+                            'is_display' => true,
+                        ],
+                        [
+                            'id' => Str::uuid()->toString(),
+                            'video_id' => 'cover_video',
+                            'type' => '1',
+                            'ts_text' => '5:00',
+                            'ts_num' => 300,
+                            'text' => '群青',
+                            'is_display' => true,
+                        ],
+                    ],
+                ],
+            ]);
+
+        $this->service->refreshArchives($channel);
+
+        // カバー曲として0:00のts_itemが登録される
+        $this->assertDatabaseHas('ts_items', [
+            'video_id' => 'cover_video',
+            'type' => '3',
+            'ts_text' => '0:00',
+            'ts_num' => 0,
+        ]);
+
+        // 概要欄のタイムスタンプも登録される
+        $this->assertDatabaseHas('ts_items', [
+            'video_id' => 'cover_video',
+            'type' => '1',
+            'text' => '夜に駆ける',
+        ]);
+        $this->assertDatabaseHas('ts_items', [
+            'video_id' => 'cover_video',
+            'type' => '1',
+            'text' => '群青',
+        ]);
+
+        // 合計3件のts_itemが登録されていること
+        $this->assertEquals(3, TsItem::where('video_id', 'cover_video')->count());
+    }
 }


### PR DESCRIPTION
## Summary
- タイトルに「歌ってみた」「cover」「カバー」を含む動画をカバー曲として検出
- カバー曲動画に0:00開始のタイムスタンプ（type='3'）を自動登録
- RefreshArchiveService実行時に自動適用

## Changes
- `RefreshArchiveService`: カバー曲検出・ts_item生成メソッド追加
- `migration`: ts_items.type に '3' を追加（MySQL/SQLite両対応）
- テスト: 8件の新規テストケース追加

## Test plan
- [x] `php artisan test` 全233件パス
- [x] SQLiteのCHECK制約更新に対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)