### PR TITLE
fix: 楽曲クリック時に配信リンクパネルが更新されない問題を修正

### DIFF
--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -171,9 +171,8 @@
                 {{-- 上部: 楽曲情報 --}}
                 <div class="p-2 cursor-pointer transition-colors"
                      :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : 'hover:text-blue-600 dark:hover:text-blue-400'"
-                     @click="ts.mapping?.song ? selectSong(ts.mapping.song, ts) : (ts.text ? selectText(ts.text, ts) : null)">
-                    <div :class="expanded ? '' : 'line-clamp-2'"
-                         @click.stop="expanded = !expanded">
+                     @click="ts.mapping?.song ? selectSong(ts.mapping.song, ts) : (ts.text ? selectText(ts.text, ts) : null); expanded = !expanded">
+                    <div :class="expanded ? '' : 'line-clamp-2'">
                         <template x-if="ts.mapping?.song">
                             <span>
                                 <span class="font-bold text-sm sm:text-base" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : ''" x-text="ts.mapping.song.title"></span>


### PR DESCRIPTION
## Summary

- チャンネル画面のタイムスタンプ表示で、楽曲名をクリックしても下部の配信リンクパネルが更新されない問題を修正
- 内側の`div`の`@click.stop`がイベント伝播を止めていたため、親`div`の`selectSong`/`selectText`が呼ばれなかった
- `@click.stop`を削除し、expandトグルを親`div`のクリックハンドラに統合

## Test plan

- [x] 全テスト通過（233テスト）
- [ ] チャンネル画面で楽曲名クリック時に下部パネルが更新されることを確認
- [ ] テキストの展開/折りたたみが引き続き動作することを確認

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)