### PR TITLE
feat: 楽曲ガチャ機能を追加

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -169,6 +169,24 @@ class ChannelController extends Controller
     }
 
     /**
+     * チャンネルのタイムスタンプからランダムに1件取得
+     */
+    public function fetchRandomTimestamp(string $id)
+    {
+        $channel = Channel::where('handle', $id)->firstOrFail();
+
+        $result = $this->timestampService->getRandomTimestamp($channel);
+
+        if (! $result) {
+            return response()->json([
+                'error' => 'タイムスタンプが見つかりませんでした',
+            ], 404);
+        }
+
+        return response()->json($result);
+    }
+
+    /**
      * タイムスタンプ取得クエリのベースを構築
      *
      * @param  bool  $withArchive  archiveリレーションを事前ロードするか

--- a/app/Services/TimestampService.php
+++ b/app/Services/TimestampService.php
@@ -254,6 +254,69 @@ class TimestampService
     }
 
     /**
+     * チャンネルのタイムスタンプからランダムに1件取得
+     *
+     * @return array|null タイムスタンプデータ（見つからない場合はnull）
+     */
+    public function getRandomTimestamp(Channel $channel): ?array
+    {
+        // ベースクエリ: ts_itemsとtimestamp_song_mappings、songsをLEFT JOIN
+        $query = TsItem::with(['archive'])
+            ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
+            ->leftJoin('songs', 'timestamp_song_mappings.song_id', '=', 'songs.id')
+            ->select(
+                'ts_items.*',
+                'timestamp_song_mappings.id as mapping_id',
+                'timestamp_song_mappings.song_id',
+                'timestamp_song_mappings.is_not_song',
+                'songs.title as song_title',
+                'songs.artist as song_artist',
+                'songs.spotify_track_id'
+            )
+            ->whereHas('archive', function ($q) use ($channel) {
+                $q->where('channel_id', $channel->channel_id)
+                    ->where('is_display', 1);
+            })
+            ->whereNotNull('ts_items.text')
+            ->where('ts_items.text', '!=', '')
+            ->whereNotNull('ts_items.normalized_text')
+            ->where('ts_items.is_display', 1);
+
+        // 「楽曲ではない」を除外
+        $query->where(function ($q) {
+            $q->whereNull('timestamp_song_mappings.id')
+                ->orWhere('timestamp_song_mappings.is_not_song', false);
+        });
+
+        // ランダムに1件取得
+        $item = $query->inRandomOrder()->first();
+
+        if (! $item) {
+            return null;
+        }
+
+        return [
+            'id' => $item->id,
+            'ts_text' => $item->ts_text,
+            'ts_num' => $item->ts_num,
+            'text' => $item->text,
+            'video_id' => $item->video_id,
+            'archive' => [
+                'title' => $item->archive->title,
+                'published_at' => $item->archive->published_at,
+            ],
+            'mapping' => $item->mapping_id ? [
+                'song' => $item->song_id ? [
+                    'title' => $item->song_title,
+                    'artist' => $item->song_artist,
+                    'spotify_track_id' => ValidationHelper::validateSpotifyTrackId($item->spotify_track_id),
+                ] : null,
+                'is_not_song' => (bool) $item->is_not_song,
+            ] : null,
+        ];
+    }
+
+    /**
      * 未解決の報告があるタイムスタンプIDを取得
      */
     private function fetchReportedIds(array $tsItemIds): array

--- a/app/Services/TimestampService.php
+++ b/app/Services/TimestampService.php
@@ -256,9 +256,10 @@ class TimestampService
     /**
      * チャンネルのタイムスタンプからランダムに1件取得
      *
+     * @param  int  $perPage  1ページあたりの件数（ページ番号計算用）
      * @return array|null タイムスタンプデータ（見つからない場合はnull）
      */
-    public function getRandomTimestamp(Channel $channel): ?array
+    public function getRandomTimestamp(Channel $channel, int $perPage = 50): ?array
     {
         // ベースクエリ: ts_itemsとtimestamp_song_mappings、songsをLEFT JOIN
         $query = TsItem::with(['archive'])
@@ -295,6 +296,11 @@ class TimestampService
             return null;
         }
 
