### PR TITLE
fix: カバー曲（歌ってみた）動画のアーカイブを表示対象にする

### DIFF
--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -20,14 +20,18 @@ class RefreshArchiveService
 
     protected ChannelQueryService $channelQueryService;
 
+    protected VideoAnalyzerService $videoAnalyzerService;
+
     public function __construct(
         YouTubeService $youtubeService,
         ChangeListService $changeListService,
-        ChannelQueryService $channelQueryService
+        ChannelQueryService $channelQueryService,
+        VideoAnalyzerService $videoAnalyzerService
     ) {
         $this->youtubeService = $youtubeService;
         $this->changeListService = $changeListService;
         $this->channelQueryService = $channelQueryService;
+        $this->videoAnalyzerService = $videoAnalyzerService;
     }
 
     public function cliLogin(string $userId): void
@@ -235,22 +239,11 @@ class RefreshArchiveService
     /**
      * カバー曲（歌ってみた）動画かどうかを判定
      *
-     * タイトルに「歌ってみた」「cover」「カバー」が含まれる場合はカバー曲と判定
+     * VideoAnalyzerService に委譲
      */
     public function isCoverSong(string $title): bool
     {
-        $lowerTitle = mb_strtolower($title);
-
-        // 検出キーワード
-        $keywords = ['歌ってみた', 'cover', 'カバー'];
-
-        foreach ($keywords as $keyword) {
-            if (mb_strpos($lowerTitle, mb_strtolower($keyword)) !== false) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->videoAnalyzerService->isCoverSong($title);
     }
 
     /**

--- a/app/Services/VideoAnalyzerService.php
+++ b/app/Services/VideoAnalyzerService.php
@@ -22,4 +22,27 @@ class VideoAnalyzerService
 
         return false;
     }
+
+    /**
+     * カバー曲（歌ってみた）動画かどうかを判定
+     *
+     * タイトルに「歌ってみた」「cover」「カバー」が含まれる場合はカバー曲と判定
+     *
+     * @param  string  $title  動画タイトル
+     * @return bool カバー曲の場合true
+     */
+    public function isCoverSong(string $title): bool
+    {
+        $lowerTitle = mb_strtolower($title);
+
+        $keywords = ['歌ってみた', 'cover', 'カバー'];
+
+        foreach ($keywords as $keyword) {
+            if (mb_strpos($lowerTitle, mb_strtolower($keyword)) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/app/Services/YouTubeService.php
+++ b/app/Services/YouTubeService.php
@@ -62,14 +62,16 @@ class YouTubeService
                 $archive['video_id'],
             );
 
-            // 歌枠の場合は一旦表示にする
-            $archive['is_display'] = $this->videoAnalyzerService->isSingingStream($archive['title']);
+            // 歌枠またはカバー曲の場合は一旦表示にする
+            $isSingingStream = $this->videoAnalyzerService->isSingingStream($archive['title']);
+            $isCoverSong = $this->videoAnalyzerService->isCoverSong($archive['title']);
+            $archive['is_display'] = $isSingingStream || $isCoverSong;
 
             // コメントを個別取得のみにする場合はここをコメントアウト
             // 以下の場合にコメントを検索する
             // 概要欄にタイムスタンプが1件以下（過去のコピペなどで0:00:00が残っている場合がある）
-            // かつ、歌枠の場合（タイトルに特定の文字列が含まれる場合）
-            if ((empty($archive['ts_items']) || count($archive['ts_items']) <= 1) && $archive['is_display']) {
+            // かつ、歌枠の場合（カバー曲は0:00タイムスタンプのみで十分なためコメント取得は不要）
+            if ((empty($archive['ts_items']) || count($archive['ts_items']) <= 1) && $isSingingStream) {
                 $commentTsItems = $this->getTimeStampsFromComments($archive['video_id']);
                 foreach ($commentTsItems as $tsItem) {
                     $archive['ts_items'][] = $tsItem;

--- a/tests/Unit/Services/RefreshArchiveServiceTest.php
+++ b/tests/Unit/Services/RefreshArchiveServiceTest.php
@@ -9,6 +9,7 @@ use App\Models\TsItem;
 use App\Services\ChangeListService;
 use App\Services\ChannelQueryService;
 use App\Services\RefreshArchiveService;
+use App\Services\VideoAnalyzerService;
 use App\Services\YouTubeService;
 use Exception;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -32,11 +33,13 @@ class RefreshArchiveServiceTest extends TestCase
         // 実際のサービスインスタンスを使用（DBテストのため）
         $changeListService = app(ChangeListService::class);
         $channelQueryService = app(ChannelQueryService::class);
+        $videoAnalyzerService = app(VideoAnalyzerService::class);
 
         $this->service = new RefreshArchiveService(
             $this->youtubeService,
             $changeListService,
-            $channelQueryService
+            $channelQueryService,
+            $videoAnalyzerService
         );
     }
 

--- a/tests/Unit/Services/VideoAnalyzerServiceTest.php
+++ b/tests/Unit/Services/VideoAnalyzerServiceTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\VideoAnalyzerService;
+use PHPUnit\Framework\TestCase;
+
+class VideoAnalyzerServiceTest extends TestCase
+{
+    protected VideoAnalyzerService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new VideoAnalyzerService;
+    }
+
+    public function test_is_singing_stream_detects_japanese(): void
+    {
+        $this->assertTrue($this->service->isSingingStream('【歌枠】夜の歌枠配信'));
+        $this->assertTrue($this->service->isSingingStream('カラオケ配信'));
+    }
+
+    public function test_is_singing_stream_detects_english(): void
+    {
+        $this->assertTrue($this->service->isSingingStream('Singing Stream'));
+        $this->assertTrue($this->service->isSingingStream('karaoke night'));
+    }
+
+    public function test_is_singing_stream_returns_false_for_normal(): void
+    {
+        $this->assertFalse($this->service->isSingingStream('普通の配信'));
+        $this->assertFalse($this->service->isSingingStream('ゲーム実況'));
+    }
+
+    public function test_is_cover_song_detects_utatte_mita(): void
+    {
+        $this->assertTrue($this->service->isCoverSong('夜に駆ける 歌ってみた'));
+        $this->assertTrue($this->service->isCoverSong('【歌ってみた】Lemon'));
+    }
+
+    public function test_is_cover_song_detects_cover(): void
+    {
+        $this->assertTrue($this->service->isCoverSong('Lemon - Cover'));
+        $this->assertTrue($this->service->isCoverSong('YOASOBI cover'));
+    }
+
+    public function test_is_cover_song_detects_katakana_cover(): void
+    {
+        $this->assertTrue($this->service->isCoverSong('夜に駆ける カバー'));
+    }
+
+    public function test_is_cover_song_returns_false_for_normal(): void
+    {
+        $this->assertFalse($this->service->isCoverSong('普通の配信'));
+        $this->assertFalse($this->service->isCoverSong('歌枠配信'));
+    }
+
+    public function test_singing_stream_and_cover_are_mutually_exclusive(): void
+    {
+        // 歌枠とカバー曲は別カテゴリ
+        $singingTitle = '【歌枠】歌ってみる配信';
+        $coverTitle = '夜に駆ける 歌ってみた';
+
+        // 歌枠タイトルは歌枠として検出されるが、カバー曲ではない
+        $this->assertTrue($this->service->isSingingStream($singingTitle));
+        $this->assertFalse($this->service->isCoverSong($singingTitle));
+
+        // カバー曲タイトルはカバー曲として検出されるが、歌枠ではない
+        $this->assertFalse($this->service->isSingingStream($coverTitle));
+        $this->assertTrue($this->service->isCoverSong($coverTitle));
+    }
+}


### PR DESCRIPTION
## Summary

カバー曲（歌ってみた）動画のアーカイブを表示対象にする

### 問題
- カバー曲動画は歌枠として検出されないため `is_display = false`
- カバー曲用の `ts_item` は作成されるが、アーカイブが非表示なので見えない

### 修正内容
- `VideoAnalyzerService` に `isCoverSong()` メソッドを追加
- `YouTubeService` で歌枠またはカバー曲の場合に `is_display = true` を設定
- ただし、コメントからのタイムスタンプ取得は歌枠のみに限定（カバー曲は0:00タイムスタンプのみで十分）
- `RefreshArchiveService::isCoverSong()` を `VideoAnalyzerService` に委譲
- `VideoAnalyzerService` のテストを追加（8件）

## Test plan

- [x] 全テスト通過（246テスト）
- [ ] アーカイブ更新後、カバー曲動画が表示されることを確認
- [ ] カバー曲動画のタイムスタンプ（0:00）が表示されることを確認
- [ ] カバー曲動画でコメントからのタイムスタンプ取得が行われないことを確認

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)