### PR TITLE
fix: 「-」を楽曲ではないとマーク後も一覧が未紐付のまま表示される問題を修正

### DIFF
--- a/app/Models/TsItem.php
+++ b/app/Models/TsItem.php
@@ -38,6 +38,12 @@ class TsItem extends Model
                 $rawText = $tsItem->attributes['text'] ?? null;
                 $normalized = TextNormalizer::normalize($rawText);
 
+                // 正規化結果が空の場合（例: "-"のみの場合）は元テキストを小文字化して使用
+                // これにより timestamp_song_mappings との JOIN が正しく動作する
+                if ($normalized === '' && $rawText !== null && trim($rawText) !== '') {
+                    $normalized = mb_strtolower(trim($rawText), 'UTF-8');
+                }
+
                 // 正規化結果が現在の値と異なる場合のみ更新（無限ループ回避）
                 if (($tsItem->attributes['normalized_text'] ?? null) !== $normalized) {
                     $tsItem->attributes['normalized_text'] = $normalized;
@@ -69,7 +75,19 @@ class TsItem extends Model
      */
     public function getNormalizedTextAttribute($value)
     {
-        // カラムに値があればそれを返す、なければ動的に計算（生の値を使用）
-        return $value ?? TextNormalizer::normalize($this->attributes['text'] ?? null);
+        if ($value !== null) {
+            return $value;
+        }
+
+        // カラムに値がなければ動的に計算（生の値を使用）
+        $rawText = $this->attributes['text'] ?? null;
+        $normalized = TextNormalizer::normalize($rawText);
+
+        // 正規化結果が空の場合は元テキストを小文字化して返す
+        if ($normalized === '' && $rawText !== null && trim($rawText) !== '') {
+            return mb_strtolower(trim($rawText), 'UTF-8');
+        }
+
+        return $normalized;
     }
 }

--- a/database/migrations/2025_12_07_143110_update_empty_normalized_text_in_ts_items.php
+++ b/database/migrations/2025_12_07_143110_update_empty_normalized_text_in_ts_items.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * normalized_text が空文字列の場合、元のtextを小文字化して設定
+     * これにより timestamp_song_mappings との JOIN が正しく動作する
+     */
+    public function up(): void
+    {
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'mysql') {
+            // MySQLの場合: LOWER(TRIM(text)) で更新
+            DB::statement("
+                UPDATE ts_items
+                SET normalized_text = LOWER(TRIM(text))
+                WHERE normalized_text = ''
+                  AND text IS NOT NULL
+                  AND TRIM(text) != ''
+            ");
+        } else {
+            // SQLiteの場合: 同様の更新
+            DB::statement("
+                UPDATE ts_items
+                SET normalized_text = LOWER(TRIM(text))
+                WHERE normalized_text = ''
+                  AND text IS NOT NULL
+                  AND TRIM(text) != ''
+            ");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * 元の空文字列に戻すことは難しいため、何もしない
+     */
+    public function down(): void
+    {
+        // 元に戻すことは困難なため、何もしない
+    }
+};

--- a/tests/Unit/Helpers/TextNormalizerTest.php
+++ b/tests/Unit/Helpers/TextNormalizerTest.php
@@ -131,5 +131,10 @@ class TextNormalizerTest extends TestCase
 
         // チルダのみ（チルダは区切り文字ではない）
         $this->assertEquals('artist~title~version', TextNormalizer::normalize('artist～title〜version'));
+
+        // ハイフンのみ（区切り文字として認識され、trimで除去されるため空文字になる）
+        $this->assertEquals('', TextNormalizer::normalize('-'));
+        $this->assertEquals('', TextNormalizer::normalize('ー'));
+        $this->assertEquals('', TextNormalizer::normalize('－'));
     }
 }


### PR DESCRIPTION
## Summary

「-」のみのタイムスタンプを「楽曲ではない」とマークしても、一覧の表示が「未紐付」のまま変化しない問題を修正

### 問題の原因
- `TextNormalizer::normalize("-")` は空文字を返す
- `ts_items.normalized_text` = `""` が保存される
- `markAsNotSong` では空の場合、元テキストを使用して `timestamp_song_mappings.normalized_text` = `"-"` を保存
- JOIN で `"" != "-"` となりマッチしない

### 修正内容
- TsItem モデルの `saving` イベントで、正規化結果が空の場合は元テキストを小文字化して使用
- `getNormalizedTextAttribute` アクセサも同様のロジックを追加
- 既存データを更新するマイグレーションを追加
- テストケースにハイフンのみのケースを追加

## Test plan

- [x] 全テスト通過（233テスト）
- [ ] 「-」タイムスタンプを「楽曲ではない」とマーク後、一覧が「非楽曲」に更新されることを確認
- [ ] マイグレーション実行で既存の空 normalized_text が更新されることを確認

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)