### PR TITLE
feat: 検索サジェスト機能を追加

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -195,6 +195,25 @@ class ChannelController extends Controller
     }
 
     /**
+     * タイムスタンプの検索候補用テキスト一覧を取得
+     */
+    public function fetchTimestampTexts(string $id)
+    {
+        $channel = Channel::where('handle', $id)->firstOrFail();
+
+        // ユニークなテキスト一覧を取得（表示対象のみ）
+        $texts = $this->buildTimestampQuery($channel)
+            ->select('text')
+            ->distinct()
+            ->pluck('text')
+            ->filter()
+            ->values()
+            ->toArray();
+
+        return response()->json($texts);
+    }
+
+    /**
      * タイムスタンプ取得クエリのベースを構築
      *
      * @param  bool  $withArchive  archiveリレーションを事前ロードするか

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -46,6 +46,11 @@ function registerArchiveListComponent() {
                 filterExpanded: false,
                 recentFilters: JSON.parse(localStorage.getItem('recentFilters') || '[]'),
 
+                // 検索サジェスト機能
+                suggestionTexts: [],
+                showSuggestions: false,
+                suggestionsLoaded: false,
+
                 // 報告機能の状態管理
                 showReportModal: false,
                 reportTarget: null,
@@ -196,6 +201,45 @@ function registerArchiveListComponent() {
                     localStorage.setItem('recentFilters', JSON.stringify(this.recentFilters));
                 },
 
+                // 検索サジェスト用テキスト一覧を読み込み
+                async loadSuggestionTexts() {
+                    if (this.suggestionsLoaded) return;
+                    try {
+                        const url = `/api/channels/${this.channel.handle}/timestamps/texts`;
+                        const response = await fetch(url);
+                        if (response.ok) {
+                            this.suggestionTexts = await response.json();
+                            this.suggestionsLoaded = true;
+                        }
+                    } catch (error) {
+                        console.error('Failed to load suggestion texts:', error);
+                    }
+                },
+
+                // フィルタされたサジェスト一覧を取得
+                get filteredSuggestions() {
+                    if (!this.searchQuery || this.searchQuery.length < 2) return [];
+                    const query = this.searchQuery.toLowerCase();
+                    return this.suggestionTexts
+                        .filter(text => text.toLowerCase().includes(query))
+                        .slice(0, 10);
+                },
+
+                // サジェストを選択
+                selectSuggestion(text) {
+                    this.searchQuery = text;
+                    this.showSuggestions = false;
+                    this.searchTimestamps();
+                },
+
+                // サジェストを閉じる
+                closeSuggestions() {
+                    // 少し遅延させてクリックイベントを先に処理
+                    setTimeout(() => {
+                        this.showSuggestions = false;
+                    }, 200);
+                },
+
                 downloadTimestamps() {
                     try {
                         const url = ChannelApiService.getDownloadUrl(this.channel.handle);
@@ -338,6 +382,9 @@ function registerArchiveListComponent() {
 
                     // YouTube IFrame APIの読み込み
                     this.loadYouTubeAPI();
+
+                    // 検索サジェスト用テキスト一覧を読み込み
+                    this.loadSuggestionTexts();
 
                     // ページ離脱時のクリーンアップ
                     window.addEventListener('beforeunload', () => {

--- a/resources/views/channels/partials/search-box.blade.php
+++ b/resources/views/channels/partials/search-box.blade.php
@@ -11,15 +11,38 @@
                     aria-label="タイムスタンプを検索"
                     class="border p-2 rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
             </template>
-            {{-- タイムスタンプタブ用の検索ボックス --}}
+            {{-- タイムスタンプタブ用の検索ボックス（サジェスト機能付き） --}}
             <template x-if="activeTab === 'timestamps'">
-                <input
-                    type="text"
-                    x-model="searchQuery"
-                    placeholder="楽曲名・アーティスト名・タイムスタンプで検索..."
-                    aria-label="楽曲名・アーティスト名・タイムスタンプで検索"
-                    maxlength="255"
-                    class="border p-2 rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
+                <div class="relative w-full">
+                    <input
+                        type="text"
+                        x-model="searchQuery"
+                        @focus="showSuggestions = true"
+                        @blur="closeSuggestions()"
+                        @keydown.escape="showSuggestions = false"
+                        @keydown.enter="showSuggestions = false"
+                        placeholder="楽曲名・アーティスト名・タイムスタンプで検索..."
+                        aria-label="楽曲名・アーティスト名・タイムスタンプで検索"
+                        maxlength="255"
+                        autocomplete="off"
+                        class="border p-2 rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
+                    {{-- サジェストドロップダウン --}}
+                    <div x-show="showSuggestions && filteredSuggestions.length > 0"
+                         x-transition:enter="transition ease-out duration-100"
+                         x-transition:enter-start="opacity-0 scale-95"
+                         x-transition:enter-end="opacity-100 scale-100"
+                         x-transition:leave="transition ease-in duration-75"
+                         x-transition:leave-start="opacity-100 scale-100"
+                         x-transition:leave-end="opacity-0 scale-95"
+                         class="absolute top-full left-0 right-0 mt-1 bg-white dark:bg-gray-800 border dark:border-gray-600 rounded shadow-lg z-50 max-h-60 overflow-y-auto">
+                        <template x-for="(suggestion, index) in filteredSuggestions" :key="index">
+                            <button type="button"
+                                    @mousedown.prevent="selectSuggestion(suggestion)"
+                                    class="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer truncate dark:text-gray-100"
+                                    x-text="suggestion"></button>
+                        </template>
+                    </div>
+                </div>
             </template>
             <template x-if="activeTab === 'archives'">
                 <div class="flex flex-row gap-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -84,6 +84,9 @@ Route::get('api/channels/{id}/timestamps', [ChannelController::class, 'fetchTime
 Route::get('api/channels/{id}/timestamps/random', [ChannelController::class, 'fetchRandomTimestamp'])
     ->name('channels.fetchRandomTimestamp')
     ->middleware('throttle:30,1'); // 1分間に30回まで
+Route::get('api/channels/{id}/timestamps/texts', [ChannelController::class, 'fetchTimestampTexts'])
+    ->name('channels.fetchTimestampTexts')
+    ->middleware('throttle:10,1'); // 1分間に10回まで
 Route::get('api/channels/{id}/timestamps/download', [ChannelController::class, 'downloadTimestamps'])
     ->name('channels.downloadTimestamps')
     ->middleware('throttle:10,1'); // 1分間に10回まで


### PR DESCRIPTION
## Summary
- 新規API: `/api/channels/{id}/timestamps/texts` でユニークなテキスト一覧を取得
- クライアント側でローカルフィルタリングしてサジェスト表示
- 2文字以上入力で候補表示（最大10件）
- サジェストクリックで検索実行
- Esc/Enterキーでサジェスト閉じる
- ダークモード対応

## Test plan
- [x] 検索ボックスでテキスト入力時にサジェストが表示されることを確認
- [x] サジェストをクリックすると検索が実行されることを確認
- [x] Escキーでサジェストが閉じることを確認
- [x] ダークモードでも適切に表示されることを確認

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)