+        // 選ばれたアイテムのソート順での位置を計算（ページ番号算出用）
+        $sortKey = $item->song_title ?? $item->text;
+        $position = $this->calculateItemPosition($channel, $sortKey, $item->id);
+        $page = (int) ceil($position / $perPage);
+
         return [
             'id' => $item->id,
             'ts_text' => $item->ts_text,
@@ -313,7 +319,55 @@ class TimestampService
                 ] : null,
                 'is_not_song' => (bool) $item->is_not_song,
             ] : null,
+            'page' => max(1, $page),
         ];
+    }
+
+    /**
+     * アイテムのソート順での位置を計算
+     */
+    private function calculateItemPosition(Channel $channel, string $sortKey, string $itemId): int
+    {
+        // ソートキーより前にあるアイテム数をカウント
+        $countBefore = TsItem::query()
+            ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
+            ->leftJoin('songs', 'timestamp_song_mappings.song_id', '=', 'songs.id')
+            ->whereHas('archive', function ($q) use ($channel) {
+                $q->where('channel_id', $channel->channel_id)
+                    ->where('is_display', 1);
+            })
+            ->whereNotNull('ts_items.text')
+            ->where('ts_items.text', '!=', '')
+            ->whereNotNull('ts_items.normalized_text')
+            ->where('ts_items.is_display', 1)
+            ->where(function ($q) {
+                $q->whereNull('timestamp_song_mappings.id')
+                    ->orWhere('timestamp_song_mappings.is_not_song', false);
+            })
+            ->whereRaw('COALESCE(songs.title, ts_items.text) < ?', [$sortKey])
+            ->count();
+
+        // 同じソートキーを持つアイテムの中での位置も考慮
+        $countSameKey = TsItem::query()
+            ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
+            ->leftJoin('songs', 'timestamp_song_mappings.song_id', '=', 'songs.id')
+            ->whereHas('archive', function ($q) use ($channel) {
+                $q->where('channel_id', $channel->channel_id)
+                    ->where('is_display', 1);
+            })
+            ->whereNotNull('ts_items.text')
+            ->where('ts_items.text', '!=', '')
+            ->whereNotNull('ts_items.normalized_text')
+            ->where('ts_items.is_display', 1)
+            ->where(function ($q) {
+                $q->whereNull('timestamp_song_mappings.id')
+                    ->orWhere('timestamp_song_mappings.is_not_song', false);
+            })
+            ->whereRaw('COALESCE(songs.title, ts_items.text) = ?', [$sortKey])
+            ->where('ts_items.id', '<', $itemId)
+            ->count();
+
+        return $countBefore + $countSameKey + 1;
     }
 
     /**

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -688,6 +688,14 @@ function registerArchiveListComponent() {
                             await this.fetchTimestamps(timestamp.page, this.searchQuery, this.selectedIndex);
                         }
 
+                        // 選択された楽曲の位置までスクロール
+                        this.$nextTick(() => {
+                            const selectedElement = document.querySelector(`[data-timestamp-id="${timestamp.id}"]`);
+                            if (selectedElement) {
+                                selectedElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                            }
+                        });
+
                         toast.success('ランダムで楽曲を選びました！');
                     } catch (error) {
                         console.error('ランダム再生に失敗しました:', error);

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -67,6 +67,9 @@ function registerArchiveListComponent() {
                 youtubePlayer: null,
                 playerInitialized: false,
                 pendingVideo: null,
+                // ランダム再生機能
+                isRandomPlaying: false,
+
                 // ドラッグ機能用
                 isDragging: false,
                 playerPosition: { x: null, y: null },
@@ -638,6 +641,54 @@ function registerArchiveListComponent() {
                 // 自動再生設定の保存
                 saveAutoPlay() {
                     sessionStorage.setItem('videoAutoPlay', this.autoPlay.toString());
+                },
+
+                // ランダム再生
+                async playRandomTimestamp() {
+                    if (this.isRandomPlaying) return;
+
+                    try {
+                        this.isRandomPlaying = true;
+
+                        const timestamp = await ChannelApiService.fetchRandomTimestamp(this.channel.handle);
+
+                        logUserAction('playRandomTimestamp', {
+                            timestampId: timestamp.id,
+                            videoId: timestamp.video_id,
+                            tsNum: timestamp.ts_num,
+                            songTitle: timestamp.mapping?.song?.title,
+                            text: timestamp.text
+                        });
+
+                        // 楽曲情報または疑似楽曲オブジェクトを設定
+                        if (timestamp.mapping?.song) {
+                            this.selectedSong = timestamp.mapping.song;
+                        } else {
+                            this.selectedSong = {
+                                title: timestamp.text || '-',
+                                artist: '',
+                                spotify_track_id: null
+                            };
+                        }
+                        this.selectedTimestamp = timestamp;
+
+                        // 配信パネルを表示
+                        if (!this.panelDismissed) {
+                            this.showDistributionPanel = true;
+                        }
+
+                        // 動画を再生
+                        if (timestamp.video_id) {
+                            this.loadAndPlayVideo(timestamp.video_id, timestamp.ts_num || 0);
+                        }
+
+                        toast.success('ランダムで楽曲を選びました！');
+                    } catch (error) {
+                        console.error('ランダム再生に失敗しました:', error);
+                        toast.error(error.message || 'ランダム再生に失敗しました');
+                    } finally {
+                        this.isRandomPlaying = false;
+                    }
                 },
 
                 // ドラッグ開始

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -657,7 +657,8 @@ function registerArchiveListComponent() {
                             videoId: timestamp.video_id,
                             tsNum: timestamp.ts_num,
                             songTitle: timestamp.mapping?.song?.title,
-                            text: timestamp.text
+                            text: timestamp.text,
+                            page: timestamp.page
                         });
 
                         // 楽曲情報または疑似楽曲オブジェクトを設定
@@ -680,6 +681,11 @@ function registerArchiveListComponent() {
                         // 動画を再生
                         if (timestamp.video_id) {
                             this.loadAndPlayVideo(timestamp.video_id, timestamp.ts_num || 0);
+                        }
+
+                        // 該当ページに切り替え
+                        if (timestamp.page && timestamp.page !== this.currentTimestampPage) {
+                            await this.fetchTimestamps(timestamp.page, this.searchQuery, this.selectedIndex);
                         }
 
                         toast.success('ランダムで楽曲を選びました！');

--- a/resources/js/channels/services/ChannelApiService.js
+++ b/resources/js/channels/services/ChannelApiService.js
@@ -63,4 +63,20 @@ export class ChannelApiService {
     static getDownloadUrl(channelHandle) {
         return `/api/channels/${channelHandle}/timestamps/download`;
     }
+
+    /**
+     * ランダムなタイムスタンプを1件取得
+     * @param {string} channelHandle - チャンネルハンドル
+     * @returns {Promise<Object>} ランダムなタイムスタンプデータ
+     */
+    static async fetchRandomTimestamp(channelHandle) {
+        const response = await fetch(`/api/channels/${channelHandle}/timestamps/random`);
+        if (!response.ok) {
+            if (response.status === 404) {
+                throw new Error('タイムスタンプが見つかりませんでした');
+            }
+            throw new Error('ランダムタイムスタンプの取得に失敗しました');
+        }
+        return response.json();
+    }
 }

