### PR TITLE
feat: 楽曲ガチャに自動再抽選機能を追加

### DIFF
--- a/app/Services/TimestampService.php
+++ b/app/Services/TimestampService.php
@@ -272,7 +272,8 @@ class TimestampService
                 'timestamp_song_mappings.is_not_song',
                 'songs.title as song_title',
                 'songs.artist as song_artist',
-                'songs.spotify_track_id'
+                'songs.spotify_track_id',
+                'songs.spotify_data'
             )
             ->whereHas('archive', function ($q) use ($channel) {
                 $q->where('channel_id', $channel->channel_id)
@@ -301,6 +302,18 @@ class TimestampService
         $position = $this->calculateItemPosition($channel, $sortKey, $item->id);
         $page = (int) ceil($position / $perPage);
 
+        // 同じ動画内の次のタイムスタンプを取得（自動再抽選用）
+        $nextTsNum = $this->getNextTimestampInVideo($item->video_id, $item->ts_num);
+
+        // spotify_dataから楽曲の長さを取得（ミリ秒）
+        $songDurationMs = null;
+        if ($item->spotify_data) {
+            $spotifyData = is_string($item->spotify_data)
+                ? json_decode($item->spotify_data, true)
+                : $item->spotify_data;
+            $songDurationMs = $spotifyData['duration_ms'] ?? null;
+        }
+
         return [
             'id' => $item->id,
             'ts_text' => $item->ts_text,
@@ -316,11 +329,33 @@ class TimestampService
                     'title' => $item->song_title,
                     'artist' => $item->song_artist,
                     'spotify_track_id' => ValidationHelper::validateSpotifyTrackId($item->spotify_track_id),
+                    'duration_ms' => $songDurationMs,
                 ] : null,
                 'is_not_song' => (bool) $item->is_not_song,
             ] : null,
             'page' => max(1, $page),
+            'next_ts_num' => $nextTsNum,
         ];
