### PR TITLE
feat: 楽曲ガチャボタンをタブ横に移動してスティッキー化

### DIFF
--- a/resources/views/channels/partials/header.blade.php
+++ b/resources/views/channels/partials/header.blade.php
@@ -1,40 +1,10 @@
 {{-- チャンネルヘッダー --}}
 <div class="p-2">
-    {{-- デスクトップ表示: 全体を中央寄せ --}}
+    {{-- チャンネル情報（デスクトップ・モバイル共通） --}}
     <div class="flex justify-center">
-        <div class="text-gray-500 flex items-center gap-4 hidden sm:flex">
-            <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')" target="_blank" rel="noopener noreferrer" class="flex items-center gap-4 hover:opacity-80">
-                <img :src="escapeHTML(channel.thumbnail || '')" alt="アイコン" class="w-20 h-20 rounded-full">
-                <span class="text-lg font-bold" x-text="channel.title || '未設定'"></span>
-            </a>
-            {{-- 区切り線 --}}
-            <div class="h-8 w-px bg-gray-300 dark:bg-gray-600 mx-2"></div>
-            {{-- デスクトップ用切り替えボタン --}}
-            <div class="flex gap-2">
-                <button @click="activeTab = 'timestamps'"
-                        :class="activeTab === 'timestamps' ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
-                        :aria-pressed="activeTab === 'timestamps'"
-                        role="tab"
-                        aria-label="タイムスタンプタブに切り替え"
-                        class="px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
-                    タイムスタンプ
-                </button>
-                <button @click="activeTab = 'archives'"
-                        :class="activeTab === 'archives' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
-                        :aria-pressed="activeTab === 'archives'"
-                        role="tab"
-                        aria-label="アーカイブタブに切り替え"
-                        class="px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
-                    アーカイブ
-                </button>
-            </div>
-        </div>
-    </div>
-    {{-- モバイル表示 --}}
-    <h2 class="text-gray-500 justify-self-center sm:hidden">
-        <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')" target="_blank" rel="noopener noreferrer" class="flex items-center gap-4 hover:opacity-80">
-            <img :src="escapeHTML(channel.thumbnail || '')" alt="アイコン" class="w-20 h-20 rounded-full">
+        <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')" target="_blank" rel="noopener noreferrer" class="flex items-center gap-4 hover:opacity-80 text-gray-500">
+            <img :src="escapeHTML(channel.thumbnail || '')" alt="アイコン" class="w-16 h-16 sm:w-20 sm:h-20 rounded-full">
             <span class="text-lg font-bold" x-text="channel.title || '未設定'"></span>
         </a>
-    </h2>
+    </div>
 </div>