--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -1,5 +1,30 @@
 {{-- タイムスタンプタブ --}}
 <div x-show="activeTab === 'timestamps'">
+    {{-- ランダム再生ボタン --}}
+    <div class="flex justify-center mb-4">
+        <button @click="playRandomTimestamp()"
+                :disabled="isRandomPlaying"
+                class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white font-bold rounded-full shadow-lg transition-all duration-200 transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none">
+            <template x-if="!isRandomPlaying">
+                <span class="flex items-center gap-2">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    楽曲ガチャ
+                </span>
+            </template>
+            <template x-if="isRandomPlaying">
+                <span class="flex items-center gap-2">
+                    <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    抽選中...
+                </span>
+            </template>
+        </button>
+    </div>
+
     {{-- ページネーション（上） --}}
     <div class="flex justify-center gap-2 mb-4">
         <button @click="fetchTimestamps(1, searchQuery, selectedIndex)"

--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -25,6 +25,49 @@
         </button>
     </div>
 
+    {{-- ガチャで選ばれた楽曲の表示 --}}
+    <template x-if="selectedTimestamp && selectedTimestamp.id">
+        <div class="mb-4 p-3 bg-gradient-to-r from-pink-50 to-purple-50 dark:from-pink-900/20 dark:to-purple-900/20 border-2 border-pink-300 dark:border-pink-600 rounded-lg">
+            <div class="flex items-center gap-2 mb-2">
+                <span class="text-xs font-bold text-pink-600 dark:text-pink-400 uppercase tracking-wider">選択中</span>
+            </div>
+            <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
+                {{-- 楽曲情報 --}}
+                <div class="flex-shrink-0 w-full sm:w-[300px]">
+                    <div class="truncate">
+                        <span class="font-medium text-sm" x-text="selectedSong?.title || selectedTimestamp.text || '-'"></span>
+                        <template x-if="selectedSong?.artist">
+                            <span>
+                                <span class="text-sm text-gray-500 dark:text-gray-400"> / </span>
+                                <span class="text-sm text-gray-500 dark:text-gray-400" x-text="selectedSong.artist"></span>
+                            </span>
+                        </template>
+                    </div>
+                </div>
+
+                {{-- アーカイブタイトル & 公開日 --}}
+                <div class="hidden sm:block text-sm truncate flex-1">
+                    <div class="truncate text-gray-600 dark:text-gray-400" x-text="selectedTimestamp.archive?.title || ''"></div>
+                    <div class="mt-0.5 text-xs text-gray-500 dark:text-gray-500">
+                        <span x-text="'公開日: ' + (selectedTimestamp.archive?.published_at ? formatPublishedDate(selectedTimestamp.archive.published_at) : '不明')"></span>
+                        <span x-text="'　タイムスタンプ: ' + selectedTimestamp.ts_text"></span>
+                    </div>
+                </div>
+
+                {{-- 動画リンク --}}
+                <a :href="getYoutubeUrl(selectedTimestamp.video_id, selectedTimestamp.ts_num)"
+                   class="inline-flex items-center gap-1 px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded text-xs sm:text-sm whitespace-nowrap transition-colors"
+                   target="_blank"
+                   title="YouTubeで再生">
+                    <svg class="w-3 h-3 sm:w-4 sm:h-4" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+                    </svg>
+                    <span>YTで開く</span>
+                </a>
+            </div>
+        </div>
+    </template>
+
     {{-- ページネーション（上） --}}
     <div class="flex justify-center gap-2 mb-4">
         <button @click="fetchTimestamps(1, searchQuery, selectedIndex)"

