### PR TITLE
feat: タイムスタンプURLのTwitterシェア機能を追加

### DIFF
--- a/resources/views/channels/partials/tabs.blade.php
+++ b/resources/views/channels/partials/tabs.blade.php
@@ -1,6 +1,25 @@
 {{-- 統合スティッキーバー（チャンネル情報 + タブ + ガチャボタン） --}}
-<div class="sticky top-0 z-30 bg-white dark:bg-gray-900 -mx-2 px-2 py-2 mb-2 border-b border-gray-200 dark:border-gray-700">
-    <div class="flex items-center justify-center gap-2 sm:gap-4 flex-wrap">
+<div class="sticky top-0 z-30 bg-white dark:bg-gray-900 -mx-2 px-2 py-2 mb-2 border-b border-gray-200 dark:border-gray-700"
+     x-data="{ showChannelName: true, resizeTimeout: null }"
+     x-init="
+        const container = $refs.headerContainer;
+        const checkWrap = () => {
+            // 一時的にチャンネル名を表示して高さを測定
+            showChannelName = true;
+            $nextTick(() => {
+                const singleLineHeight = 48;
+                if (container.offsetHeight > singleLineHeight) {
+                    showChannelName = false;
+                }
+            });
+        };
+        checkWrap();
+        window.addEventListener('resize', () => {
+            clearTimeout(resizeTimeout);
+            resizeTimeout = setTimeout(checkWrap, 150);
+        });
+     ">
+    <div class="flex items-center justify-center gap-2 sm:gap-4 flex-wrap" x-ref="headerContainer">
         {{-- チャンネル情報 --}}
         <a :href="'https://youtube.com/@' + escapeHTML(channel.handle || '')"
            target="_blank"
@@ -9,7 +28,7 @@
             <img :src="escapeHTML(channel.thumbnail || '')"
                  alt="アイコン"
                  class="w-8 h-8 sm:w-10 sm:h-10 rounded-full">
-            <span class="font-bold text-sm sm:text-base hidden sm:inline" x-text="channel.title || '未設定'"></span>
+            <span x-show="showChannelName" class="font-bold text-sm sm:text-base" x-text="channel.title || '未設定'"></span>
         </a>
 
         {{-- 区切り線 --}}

--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -217,6 +217,51 @@
                                 <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
                             </svg>
                         </a>
+                        {{-- 共有メニュー --}}
+                        <div class="relative flex-shrink-0" x-data="{ shareOpen: false, menuPos: { top: 0, left: 0 } }" x-ref="shareContainer">
+                            <button @click="shareOpen = !shareOpen; if(shareOpen) { const rect = $refs.shareContainer.getBoundingClientRect(); menuPos = { top: rect.bottom + 4, left: rect.right - 144 }; }"
+                                    class="inline-flex items-center justify-center p-1.5 text-white rounded transition-colors"
+                                    :class="ts.has_pending_report ? 'bg-gray-500 hover:bg-gray-600' : 'bg-gray-600 hover:bg-gray-700'"
+                                    title="共有">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
+                                </svg>
+                            </button>
+                            {{-- ドロップダウンメニュー（bodyにテレポート） --}}
+                            <template x-teleport="body">
+                                <div x-show="shareOpen"
+                                     @click.away="shareOpen = false"
+                                     x-transition:enter="transition ease-out duration-100"
+                                     x-transition:enter-start="transform opacity-0 scale-95"
+                                     x-transition:enter-end="transform opacity-100 scale-100"
+                                     x-transition:leave="transition ease-in duration-75"
+                                     x-transition:leave-start="transform opacity-100 scale-100"
+                                     x-transition:leave-end="transform opacity-0 scale-95"
+                                     class="fixed w-36 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 z-[9999]"
+                                     :style="'top: ' + menuPos.top + 'px; left: ' + menuPos.left + 'px;'"
+                                     @click="shareOpen = false">
+                                    {{-- Twitter --}}
+                                    <a :href="getTwitterShareUrl(ts.ts_text || '', ts.mapping?.song ? ts.mapping.song.title + (ts.mapping.song.artist ? ' / ' + ts.mapping.song.artist : '') : (ts.text || ''), ts.archive?.title || '', ts.video_id, ts.ts_num || 0)"
+                                       target="_blank"
+                                       class="block w-full">
+                                        <span class="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-t-md">
+                                            <svg class="w-4 h-4 text-sky-500 flex-shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                                                <path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/>
+                                            </svg>
+                                            <span>Twitter</span>
+                                        </span>
+                                    </a>
+                                    {{-- URLコピー --}}
+                                    <button @click="copyToClipboard(getArchiveUrl(ts.video_id, ts.ts_num)); $dispatch('show-toast', { message: 'URLをコピーしました', type: 'success' })"
+                                            class="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-b-md w-full text-left">
+                                        <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/>
+                                        </svg>
+                                        URLをコピー
+                                    </button>
+                                </div>
+                            </template>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -61,6 +61,40 @@
             return 'https://youtu.be/' + encodeURIComponentLocal(videoId || '') + (tsNum !== 0 ? '?t=' + tsNum + 's' : '');
         }
 
