### PR TITLE
refactor: YouTubeチャンネルリンクの改善

### DIFF
--- a/resources/views/channels/partials/header.blade.php
+++ b/resources/views/channels/partials/header.blade.php
@@ -3,10 +3,9 @@
     {{-- デスクトップ表示: 全体を中央寄せ --}}
     <div class="flex justify-center">
         <div class="text-gray-500 flex items-center gap-4 hidden sm:flex">
-            <img :src="escapeHTML(channel.thumbnail || '')" alt="アイコン" class="w-20 h-20 rounded-full">
-            <span class="text-lg font-bold" x-text="channel.title || '未設定'"></span>
-            <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')" target="_blank" rel="noopener noreferrer" class="hover:opacity-80">
-                Youtubeチャンネルはこちら
+            <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')" target="_blank" rel="noopener noreferrer" class="flex items-center gap-4 hover:opacity-80">
+                <img :src="escapeHTML(channel.thumbnail || '')" alt="アイコン" class="w-20 h-20 rounded-full">
+                <span class="text-lg font-bold" x-text="channel.title || '未設定'"></span>
             </a>
             {{-- 区切り線 --}}
             <div class="h-8 w-px bg-gray-300 dark:bg-gray-600 mx-2"></div>

--- a/resources/views/manage/show.blade.php
+++ b/resources/views/manage/show.blade.php
@@ -19,10 +19,9 @@
 
         <div class="p-2">
             <h2 class="text-gray-500 sm:flex items-center justify-center gap-4 hidden">
-                <img src="{{ $channel->thumbnail ?? '' }}" alt="アイコン" class="w-20 h-20 rounded-full">
-                <span class="text-lg font-bold text-black">{{ $channel->title ?? '' }}</span>
-                <a href="{{ url('https://youtube.com/@' . $channel->handle) }}" target="_blank" rel="noopener noreferrer">
-                    Youtubeチャンネルはこちら
+                <a href="{{ url('https://youtube.com/@' . $channel->handle) }}" target="_blank" rel="noopener noreferrer" class="flex items-center gap-4 hover:opacity-80">
+                    <img src="{{ $channel->thumbnail ?? '' }}" alt="アイコン" class="w-20 h-20 rounded-full">
+                    <span class="text-lg font-bold text-black dark:text-gray-200">{{ $channel->title ?? '' }}</span>
                 </a>
             </h2>
             <h2 class="text-gray-500 justify-self-center sm:hidden">


### PR DESCRIPTION
## Summary
- 「Youtubeチャンネルはこちら」テキストを削除
- アイコンとチャンネル名をクリック可能なリンクに変更

## Changes
- `channels/partials/header.blade.php`: デスクトップ表示でアイコン+名前をリンク化
- `manage/show.blade.php`: 管理画面も同様に改善

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)