--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -25,49 +25,6 @@
         </button>
     </div>
 
-    {{-- ガチャで選ばれた楽曲の表示 --}}
-    <template x-if="selectedTimestamp && selectedTimestamp.id">
-        <div class="mb-4 p-3 bg-gradient-to-r from-pink-50 to-purple-50 dark:from-pink-900/20 dark:to-purple-900/20 border-2 border-pink-300 dark:border-pink-600 rounded-lg">
-            <div class="flex items-center gap-2 mb-2">
-                <span class="text-xs font-bold text-pink-600 dark:text-pink-400 uppercase tracking-wider">選択中</span>
-            </div>
-            <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3">
-                {{-- 楽曲情報 --}}
-                <div class="flex-shrink-0 w-full sm:w-[300px]">
-                    <div class="truncate">
-                        <span class="font-medium text-sm" x-text="selectedSong?.title || selectedTimestamp.text || '-'"></span>
-                        <template x-if="selectedSong?.artist">
-                            <span>
-                                <span class="text-sm text-gray-500 dark:text-gray-400"> / </span>
-                                <span class="text-sm text-gray-500 dark:text-gray-400" x-text="selectedSong.artist"></span>
-                            </span>
-                        </template>
-                    </div>
-                </div>
-
-                {{-- アーカイブタイトル & 公開日 --}}
-                <div class="hidden sm:block text-sm truncate flex-1">
-                    <div class="truncate text-gray-600 dark:text-gray-400" x-text="selectedTimestamp.archive?.title || ''"></div>
-                    <div class="mt-0.5 text-xs text-gray-500 dark:text-gray-500">
-                        <span x-text="'公開日: ' + (selectedTimestamp.archive?.published_at ? formatPublishedDate(selectedTimestamp.archive.published_at) : '不明')"></span>
-                        <span x-text="'　タイムスタンプ: ' + selectedTimestamp.ts_text"></span>
-                    </div>
-                </div>
-
-                {{-- 動画リンク --}}
-                <a :href="getYoutubeUrl(selectedTimestamp.video_id, selectedTimestamp.ts_num)"
-                   class="inline-flex items-center gap-1 px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded text-xs sm:text-sm whitespace-nowrap transition-colors"
-                   target="_blank"
-                   title="YouTubeで再生">
-                    <svg class="w-3 h-3 sm:w-4 sm:h-4" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
-                    </svg>
-                    <span>YTで開く</span>
-                </a>
-            </div>
-        </div>
-    </template>
-
     {{-- ページネーション（上） --}}
     <div class="flex justify-center gap-2 mb-4">
         <button @click="fetchTimestamps(1, searchQuery, selectedIndex)"