+    }
+
+    /**
+     * 同じ動画内の次のタイムスタンプ（秒数）を取得
+     */
+    private function getNextTimestampInVideo(string $videoId, ?int $currentTsNum): ?int
+    {
+        if ($currentTsNum === null) {
+            return null;
+        }
+
+        $nextItem = TsItem::where('video_id', $videoId)
+            ->where('ts_num', '>', $currentTsNum)
+            ->where('is_display', 1)
+            ->whereNotNull('text')
+            ->where('text', '!=', '')
+            ->orderBy('ts_num', 'asc')
+            ->first(['ts_num']);
+
+        return $nextItem?->ts_num;
     }
 
     /**

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -90,6 +90,13 @@ function registerArchiveListComponent() {
                 // ランダム再生機能
                 isRandomPlaying: false,
 
+                // 自動再抽選機能
+                autoReshuffle: false,
+                reshuffleMonitorId: null,
+                currentSongEndTime: null,
+                fadeOutIntervalId: null,
+                originalVolume: 100,
+
                 // ドラッグ機能用
                 isDragging: false,
                 playerPosition: { x: null, y: null },
@@ -405,6 +412,10 @@ function registerArchiveListComponent() {
                         this.autoPlay = autoPlaySaved === 'true';
                     }
 
+                    // 自動再抽選設定を読み込み（sessionStorageから、デフォルトOFF）
+                    const autoReshuffleSaved = sessionStorage.getItem('autoReshuffle');
+                    this.autoReshuffle = autoReshuffleSaved === 'true';
+
                     // YouTube IFrame APIの読み込み
                     this.loadYouTubeAPI();
 
@@ -413,6 +424,7 @@ function registerArchiveListComponent() {
 
                     // ページ離脱時のクリーンアップ
                     window.addEventListener('beforeunload', () => {
+                        this.stopReshuffleMonitor();
                         this.destroyPlayer();
                     });
                 },
@@ -479,6 +491,14 @@ function registerArchiveListComponent() {
                         tsNum: timestamp?.ts_num
                     });
 
+                    // 自動ガチャ中に手動で楽曲を選択した場合、自動再抽選をOFFにする
+                    if (this.autoReshuffle) {
+                        this.autoReshuffle = false;
+                        this.saveAutoReshuffle();
+                        this.stopReshuffleMonitor();
+                        toast.info('自動再抽選をOFFにしました');
+                    }
+
                     this.selectedSong = song;
                     this.selectedTimestamp = timestamp;
                     if (!this.panelDismissed) {
@@ -500,6 +520,14 @@ function registerArchiveListComponent() {
                         videoId: timestamp?.video_id,
                         tsNum: timestamp?.ts_num
                     });
+
+                    // 自動ガチャ中に手動で楽曲を選択した場合、自動再抽選をOFFにする
+                    if (this.autoReshuffle) {
+                        this.autoReshuffle = false;
+                        this.saveAutoReshuffle();
+                        this.stopReshuffleMonitor();
+                        toast.info('自動再抽選をOFFにしました');
+                    }
 
                     const pseudoSong = {
                         title: text.trim(),
@@ -620,6 +648,15 @@ function registerArchiveListComponent() {
                             },
                             'onStateChange': (event) => {
                                 this.isPlaying = event.data === YT.PlayerState.PLAYING;
+                                // 自動再抽選: 再生状態に応じて監視を開始/停止
+                                if (this.autoReshuffle && this.currentSongEndTime !== null) {
+                                    if (event.data === YT.PlayerState.PLAYING) {
+                                        this.startReshuffleMonitor();
+                                    } else if (event.data === YT.PlayerState.PAUSED ||
+                                               event.data === YT.PlayerState.ENDED) {
+                                        this.stopReshuffleMonitor();
+                                    }
+                                }
                             },
                             'onError': (event) => {
                                 console.error('YouTube Player Error:', event.data);
@@ -771,6 +808,9 @@ function registerArchiveListComponent() {
                             this.showDistributionPanel = true;
                         }
 
+                        // 自動再抽選用: 終了時刻を計算
+                        this.currentSongEndTime = this.calculateEndTime(timestamp);
+
                         // 動画を再生
                         if (timestamp.video_id) {
                             this.loadAndPlayVideo(timestamp.video_id, timestamp.ts_num || 0);
@@ -790,12 +830,164 @@ function registerArchiveListComponent() {
                         });
 
                         toast.success('ランダムで楽曲を選びました！');
+
+                        // 自動再抽選: 有効な場合は監視を開始
+                        if (this.autoReshuffle && this.currentSongEndTime !== null) {
+                            this.startReshuffleMonitor();
+                        }
                     } catch (error) {
                         console.error('ランダム再生に失敗しました:', error);
                         toast.error(error.message || 'ランダム再生に失敗しました');
                     } finally {
                         this.isRandomPlaying = false;
                     }
+                },
+
+                /**
+                 * 終了時刻を計算（自動再抽選用）
+                 *
+                 * 優先順位:
+                 * 1. 楽曲長さあり & 次のTSあり → min(開始 + 楽曲長さ + 10秒, 次のTS)
+                 * 2. 楽曲長さのみあり → 開始 + 楽曲長さ + 10秒
+                 * 3. 次のTSのみあり → 次のTS - 10秒
+                 * 4. どちらもなし → デフォルト5分
+                 */
+                calculateEndTime(timestamp) {
+                    const startTime = timestamp.ts_num || 0;
+                    const nextTsNum = timestamp.next_ts_num;
+                    const durationMs = timestamp.mapping?.song?.duration_ms;
+                    const durationSec = durationMs ? Math.ceil(durationMs / 1000) : null;
+                    const defaultDuration = 5 * 60; // 5分
+
+                    if (durationSec !== null && nextTsNum !== null) {
+                        // 楽曲長さあり & 次のTSあり
+                        return Math.min(startTime + durationSec + 10, nextTsNum);
+                    } else if (durationSec !== null) {
+                        // 楽曲長さのみあり
+                        return startTime + durationSec + 10;
+                    } else if (nextTsNum !== null) {
+                        // 次のTSのみあり
+                        return Math.max(startTime, nextTsNum - 10);
+                    } else {
+                        // どちらもなし（デフォルト5分）
+                        return startTime + defaultDuration;
+                    }
+                },
+
+                /**
+                 * 再生位置監視を開始（自動再抽選用）
+                 */
+                startReshuffleMonitor() {
+                    // 既存の監視を停止
+                    this.stopReshuffleMonitor();
+
+                    if (!this.youtubePlayer || this.currentSongEndTime === null) return;
+
+                    const FADE_OUT_DURATION = 3; // フェードアウト秒数
+                    const CHECK_INTERVAL = 500; // チェック間隔（ミリ秒）
+
+                    this.reshuffleMonitorId = setInterval(() => {
+                        if (!this.youtubePlayer || typeof this.youtubePlayer.getCurrentTime !== 'function') {
+                            this.stopReshuffleMonitor();
+                            return;
+                        }
+
+                        const currentTime = this.youtubePlayer.getCurrentTime();
+                        const fadeOutStartTime = this.currentSongEndTime - FADE_OUT_DURATION;
+
+                        // フェードアウト開始時刻に到達
+                        if (currentTime >= fadeOutStartTime && !this.fadeOutIntervalId) {
+                            this.startFadeOut();
+                        }
+
+                        // 終了時刻に到達
+                        if (currentTime >= this.currentSongEndTime) {
+                            this.stopReshuffleMonitor();
+                            // 次の曲を抽選
+                            this.playRandomTimestamp();
+                        }
+                    }, CHECK_INTERVAL);
+                },
+
+                /**
+                 * 再生位置監視を停止
+                 */
+                stopReshuffleMonitor() {
+                    if (this.reshuffleMonitorId) {
+                        clearInterval(this.reshuffleMonitorId);
+                        this.reshuffleMonitorId = null;
+                    }
+                    this.stopFadeOut();
+                },
+
+                /**
+                 * フェードアウトを開始
+                 */
+                startFadeOut() {
+                    if (this.fadeOutIntervalId || !this.youtubePlayer) return;
+
+                    // 現在の音量を保存
+                    if (typeof this.youtubePlayer.getVolume === 'function') {
+                        this.originalVolume = this.youtubePlayer.getVolume();
+                    }
+
+                    const FADE_STEPS = 10;
+                    const FADE_INTERVAL = 300; // 3秒 / 10ステップ = 300ms
+                    let step = 0;
+
+                    this.fadeOutIntervalId = setInterval(() => {
+                        step++;
+                        const newVolume = Math.max(0, this.originalVolume * (1 - step / FADE_STEPS));
+
+                        if (this.youtubePlayer && typeof this.youtubePlayer.setVolume === 'function') {
+                            this.youtubePlayer.setVolume(newVolume);
+                        }
+
+                        if (step >= FADE_STEPS) {
+                            this.stopFadeOut();
+                        }
+                    }, FADE_INTERVAL);
+                },
+
+                /**
+                 * フェードアウトを停止して音量を復元
+                 */
+                stopFadeOut() {
+                    if (this.fadeOutIntervalId) {
+                        clearInterval(this.fadeOutIntervalId);
+                        this.fadeOutIntervalId = null;
+                    }
+                    // 音量を復元
+                    if (this.youtubePlayer && typeof this.youtubePlayer.setVolume === 'function') {
+                        this.youtubePlayer.setVolume(this.originalVolume);
+                    }
+                },
+
+                /**
+                 * 自動再抽選のON/OFF切り替え
+                 */
+                toggleAutoReshuffle() {
+                    this.autoReshuffle = !this.autoReshuffle;
+                    this.saveAutoReshuffle();
+
+                    if (this.autoReshuffle) {
+                        // ONにした場合、現在再生中で終了時刻が設定されていれば監視開始
+                        if (this.isPlaying && this.currentSongEndTime !== null) {
+                            this.startReshuffleMonitor();
+                        }
+                        toast.success('自動再抽選をONにしました');
+                    } else {
+                        // OFFにした場合、監視を停止
+                        this.stopReshuffleMonitor();
+                        toast.info('自動再抽選をOFFにしました');
+                    }
+                },
+
+                /**
+                 * 自動再抽選設定を保存
+                 */
+                saveAutoReshuffle() {
+                    sessionStorage.setItem('autoReshuffle', this.autoReshuffle.toString());
                 },
 
                 // ドラッグ開始

