### PR TITLE
fix: Google OAuthから不要なyoutube.readonlyスコープを削除

### DIFF
--- a/app/Http/Controllers/Auth/GoogleAuthController.php
+++ b/app/Http/Controllers/Auth/GoogleAuthController.php
@@ -17,9 +17,6 @@ class GoogleAuthController extends Controller
     public function redirect()
     {
         return Socialite::driver('google')
-            ->scopes([
-                'https://www.googleapis.com/auth/youtube.readonly',
-            ])
             ->with([
                 'access_type' => 'offline',
                 'prompt' => 'select_account', // アカウント選択のみ（初回のみ同意画面）


### PR DESCRIPTION
## Summary
- Google OAuthログイン時に要求していた`youtube.readonly`スコープを削除
- ユーザープライバシーの向上

## 背景
- ログイン機能にYouTube読み取り権限は不要
- YouTube Data APIは別途ユーザー毎のAPIキーを使用
- 不要な権限要求を削除することでユーザー同意画面がシンプルに

## 変更内容
- `GoogleAuthController::redirect()` から `youtube.readonly` スコープを削除

## Test plan
- [x] GoogleAuthControllerTest が全てパス

🤖 Generated with [Claude Code](https://claude.ai/claude-code)