--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -153,6 +153,7 @@
 
         <template x-for="ts in (timestamps.data || [])" :key="ts.id">
             <div class="p-2 border rounded transition-colors"
+                 :data-timestamp-id="ts.id"
                  :class="{
                      'border-blue-500 bg-blue-50 dark:bg-blue-900/20 dark:border-blue-400': selectedSong && ((ts.mapping?.song && ts.mapping.song.title === selectedSong.title && ts.mapping.song.artist === selectedSong.artist) || (!ts.mapping?.song && ts.text === selectedSong.title)),
                      'bg-gray-200 dark:bg-gray-700 border-gray-300 dark:border-gray-500': ts.has_pending_report && !(selectedSong && ((ts.mapping?.song && ts.mapping.song.title === selectedSong.title && ts.mapping.song.artist === selectedSong.artist) || (!ts.mapping?.song && ts.text === selectedSong.title))),

--- a/routes/web.php
+++ b/routes/web.php
@@ -81,6 +81,9 @@ Route::get('/channels/{id}', [ChannelController::class, 'show'])->name('channels
 
 Route::get('api/channels/{id}', [ChannelController::class, 'fetchArchives'])->name('channels.fetchArchives');
 Route::get('api/channels/{id}/timestamps', [ChannelController::class, 'fetchTimestamps'])->name('channels.fetchTimestamps');
+Route::get('api/channels/{id}/timestamps/random', [ChannelController::class, 'fetchRandomTimestamp'])
+    ->name('channels.fetchRandomTimestamp')
+    ->middleware('throttle:30,1'); // 1分間に30回まで
 Route::get('api/channels/{id}/timestamps/download', [ChannelController::class, 'downloadTimestamps'])
     ->name('channels.downloadTimestamps')
     ->middleware('throttle:10,1'); // 1分間に10回まで


### PR DESCRIPTION
## Summary
- チャンネルページに「楽曲ガチャ」ボタンを追加
- ランダムに楽曲を選んで自動再生する機能
- 選ばれた楽曲のページへ自動切り替え・スクロール

## Changes
- `ChannelController`: `fetchRandomTimestamp` APIエンドポイント追加
- `TimestampService`: `getRandomTimestamp`, `calculateItemPosition` メソッド追加
- `archive-list.js`: `playRandomTimestamp` メソッド追加
- `ChannelApiService.js`: `fetchRandomTimestamp` API追加
- `timestamps-tab.blade.php`: ガチャボタンUI追加
- `routes/web.php`: レート制限付きルート追加（30回/分）

## Test plan
- [x] `npm run build` 成功
- [x] `php artisan test` 全233件パス
- [x] developにrebase済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)