### PR TITLE
feat: 曲名フォントを強調表示に変更

### DIFF
--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -168,7 +168,7 @@
                         <div class="truncate">
                             <template x-if="ts.mapping?.song">
                                 <span>
-                                    <span class="font-medium text-xs sm:text-sm" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : ''" x-text="ts.mapping.song.title"></span>
+                                    <span class="font-bold text-sm sm:text-base" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : ''" x-text="ts.mapping.song.title"></span>
                                     <span class="text-xs sm:text-sm" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'"> / </span>
                                     <span class="text-xs sm:text-sm" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'" x-text="ts.mapping.song.artist"></span>
                                 </span>


### PR DESCRIPTION
## Summary
- 曲名を `font-medium` から `font-bold` に変更
- フォントサイズを `text-xs sm:text-sm` から `text-sm sm:text-base` に拡大
- タイムスタンプカードの曲名の視認性を向上

## Test plan
- [x] タイムスタンプタブで曲名が太字・大きめに表示されることを確認
- [x] モバイル・デスクトップ両方でレイアウト崩れがないことを確認

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)