--- a/resources/views/channels/partials/tabs.blade.php
+++ b/resources/views/channels/partials/tabs.blade.php
@@ -58,34 +58,49 @@
         <div x-show="activeTab === 'timestamps'" class="h-6 w-px bg-gray-300 dark:bg-gray-600 hidden sm:block"></div>
 
         {{-- 楽曲ガチャボタン（タイムスタンプタブのみ表示） --}}
-        <button x-show="activeTab === 'timestamps'"
-                x-transition:enter="transition ease-out duration-200"
-                x-transition:enter-start="opacity-0 scale-95"
-                x-transition:enter-end="opacity-100 scale-100"
-                x-transition:leave="transition ease-in duration-100"
-                x-transition:leave-start="opacity-100 scale-100"
-                x-transition:leave-end="opacity-0 scale-95"
-                @click="playRandomTimestamp()"
-                :disabled="isRandomPlaying"
-                class="inline-flex items-center gap-1 sm:gap-2 px-3 sm:px-4 py-1.5 sm:py-2 bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white font-bold rounded-lg shadow transition-all duration-200 hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 text-sm">
-            <template x-if="!isRandomPlaying">
-                <span class="flex items-center gap-1 sm:gap-2">
-                    <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                    </svg>
-                    <span class="hidden sm:inline">楽曲ガチャ</span>
-                    <span class="sm:hidden">ガチャ</span>
-                </span>
-            </template>
-            <template x-if="isRandomPlaying">
-                <span class="flex items-center gap-1 sm:gap-2">
-                    <svg class="animate-spin w-4 h-4 sm:w-5 sm:h-5" fill="none" viewBox="0 0 24 24">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                    </svg>
-                    <span class="hidden sm:inline">抽選中...</span>
-                </span>
-            </template>
-        </button>
+        <div x-show="activeTab === 'timestamps'"
+             x-transition:enter="transition ease-out duration-200"
+             x-transition:enter-start="opacity-0 scale-95"
+             x-transition:enter-end="opacity-100 scale-100"
+             x-transition:leave="transition ease-in duration-100"
+             x-transition:leave-start="opacity-100 scale-100"
+             x-transition:leave-end="opacity-0 scale-95"
+             class="flex items-center gap-1 sm:gap-2">
+            {{-- ガチャボタン --}}
+            <button @click="playRandomTimestamp()"
+                    :disabled="isRandomPlaying"
+                    class="inline-flex items-center gap-1 sm:gap-2 px-3 sm:px-4 py-1.5 sm:py-2 bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white font-bold rounded-lg shadow transition-all duration-200 hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 text-sm">
+                <template x-if="!isRandomPlaying">
+                    <span class="flex items-center gap-1 sm:gap-2">
+                        <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                        </svg>
+                        <span class="hidden sm:inline">楽曲ガチャ</span>
+                        <span class="sm:hidden">ガチャ</span>
+                    </span>
+                </template>
+                <template x-if="isRandomPlaying">
+                    <span class="flex items-center gap-1 sm:gap-2">
+                        <svg class="animate-spin w-4 h-4 sm:w-5 sm:h-5" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                        <span class="hidden sm:inline">抽選中...</span>
+                    </span>
+                </template>
+            </button>
+
+            {{-- 自動再抽選トグル --}}
+            <button @click="toggleAutoReshuffle()"
+                    :class="autoReshuffle ? 'bg-green-500 hover:bg-green-600 text-white' : 'bg-gray-200 hover:bg-gray-300 text-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-300'"
+                    :title="autoReshuffle ? '自動再抽選: ON' : '自動再抽選: OFF'"
+                    class="inline-flex items-center gap-1 px-2 sm:px-3 py-1.5 sm:py-2 rounded-lg font-medium text-sm transition-all duration-200 shadow">
+                {{-- リピートアイコン --}}
+                <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                <span class="hidden sm:inline" x-text="autoReshuffle ? '自動' : '手動'"></span>
+            </button>
+        </div>
     </div>
 </div>

