### PR TITLE
feat: チャンネル一覧に最終更新日を表示

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -32,8 +32,16 @@ class ChannelController extends Controller
         // チャンネル情報を取得して表示
         $page = config('utils.page');
         $paginatedChannels = Channel::paginate($page);
+
+        // 各チャンネルに最終更新日を追加
+        $channelsWithLastUpdate = collect($paginatedChannels->items())->map(function ($channel) {
+            $channel->last_refresh_at = $channel->archives()->max('updated_at');
+
+            return $channel;
+        });
+
         $channels = [
-            'data' => $paginatedChannels->items(),
+            'data' => $channelsWithLastUpdate->toArray(),
             'current_page' => $paginatedChannels->currentPage(),
             'last_page' => $paginatedChannels->lastPage(),
             'per_page' => $paginatedChannels->perPage(),

--- a/resources/views/channels/index.blade.php
+++ b/resources/views/channels/index.blade.php
@@ -16,9 +16,14 @@
                 class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 w-[100%] max-w-5xl border shadow p-4 rounded-lg">
                 <template x-for="channel in channels" :key="channel.handle">
                     <a :href="'/channels/'+channel.handle">
-                        <div class="flex items-center gap-4 border rounded-lg shadow-lg p-4 bg-white cursor-pointer hover:bg-gray-200">
+                        <div class="flex items-center gap-4 border rounded-lg shadow-lg p-4 bg-white dark:bg-gray-800 cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700">
                             <img :src="escapeHTML(channel.thumbnail || '')" alt="アイコン" class="w-20 h-20 rounded-full" />
-                            <span class="text-lg font-bold" x-text="channel.title || '未設定'"></span>
+                            <div class="flex flex-col">
+                                <span class="text-lg font-bold dark:text-gray-100" x-text="channel.title || '未設定'"></span>
+                                <span class="text-xs text-gray-500 dark:text-gray-400"
+                                      x-show="channel.last_refresh_at"
+                                      x-text="'最終更新: ' + (channel.last_refresh_at ? new Date(channel.last_refresh_at).toLocaleDateString('ja-JP') : '')"></span>
+                            </div>
                         </div>
                     </a>
                 </template>


### PR DESCRIPTION
## Summary
- ChannelController::index() で各チャンネルのarchives最終更新日を取得
- チャンネルカードにチャンネル名の下に「最終更新: YYYY/MM/DD」を表示
- ダークモード対応のスタイル追加

## Test plan
- [x] チャンネル一覧で最終更新日が表示されることを確認
- [x] アーカイブがないチャンネルでは最終更新日が表示されないことを確認
- [x] ダークモードでも適切に表示されることを確認

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)