### PR TITLE
feat: ユーザー操作ログをサーバーサイドのファイル出力に変更

### DIFF
--- a/app/Http/Controllers/UserActionLogController.php
+++ b/app/Http/Controllers/UserActionLogController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class UserActionLogController extends Controller
+{
+    /**
+     * ユーザー操作ログを記録
+     */
+    public function log(Request $request)
+    {
+        $validated = $request->validate([
+            'action' => 'required|string|max:100',
+            'data' => 'nullable|array',
+        ]);
+
+        $logData = [
+            'action' => $validated['action'],
+            'data' => $validated['data'] ?? [],
+            'ip' => $request->ip(),
+            'user_agent' => $request->userAgent(),
+            'timestamp' => now()->toIso8601String(),
+        ];
+
+        Log::channel('user_actions')->info(json_encode($logData, JSON_UNESCAPED_UNICODE));
+
+        return response()->json(['status' => 'ok']);
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -134,6 +134,14 @@ return [
             'level' => env('LOG_SEARCH_LEVEL', 'info'),
             'replace_placeholders' => true,
         ],
+
+        'user_actions' => [
+            'driver' => 'daily',
+            'days' => 30,
+            'path' => storage_path('logs/user_actions.log'),
+            'level' => 'info',
+            'replace_placeholders' => true,
+        ],
     ],
 
 ];

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -13,12 +13,23 @@ import { ChannelApiService } from './services/ChannelApiService.js';
 import { ReportService } from './services/ReportService.js';
 
 /**
- * ユーザー操作ログを出力
+ * ユーザー操作ログをサーバーに送信
  * @param {string} action - 操作名
  * @param {Object} data - ログデータ
  */
-const logUserAction = (action, data) => {
-    console.log(`[UserAction] ${action}:`, data);
+const logUserAction = async (action, data) => {
+    try {
+        await fetch('/api/user-actions/log', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',
+            },
+            body: JSON.stringify({ action, data }),
+        });
+    } catch (error) {
+        // ログ送信失敗は無視（ユーザー体験に影響を与えない）
+    }
 };
 
 /**

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,4 +102,9 @@ Route::post('/contact', [ContactController::class, 'store'])
 // タイムスタンプ報告API（ゲスト可）
 Route::post('api/timestamp-reports', [TimestampReportController::class, 'store'])->name('timestamp-reports.store');
 
+// ユーザー操作ログAPI（ゲスト可、レートリミット適用）
+Route::post('api/user-actions/log', [\App\Http\Controllers\UserActionLogController::class, 'log'])
+    ->name('user-actions.log')
+    ->middleware('throttle:60,1'); // 1分間に60回まで
+
 require __DIR__.'/auth.php';

--- a/tests/Feature/UserActionLogControllerTest.php
+++ b/tests/Feature/UserActionLogControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class UserActionLogControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_log_user_action(): void
+    {
+        Log::shouldReceive('channel')
+            ->once()
+            ->with('user_actions')
+            ->andReturnSelf();
+
+        Log::shouldReceive('info')
+            ->once()
+            ->withArgs(function ($message) {
+                $data = json_decode($message, true);
+
+                return $data['action'] === 'testAction'
+                    && $data['data']['key'] === 'value';
+            });
+
+        $response = $this->postJson('/api/user-actions/log', [
+            'action' => 'testAction',
+            'data' => ['key' => 'value'],
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJson(['status' => 'ok']);
+    }
+
+    public function test_can_log_without_data(): void
+    {
+        Log::shouldReceive('channel')
+            ->once()
+            ->with('user_actions')
+            ->andReturnSelf();
+
+        Log::shouldReceive('info')
+            ->once();
+
+        $response = $this->postJson('/api/user-actions/log', [
+            'action' => 'simpleAction',
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_validation_fails_without_action(): void
+    {
+        $response = $this->postJson('/api/user-actions/log', [
+            'data' => ['key' => 'value'],
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['action']);
+    }
+
+    public function test_validation_fails_with_too_long_action(): void
+    {
+        $response = $this->postJson('/api/user-actions/log', [
+            'action' => str_repeat('a', 101),
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['action']);
+    }
+
+    public function test_rate_limiting_is_applied(): void
+    {
+        Log::shouldReceive('channel')->andReturnSelf();
+        Log::shouldReceive('info')->andReturn(null);
+
+        // 60回のリクエストは成功する
+        for ($i = 0; $i < 60; $i++) {
+            $response = $this->postJson('/api/user-actions/log', [
+                'action' => 'testAction',
+            ]);
+            $response->assertStatus(200);
+        }
+
+        // 61回目はレートリミットに引っかかる
+        $response = $this->postJson('/api/user-actions/log', [
+            'action' => 'testAction',
+        ]);
+        $response->assertStatus(429);
+    }
+}


### PR DESCRIPTION
## Summary

ユーザー操作ログをコンソール出力からサーバーサイドのファイル出力に変更

### 変更内容
- `UserActionLogController` を追加してログAPIエンドポイントを作成
- `config/logging.php` に `user_actions` チャンネルを追加（日次ローテーション、30日保持）
- `archive-list.js` の `logUserAction` 関数をAPIへのPOSTに変更
- レートリミット: 1分間に60回まで
- テスト5件追加

### ログファイル
```
storage/logs/user_actions-YYYY-MM-DD.log
```

### ログフォーマット
```json
{
  "action": "playVideo",
  "data": {"videoId": "xxx", "startTime": 123},
  "ip": "192.168.1.1",
  "user_agent": "Mozilla/5.0...",
  "timestamp": "2025-12-07T12:34:56+09:00"
}
```

## Test plan

- [x] 全テスト通過（238テスト）
- [ ] チャンネル画面でユーザー操作時にログファイルが出力されることを確認
- [ ] `storage/logs/user_actions-*.log` ファイルが作成されることを確認

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)