+        function isCoverSong(title) {
+            if (!title) return false;
+            const lowerTitle = title.toLowerCase();
+            return lowerTitle.includes('歌ってみた') || lowerTitle.includes('cover') || lowerTitle.includes('カバー');
+        }
+
+        function getTwitterShareUrl(tsText, text, archiveTitle, videoId, tsNum = 0) {
+            const youtubeUrl = getArchiveUrl(videoId, tsNum);
+            let tweetText = '';
+            // カバー曲（0:00）の場合はアーカイブ名のみ
+            const isCover = tsNum === 0 && isCoverSong(archiveTitle);
+            if (isCover) {
+                tweetText += '📺 ' + archiveTitle + '\n';
+            } else {
+                if (tsText && text) {
+                    tweetText += tsText + ' ' + text + '\n';
+                } else if (text) {
+                    tweetText += text + '\n';
+                }
+                if (archiveTitle) {
+                    tweetText += '📺 ' + archiveTitle + '\n';
+                }
+            }
+            return 'https://twitter.com/intent/tweet?text=' + encodeURIComponentLocal(tweetText) + '&url=' + encodeURIComponentLocal(youtubeUrl);
+        }
+
+        function copyToClipboard(text) {
+            navigator.clipboard.writeText(text).then(function() {
+                // Success - will be handled by Alpine
+            }).catch(function(err) {
+                console.error('Failed to copy: ', err);
+            });
+        }
+
         function getCookie(name) {
             const value = `; ${document.cookie}`;
             const parts = value.split(`; ${name}=`);


### PR DESCRIPTION
## Summary
- タイムスタンプ一覧に共有メニュー（ドロップダウン）を追加
- ヘッダーが2行になる場合にチャンネル名を自動で非表示

## 変更内容

### 共有機能
- 共有ボタン → ドロップダウンメニュー（Twitter / URLをコピー）
- `x-teleport="body"` でoverflow問題を回避
- カバー曲（0:00）の場合はアーカイブ名のみ共有

### Twitter共有形式
**通常のタイムスタンプ:**
```
1:23:45 曲名 / アーティスト
📺 【歌枠】夜の歌枠配信
https://youtu.be/VIDEO_ID?t=5025s
```

**カバー曲（0:00）:**
```
📺 夜に駆ける 歌ってみた
https://youtu.be/VIDEO_ID
```

### レスポンシブ対応
- ヘッダーの高さが48pxを超えた場合（2行になった場合）にチャンネル名を非表示
- 150msのdebounceでちらつき防止

## 修正ファイル
- `resources/views/layouts/app.blade.php` - ヘルパー関数追加
- `resources/views/channels/partials/timestamps-tab.blade.php` - 共有メニュー追加
- `resources/views/channels/partials/tabs.blade.php` - レスポンシブ対応

🤖 Generated with [Claude Code](https://claude.ai/claude-code)