--- a/resources/views/channels/partials/tabs.blade.php
+++ b/resources/views/channels/partials/tabs.blade.php
@@ -1,15 +1,54 @@
-{{-- タブUI（モバイル専用） --}}
-<div class="mb-4 sm:hidden">
-    <nav class="flex space-x-4 border-b border-gray-200 dark:border-gray-700">
-        <button @click="activeTab = 'timestamps'"
-                :class="activeTab === 'timestamps' ? 'border-green-500 text-green-600 dark:text-green-400' : 'border-transparent text-gray-500 dark:text-gray-400'"
-                class="px-3 py-2 text-sm font-medium border-b-2 -mb-px hover:text-gray-700 dark:hover:text-gray-300">
-            タイムスタンプ
+{{-- スティッキータブバー（タブ + ガチャボタン） --}}
+<div class="sticky top-0 z-30 bg-white dark:bg-gray-900 -mx-2 px-2 py-2 mb-2 border-b border-gray-200 dark:border-gray-700">
+    <div class="flex items-center justify-center gap-2 sm:gap-4">
+        {{-- タブ切り替えボタン --}}
+        <div class="flex gap-1 sm:gap-2">
+            <button @click="activeTab = 'timestamps'"
+                    :class="activeTab === 'timestamps' ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
+                    :aria-pressed="activeTab === 'timestamps'"
+                    role="tab"
+                    aria-label="タイムスタンプタブに切り替え"
+                    class="px-3 sm:px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
+                タイムスタンプ
+            </button>
+            <button @click="activeTab = 'archives'"
+                    :class="activeTab === 'archives' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300'"
+                    :aria-pressed="activeTab === 'archives'"
+                    role="tab"
+                    aria-label="アーカイブタブに切り替え"
+                    class="px-3 sm:px-4 py-2 rounded-lg font-medium text-sm transition-colors hover:opacity-80">
+                アーカイブ
+            </button>
+        </div>
+        {{-- 楽曲ガチャボタン（タイムスタンプタブのみ表示） --}}
+        <button x-show="activeTab === 'timestamps'"
+                x-transition:enter="transition ease-out duration-200"
+                x-transition:enter-start="opacity-0 scale-95"
+                x-transition:enter-end="opacity-100 scale-100"
+                x-transition:leave="transition ease-in duration-100"
+                x-transition:leave-start="opacity-100 scale-100"
+                x-transition:leave-end="opacity-0 scale-95"
+                @click="playRandomTimestamp()"
+                :disabled="isRandomPlaying"
+                class="inline-flex items-center gap-1 sm:gap-2 px-3 sm:px-4 py-2 bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white font-bold rounded-lg shadow transition-all duration-200 hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 text-sm">
+            <template x-if="!isRandomPlaying">
+                <span class="flex items-center gap-1 sm:gap-2">
+                    <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    <span class="hidden sm:inline">楽曲ガチャ</span>
+                    <span class="sm:hidden">ガチャ</span>
+                </span>
+            </template>
+            <template x-if="isRandomPlaying">
+                <span class="flex items-center gap-1 sm:gap-2">
+                    <svg class="animate-spin w-4 h-4 sm:w-5 sm:h-5" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    <span class="hidden sm:inline">抽選中...</span>
+                </span>
+            </template>
         </button>
-        <button @click="activeTab = 'archives'"
-                :class="activeTab === 'archives' ? 'border-blue-500 text-blue-600 dark:text-blue-400' : 'border-transparent text-gray-500 dark:text-gray-400'"
-                class="px-3 py-2 text-sm font-medium border-b-2 -mb-px hover:text-gray-700 dark:hover:text-gray-300">
-            アーカイブ
-        </button>
-    </nav>
+    </div>
 </div>

--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -1,30 +1,5 @@
 {{-- タイムスタンプタブ --}}
 <div x-show="activeTab === 'timestamps'">
-    {{-- ランダム再生ボタン --}}
-    <div class="flex justify-center mb-4">
-        <button @click="playRandomTimestamp()"
-                :disabled="isRandomPlaying"
-                class="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white font-bold rounded-full shadow-lg transition-all duration-200 transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none">
-            <template x-if="!isRandomPlaying">
-                <span class="flex items-center gap-2">
-                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                    </svg>
-                    楽曲ガチャ
-                </span>
-            </template>
-            <template x-if="isRandomPlaying">
-                <span class="flex items-center gap-2">
-                    <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    抽選中...
-                </span>
-            </template>
-        </button>
-    </div>
-
     {{-- ページネーション（上） --}}
     <div class="flex justify-center gap-2 mb-4">
         <button @click="fetchTimestamps(1, searchQuery, selectedIndex)"


### PR DESCRIPTION
## Summary
- 楽曲ガチャボタンをタブ切り替えボタンの右側に配置
- スクロールしても画面上部に固定表示されるスティッキーバーを実装

## Changes
- `header.blade.php`: チャンネル情報のみに簡素化
- `tabs.blade.php`: スティッキータブバーに変更、ガチャボタンを統合
- `timestamps-tab.blade.php`: 重複するガチャボタンを削除
- モバイル対応（レスポンシブデザイン）

## Before
- ガチャボタンがタイムスタンプタブ内の上部に配置
- スクロールすると画面外に消える

## After
- ガチャボタンがタブ切り替えボタンの横に配置
- sticky positioning で常に画面上部に表示

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)