--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -193,33 +193,36 @@
 
                 {{-- 下部: メタ情報グレー帯 --}}
                 <div class="px-2 py-1.5 bg-gray-100 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700">
-                    <div class="flex items-center justify-between gap-2">
+                    <div class="flex items-center gap-2">
                         {{-- タイムスタンプ --}}
-                        <span class="text-xs font-mono"
+                        <span class="text-xs font-mono w-20 flex-shrink-0"
                               :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : 'text-gray-600 dark:text-gray-400'"
                               x-text="ts.ts_text"></span>
                         {{-- 公開日 --}}
-                        <span class="text-xs hidden sm:inline"
+                        <span class="text-xs hidden sm:inline w-32 flex-shrink-0"
                               :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-500'"
                               x-text="ts.archive.published_at ? formatPublishedDate(ts.archive.published_at) : ''"></span>
                         {{-- 配信タイトル（デスクトップのみ） --}}
-                        <span class="hidden sm:inline text-xs truncate flex-1 max-w-[200px] text-right"
+                        <span class="hidden sm:inline text-xs truncate flex-1 min-w-0"
                               :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-500'"
                               :title="ts.archive.title"
                               x-text="ts.archive.title"></span>
-                        {{-- YouTubeボタン --}}
-                        <a :href="getYoutubeUrl(ts.video_id, ts.ts_num)"
-                           class="inline-flex items-center justify-center p-1.5 text-white rounded transition-colors flex-shrink-0"
-                           :class="ts.has_pending_report ? 'bg-red-800 hover:bg-red-900' : 'bg-red-600 hover:bg-red-700'"
-                           target="_blank"
-                           title="YouTubeで再生">
-                            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
-                            </svg>
-                        </a>
-                        {{-- 共有メニュー --}}
-                        <div class="relative flex-shrink-0" x-data="{ shareOpen: false, menuPos: { top: 0, left: 0 } }" x-ref="shareContainer">
-                            <button @click="shareOpen = !shareOpen; if(shareOpen) { const rect = $refs.shareContainer.getBoundingClientRect(); menuPos = { top: rect.bottom + 4, left: rect.right - 144 }; }"
+                        {{-- スペーサー（モバイル時に右寄せ用） --}}
+                        <span class="flex-1 sm:hidden"></span>
+                        {{-- YouTubeボタン & 共有メニュー --}}
+                        <div class="flex items-center gap-2 flex-shrink-0">
+                            <a :href="getYoutubeUrl(ts.video_id, ts.ts_num)"
+                               class="inline-flex items-center justify-center p-1.5 text-white rounded transition-colors"
+                               :class="ts.has_pending_report ? 'bg-red-800 hover:bg-red-900' : 'bg-red-600 hover:bg-red-700'"
+                               target="_blank"
+                               title="YouTubeで再生">
+                                <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/>
+                                </svg>
+                            </a>
+                            {{-- 共有メニュー --}}
+                            <div class="relative" x-data="{ shareOpen: false, menuPos: { top: 0, left: 0 } }" x-ref="shareContainer">
+                                <button @click="shareOpen = !shareOpen; if(shareOpen) { const rect = $refs.shareContainer.getBoundingClientRect(); menuPos = { top: rect.bottom + 4, left: rect.right - 144 }; }"
                                     class="inline-flex items-center justify-center p-1.5 text-white rounded transition-colors"
                                     :class="ts.has_pending_report ? 'bg-gray-500 hover:bg-gray-600' : 'bg-gray-600 hover:bg-gray-700'"
                                     title="共有">
@@ -261,6 +264,7 @@
                                     </button>
                                 </div>
                             </template>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- 楽曲ガチャボタンの横に自動/手動切り替えボタンを配置
- 自動再抽選ON時、曲の終了を検知して次の曲を自動抽選・再生
- 曲の終了前3秒間はフェードアウト効果
- 手動で別の曲をクリックすると自動再抽選は自動的にOFF

## 終了時刻の計算ロジック
1. 楽曲長さあり & 次のTSあり → min(開始 + 楽曲長さ + 10秒, 次のTS)
2. 楽曲長さのみあり → 開始 + 楽曲長さ + 10秒
3. 次のTSのみあり → 次のTS - 10秒
4. どちらもなし → デフォルト5分

## UI改善
- YouTubeと共有アイコンを近づけて配置
- タイムスタンプカードのメタ情報を固定幅で整列

## Test plan
- [ ] 楽曲ガチャで曲を抽選
- [ ] 自動/手動ボタンをクリックして切り替え
- [ ] 自動ON時、曲終了後に次の曲が自動抽選されることを確認
- [ ] 自動ON中に手動で別の曲をクリックし、自動がOFFになることを確認
- [ ] フェードアウト効果が曲終了前に適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)