### PR TITLE
feat: Spotify APIを使用した楽曲の自動紐付け機能を追加

### DIFF
--- a/app/Console/Commands/AutoLinkSongs.php
+++ b/app/Console/Commands/AutoLinkSongs.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\AutoLinkService;
+use Illuminate\Console\Command;
+
+class AutoLinkSongs extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'songs:auto-link
+                            {--limit=100 : 処理件数上限}
+                            {--dry-run : 実際の処理を行わず、対象件数のみ表示}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '未紐付けのタイムスタンプをSpotify APIで自動検索し、トップ結果を紐付けます。';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(AutoLinkService $autoLinkService): int
+    {
+        $limit = (int) $this->option('limit');
+        $dryRun = $this->option('dry-run');
+
+        $this->info('=== 楽曲自動紐付け処理 ===');
+        $this->info(sprintf('処理件数上限: %d件', $limit));
+
+        if ($dryRun) {
+            $this->warn('ドライランモード: 実際の処理は行いません');
+
+            return $this->runDryRun($limit);
+        }
+
+        return $this->runAutoLink($autoLinkService, $limit);
+    }
+
+    /**
+     * ドライラン実行
+     */
+    protected function runDryRun(int $limit): int
+    {
+        // 未紐付け件数を取得
+        $count = \App\Models\TsItem::select('ts_items.normalized_text')
+            ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
+            ->whereNotNull('ts_items.text')
+            ->where('ts_items.text', '!=', '')
+            ->whereNotNull('ts_items.normalized_text')
+            ->where('ts_items.is_display', 1)
+            ->whereHas('archive', function ($q) {
+                $q->where('is_display', 1);
+            })
+            ->whereNull('timestamp_song_mappings.id')
+            ->distinct()
+            ->count('ts_items.normalized_text');
+
+        $this->info(sprintf('未紐付けのユニークテキスト数: %d件', $count));
+        $this->info(sprintf('処理対象: %d件', min($count, $limit)));
+
+        return 0;
+    }
+
+    /**
+     * 自動紐付け実行
+     */
+    protected function runAutoLink(AutoLinkService $autoLinkService, int $limit): int
+    {
+        $startTime = microtime(true);
+
+        $result = $autoLinkService->autoLinkUnlinkedTimestamps($limit, function ($message) {
+            $this->line($message);
+        });
+
+        $duration = round(microtime(true) - $startTime, 2);
+
+        $this->newLine();
+        $this->info('=== 処理結果 ===');
+        $this->table(
+            ['項目', '件数'],
+            [
+                ['処理件数', $result['processed']],
+                ['紐付け成功', $result['linked']],
+                ['検索結果なし/エラー', $result['failed']],
+                ['スキップ（類似曲あり）', $result['skipped']],
+            ]
+        );
+        $this->info(sprintf('処理時間: %s秒', $duration));
+
+        return 0;
+    }
+}

--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -382,6 +382,22 @@ class SongController extends Controller
     }
 
     /**
+     * 自動紐付けを確定（手動紐付けに変更）
+     */
+    public function confirmAutoLink(NormalizedTextRequest $request)
+    {
+        $validated = $request->validated();
+
+        $confirmed = $this->songMappingService->confirmAutoLink($validated['normalized_text']);
+
+        if (! $confirmed) {
+            return response()->json(['message' => '確定対象のマッピングが見つかりません。'], 404);
+        }
+
+        return response()->json(['message' => '自動紐付けを確定しました。']);
+    }
+
+    /**
      * あいまい検索で類似するマッピングを検索
      */
     public function fuzzySearch(Request $request)

--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -60,7 +60,7 @@ class SongController extends Controller
         // ベースクエリ: ts_itemsとtimestamp_song_mappingsをLEFT JOIN
         $query = TsItem::with(['archive'])
             ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
-            ->select('ts_items.*', 'timestamp_song_mappings.id as mapping_id', 'timestamp_song_mappings.song_id', 'timestamp_song_mappings.is_not_song')
+            ->select('ts_items.*', 'timestamp_song_mappings.id as mapping_id', 'timestamp_song_mappings.song_id', 'timestamp_song_mappings.is_not_song', 'timestamp_song_mappings.is_manual')
             ->whereNotNull('ts_items.text')
             ->where('ts_items.text', '!=', '')
             ->whereNotNull('ts_items.normalized_text') // マイグレーション後の未更新レコードを除外
@@ -91,6 +91,12 @@ class SongController extends Controller
                 $query->whereNotNull('timestamp_song_mappings.id')
                     ->where('timestamp_song_mappings.is_not_song', true);
                 break;
+            case 'auto_linked':
+                // 自動紐付け: マッピングあり かつ is_manual=false かつ is_not_song=false
+                $query->whereNotNull('timestamp_song_mappings.id')
+                    ->where('timestamp_song_mappings.is_manual', false)
+                    ->where('timestamp_song_mappings.is_not_song', false);
+                break;
                 // 'all' は条件なし
         }
 
@@ -117,9 +123,14 @@ class SongController extends Controller
             $data['mapping'] = $mapping ? $mapping->toArray() : null;
             $data['song'] = $mapping && $mapping->song ? $mapping->song->toArray() : null;
             $data['is_not_song'] = $mapping ? $mapping->is_not_song : false;
+            // is_manual は mapping から取得（JOINのカラムは後で削除）
+            $isManual = $mapping ? $mapping->is_manual : null;
 
             // JOINで追加されたカラムを削除
-            unset($data['mapping_id'], $data['song_id']);
+            unset($data['mapping_id'], $data['song_id'], $data['is_manual']);
+
+            // mapping から取得した is_manual を設定
+            $data['is_manual'] = $isManual;
 
             return $data;
         });

--- a/app/Http/Requests/FetchTimestampsRequest.php
+++ b/app/Http/Requests/FetchTimestampsRequest.php
@@ -25,7 +25,7 @@ class FetchTimestampsRequest extends FormRequest
             'per_page' => 'integer|min:1|max:100',
             'page' => 'integer|min:1',
             'search' => 'nullable|string|max:255',
-            'filter' => 'nullable|in:all,unlinked,linked,not_song',
+            'filter' => 'nullable|in:all,unlinked,linked,not_song,auto_linked',
         ];
     }
 }

--- a/app/Services/AutoLinkService.php
+++ b/app/Services/AutoLinkService.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace App\Services;
+
+use App\Helpers\TextNormalizer;
+use App\Models\Song;
+use App\Models\TimestampSongMapping;
+use App\Models\TsItem;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class AutoLinkService
+{
+    protected SpotifyService $spotifyService;
+
+    protected SongSearchService $songSearchService;
+
+    /**
+     * 1リクエストあたりの遅延時間（ミリ秒）
+     */
+    protected int $delayMs;
+
+    /**
+     * レート制限エラー時の待機時間（秒）
+     */
+    protected int $rateLimitWaitSeconds;
+
+    public function __construct(SpotifyService $spotifyService, SongSearchService $songSearchService)
+    {
+        $this->spotifyService = $spotifyService;
+        $this->songSearchService = $songSearchService;
+        $this->delayMs = config('songs.auto_link.delay_ms', 500);
+        $this->rateLimitWaitSeconds = config('songs.auto_link.rate_limit_wait_seconds', 60);
+    }
+
+    /**
+     * 未紐付けのタイムスタンプを自動でSpotify検索し、トップ結果を紐付ける
+     *
+     * @param  int  $limit  処理件数上限
+     * @param  callable|null  $onProgress  進捗コールバック function(string $message): void
+     * @return array{processed: int, linked: int, failed: int, skipped: int}
+     */
+    public function autoLinkUnlinkedTimestamps(int $limit = 100, ?callable $onProgress = null): array
+    {
+        $result = [
+            'processed' => 0,
+            'linked' => 0,
+            'failed' => 0,
+            'skipped' => 0,
+        ];
+
+        // 未紐付けのタイムスタンプを取得（ユニークなnormalized_textのみ）
+        $unlinkedTexts = $this->getUnlinkedTexts($limit);
+
+        if (empty($unlinkedTexts)) {
+            $this->log('info', '未紐付けのタイムスタンプが見つかりませんでした。');
+            $onProgress && $onProgress('未紐付けのタイムスタンプが見つかりませんでした。');
+
+            return $result;
+        }
+
+        $this->log('info', sprintf('自動紐付け開始: %d件の未紐付けテキストを処理します。', count($unlinkedTexts)));
+        $onProgress && $onProgress(sprintf('%d件の未紐付けテキストを処理します。', count($unlinkedTexts)));
+
+        foreach ($unlinkedTexts as $index => $item) {
+            $result['processed']++;
+
+            try {
+                $linkResult = $this->processAutoLink($item['text'], $item['normalized_text']);
+
+                if ($linkResult === 'linked') {
+                    $result['linked']++;
+                    $onProgress && $onProgress(sprintf('[%d/%d] 紐付け成功: %s', $index + 1, count($unlinkedTexts), $item['text']));
+                } elseif ($linkResult === 'skipped') {
+                    $result['skipped']++;
+                    $onProgress && $onProgress(sprintf('[%d/%d] スキップ: %s', $index + 1, count($unlinkedTexts), $item['text']));
+                } else {
+                    $result['failed']++;
+                    $onProgress && $onProgress(sprintf('[%d/%d] 検索結果なし: %s', $index + 1, count($unlinkedTexts), $item['text']));
+                }
+
+                // レート制限対策: 適切な遅延を入れる
+                if ($index < count($unlinkedTexts) - 1) {
+                    usleep($this->delayMs * 1000);
+                }
+            } catch (\Exception $e) {
+                $result['failed']++;
+
+                // レート制限エラーの場合は待機して続行
+                if (strpos($e->getMessage(), 'レート制限') !== false) {
+                    $this->log('warning', sprintf('レート制限に達しました。%d秒待機します。', $this->rateLimitWaitSeconds));
+                    $onProgress && $onProgress(sprintf('レート制限に達しました。%d秒待機します...', $this->rateLimitWaitSeconds));
+                    sleep($this->rateLimitWaitSeconds);
+
+                    continue;
+                }
+
+                $this->log('error', sprintf('自動紐付けエラー: %s - %s', $item['text'], $e->getMessage()));
+                $onProgress && $onProgress(sprintf('[%d/%d] エラー: %s - %s', $index + 1, count($unlinkedTexts), $item['text'], $e->getMessage()));
+            }
+        }
+
+        $this->log('info', sprintf(
+            '自動紐付け完了: 処理=%d, 成功=%d, 失敗=%d, スキップ=%d',
+            $result['processed'],
+            $result['linked'],
+            $result['failed'],
+            $result['skipped']
+        ));
+
+        return $result;
+    }
+
+    /**
+     * 未紐付けのテキスト一覧を取得
+     *
+     * @param  int  $limit  取得件数上限
+     * @return array<array{text: string, normalized_text: string}>
+     */
+    protected function getUnlinkedTexts(int $limit): array
+    {
+        return TsItem::select('ts_items.text', 'ts_items.normalized_text')
+            ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
+            ->whereNotNull('ts_items.text')
+            ->where('ts_items.text', '!=', '')
+            ->whereNotNull('ts_items.normalized_text')
+            ->where('ts_items.is_display', 1)
+            ->whereHas('archive', function ($q) {
+                $q->where('is_display', 1);
+            })
+            ->whereNull('timestamp_song_mappings.id')
+            ->groupBy('ts_items.normalized_text', 'ts_items.text')
+            ->orderBy('ts_items.text', 'asc')
+            ->limit($limit)
+            ->get()
+            ->map(fn ($item) => [
+                'text' => $item->text,
+                'normalized_text' => $item->normalized_text,
+            ])
+            ->toArray();
+    }
+
+    /**
+     * 単一テキストの自動紐付け処理
+     *
+     * @return string 'linked'|'skipped'|'not_found'
+     */
+    protected function processAutoLink(string $text, string $normalizedText): string
+    {
+        // Spotify検索実行
+        $tracks = $this->spotifyService->searchWithAuth($text, 1);
+
+        if (empty($tracks)) {
+            return 'not_found';
+        }
+
+        $track = $tracks[0];
+        $title = $track['name'];
+        $artist = collect($track['artists'])->pluck('name')->join(', ');
+        $spotifyTrackId = $track['id'];
+
+        // 既存の楽曲マスタを検索（Spotify Track IDで）
+        $existingSong = Song::where('spotify_track_id', $spotifyTrackId)->first();
+
+        if ($existingSong) {
+            // 既存の楽曲マスタを使用
+            $this->createAutoLinkMapping($normalizedText, $existingSong->id);
+
+            return 'linked';
+        }
+
+        // 正規化後のTitle + Artistで完全一致チェック
+        $normalizedTitle = TextNormalizer::normalize($title);
+        $normalizedArtist = TextNormalizer::normalize($artist);
+        $exactMatch = $this->songSearchService->findExactMatch($normalizedTitle, $normalizedArtist);
+
+        if ($exactMatch) {
+            // 既存の楽曲マスタを使用
+            $this->createAutoLinkMapping($normalizedText, $exactMatch->id);
+
+            return 'linked';
+        }
+
+        // 類似度チェック（閾値0.9で厳しめ）
+        $threshold = config('songs.auto_link.similarity_threshold', 0.9);
+        $similarSongs = $this->songSearchService->findSimilarSongs($normalizedTitle, $normalizedArtist, $threshold);
+
+        if (count($similarSongs) > 0) {
+            // 類似曲が見つかった場合はスキップ（手動確認が必要）
+            return 'skipped';
+        }
+
+        // 新規楽曲マスタを作成
+        $song = $this->createSongFromSpotify($track);
+        $this->createAutoLinkMapping($normalizedText, $song->id);
+
+        return 'linked';
+    }
+
+    /**
+     * Spotifyトラックデータから楽曲マスタを作成
+     */
+    protected function createSongFromSpotify(array $track): Song
+    {
+        return Song::create([
+            'id' => Str::ulid(),
+            'title' => $track['name'],
+            'artist' => collect($track['artists'])->pluck('name')->join(', '),
+            'spotify_track_id' => $track['id'],
+            'spotify_data' => $track,
+        ]);
+    }
+
+    /**
+     * 自動紐付けマッピングを作成
+     */
+    protected function createAutoLinkMapping(string $normalizedText, string $songId): void
+    {
+        DB::transaction(function () use ($normalizedText, $songId) {
+            $mapping = TimestampSongMapping::where('normalized_text', $normalizedText)->first();
+
+            if ($mapping) {
+                $mapping->update([
+                    'song_id' => $songId,
+                    'is_not_song' => false,
+                    'is_manual' => false,
+                    'confidence' => 0.8, // 自動紐付けは0.8
+                ]);
+            } else {
+                TimestampSongMapping::create([
+                    'id' => Str::ulid(),
+                    'normalized_text' => $normalizedText,
+                    'song_id' => $songId,
+                    'is_not_song' => false,
+                    'is_manual' => false,
+                    'confidence' => 0.8,
+                ]);
+            }
+        });
+    }
+
+    /**
+     * ログ出力
+     */
+    protected function log(string $level, string $message): void
+    {
+        Log::$level('[AutoLinkService] '.$message);
+    }
+}

--- a/app/Services/SongMappingService.php
+++ b/app/Services/SongMappingService.php
@@ -109,4 +109,29 @@ class SongMappingService
     {
         TimestampSongMapping::where('song_id', $songId)->delete();
     }
+
+    /**
+     * 自動紐付けを確定（手動紐付けに変更）
+     *
+     * @param  string  $normalizedText  正規化済みテキスト
+     * @return bool 確定成功した場合true
+     */
+    public function confirmAutoLink(string $normalizedText): bool
+    {
+        $mapping = TimestampSongMapping::where('normalized_text', $normalizedText)
+            ->where('is_manual', false)
+            ->whereNotNull('song_id')
+            ->first();
+
+        if (! $mapping) {
+            return false;
+        }
+
+        $mapping->update([
+            'is_manual' => true,
+            'confidence' => 1.0,
+        ]);
+
+        return true;
+    }
 }

--- a/app/Services/TimestampService.php
+++ b/app/Services/TimestampService.php
@@ -44,6 +44,7 @@ class TimestampService
                 'timestamp_song_mappings.id as mapping_id',
                 'timestamp_song_mappings.song_id',
                 'timestamp_song_mappings.is_not_song',
+                'timestamp_song_mappings.is_manual',
                 'songs.title as song_title',
                 'songs.artist as song_artist',
                 'songs.spotify_track_id'
@@ -109,6 +110,7 @@ class TimestampService
                         'spotify_track_id' => ValidationHelper::validateSpotifyTrackId($item->spotify_track_id),
                     ] : null,
                     'is_not_song' => (bool) $item->is_not_song,
+                    'is_manual' => (bool) $item->is_manual,
                 ] : null,
                 'has_pending_report' => in_array($item->id, $reportedTsItemIds),
             ];
@@ -270,6 +272,7 @@ class TimestampService
                 'timestamp_song_mappings.id as mapping_id',
                 'timestamp_song_mappings.song_id',
                 'timestamp_song_mappings.is_not_song',
+                'timestamp_song_mappings.is_manual',
                 'songs.title as song_title',
                 'songs.artist as song_artist',
                 'songs.spotify_track_id',
@@ -332,6 +335,7 @@ class TimestampService
                     'duration_ms' => $songDurationMs,
                 ] : null,
                 'is_not_song' => (bool) $item->is_not_song,
+                'is_manual' => (bool) $item->is_manual,
             ] : null,
             'page' => max(1, $page),
             'next_ts_num' => $nextTsNum,

--- a/config/songs.php
+++ b/config/songs.php
@@ -22,4 +22,23 @@ return [
     |
     */
     'fuzzy_search_threshold' => env('SONG_FUZZY_SEARCH_THRESHOLD', 0.7),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto Link Settings
+    |--------------------------------------------------------------------------
+    |
+    | 自動紐付け機能の設定です。
+    |
+    */
+    'auto_link' => [
+        // 1リクエストあたりの遅延時間（ミリ秒）
+        'delay_ms' => env('AUTO_LINK_DELAY_MS', 500),
+
+        // レート制限エラー時の待機時間（秒）
+        'rate_limit_wait_seconds' => env('AUTO_LINK_RATE_LIMIT_WAIT_SECONDS', 60),
+
+        // 自動紐付け時の類似度チェックしきい値（高めに設定）
+        'similarity_threshold' => env('AUTO_LINK_SIMILARITY_THRESHOLD', 0.9),
+    ],
 ];

--- a/database/factories/TimestampSongMappingFactory.php
+++ b/database/factories/TimestampSongMappingFactory.php
@@ -81,6 +81,14 @@ class TimestampSongMappingFactory extends Factory
     }
 
     /**
+     * Alias for automatic() - Indicate that the mapping was auto-linked.
+     */
+    public function autoLinked(): static
+    {
+        return $this->automatic();
+    }
+
+    /**
      * Set a specific normalized text.
      */
     public function withText(string $text): static

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -224,12 +224,19 @@ class TimestampNormalization {
             statusDiv.className += ' text-red-600 dark:text-red-400';
             statusDiv.textContent = '楽曲ではない';
         } else if (ts.song) {
-            statusDiv.className += ' text-green-600 dark:text-green-400';
-            const statusText = `${ts.song.title} / ${ts.song.artist}`;
+            // 自動紐付けの場合は黄色、手動紐付けの場合は緑
+            const isAutoLinked = ts.is_manual === false;
+            if (isAutoLinked) {
+                statusDiv.className += ' text-yellow-600 dark:text-yellow-400';
+            } else {
+                statusDiv.className += ' text-green-600 dark:text-green-400';
+            }
+            const prefix = isAutoLinked ? '[自動] ' : '';
+            const statusText = `${prefix}${ts.song.title} / ${ts.song.artist}`;
             statusDiv.textContent = statusText.length > CONSTANTS.MAX_STATUS_LENGTH
                 ? statusText.substring(0, CONSTANTS.MAX_STATUS_LENGTH) + '...'
                 : statusText;
-            statusDiv.title = `${ts.song.title} / ${ts.song.artist}`;
+            statusDiv.title = `${prefix}${ts.song.title} / ${ts.song.artist}`;
         } else {
             statusDiv.className += ' text-gray-400';
             statusDiv.textContent = '未紐づけ';

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -209,9 +209,20 @@ class TimestampNormalization {
         // コピーボタン
         const copyBtn = this.createCopyButton(ts.text);
 
+        // ボタンコンテナ
+        const buttonContainer = document.createElement('div');
+        buttonContainer.className = 'flex items-center gap-1 flex-shrink-0';
+        buttonContainer.appendChild(copyBtn);
+
+        // 自動紐付け確定ボタン（自動紐付けの場合のみ表示）
+        if (ts.is_manual === false && ts.song) {
+            const confirmBtn = this.createConfirmButton(ts.normalized_text);
+            buttonContainer.appendChild(confirmBtn);
+        }
+
         div.appendChild(checkbox);
         div.appendChild(contentDiv);
-        div.appendChild(copyBtn);
+        div.appendChild(buttonContainer);
 
         return div;
     }
@@ -274,6 +285,35 @@ class TimestampNormalization {
         });
 
         return copyBtn;
+    }
+
+    createConfirmButton(normalizedText) {
+        const confirmBtn = document.createElement('button');
+        confirmBtn.className = 'px-2 py-1 text-xs bg-yellow-500 hover:bg-yellow-600 text-white rounded transition-colors';
+        confirmBtn.textContent = '確定';
+        confirmBtn.title = '自動紐付けを確定';
+
+        confirmBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.confirmAutoLink(normalizedText);
+        });
+
+        return confirmBtn;
+    }
+
+    async confirmAutoLink(normalizedText) {
+        try {
+            await axios.post('/api/songs/confirm-auto-link', { normalized_text: normalizedText });
+            toast.success('自動紐付けを確定しました');
+            this.loadTimestamps(this.currentPage, this.currentSearchQuery);
+        } catch (error) {
+            console.error('確定エラー:', error);
+            if (error.response?.status === 404) {
+                toast.error('確定対象のマッピングが見つかりません');
+            } else {
+                toast.error('確定に失敗しました');
+            }
+        }
     }
 
     displayPagination(data) {

--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -174,11 +174,19 @@
                      @click="ts.mapping?.song ? selectSong(ts.mapping.song, ts) : (ts.text ? selectText(ts.text, ts) : null); expanded = !expanded">
                     <div :class="expanded ? '' : 'line-clamp-2'">
                         <template x-if="ts.mapping?.song">
-                            <span>
-                                <span class="font-bold text-sm sm:text-base" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : ''" x-text="ts.mapping.song.title"></span>
-                                <span class="text-xs sm:text-sm" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'"> / </span>
-                                <span class="text-xs sm:text-sm" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'" x-text="ts.mapping.song.artist"></span>
-                            </span>
+                            <div>
+                                <div>
+                                    <span class="font-bold text-sm sm:text-base" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : ''" x-text="ts.mapping.song.title"></span>
+                                    <span class="text-xs sm:text-sm" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'"> / </span>
+                                    <span class="text-xs sm:text-sm" :class="ts.has_pending_report ? 'text-gray-400 dark:text-gray-500' : 'text-gray-500 dark:text-gray-400'" x-text="ts.mapping.song.artist"></span>
+                                </div>
+                                {{-- 自動紐付けの場合、元のタイムスタンプテキストを表示 --}}
+                                <template x-if="ts.mapping.is_manual === false && ts.text && ts.text !== ts.mapping.song.title">
+                                    <div class="text-xs text-yellow-600 dark:text-yellow-400 mt-0.5">
+                                        <span class="opacity-75">[自動]</span> <span x-text="ts.text"></span>
+                                    </div>
+                                </template>
+                            </div>
                         </template>
                         <template x-if="!ts.mapping?.song && ts.text">
                             <span class="font-bold text-sm sm:text-base"

--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -38,6 +38,9 @@
                                     <button data-filter="linked" class="filter-btn px-3 py-1 text-sm rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600">
                                         紐付済
                                     </button>
+                                    <button data-filter="auto_linked" class="filter-btn px-3 py-1 text-sm rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600">
+                                        自動
+                                    </button>
                                     <button data-filter="not_song" class="filter-btn px-3 py-1 text-sm rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600">
                                         非楽曲
                                     </button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,6 +55,7 @@ Route::middleware(['auth'])->group(function () {
     Route::post('api/songs/link', [SongController::class, 'linkTimestamp'])->name('songs.linkTimestamp');
     Route::post('api/songs/mark-not-song', [SongController::class, 'markAsNotSong'])->name('songs.markAsNotSong');
     Route::post('api/songs/unmark-not-song', [SongController::class, 'unmarkAsNotSong'])->name('songs.unmarkAsNotSong');
+    Route::post('api/songs/confirm-auto-link', [SongController::class, 'confirmAutoLink'])->name('songs.confirmAutoLink');
     // Specific routes must come before parameterized routes to avoid parameter capture
     Route::delete('api/songs/unlink', [SongController::class, 'unlinkTimestamp'])->name('songs.unlinkTimestamp');
     Route::get('api/songs/fuzzy-search', [SongController::class, 'fuzzySearch'])->name('songs.fuzzySearch');

--- a/tests/Feature/SongControllerTest.php
+++ b/tests/Feature/SongControllerTest.php
@@ -217,6 +217,85 @@ class SongControllerTest extends TestCase
     }
 
     /**
+     * タイムスタンプ一覧取得のテスト（フィルター: auto_linked）
+     */
+    public function test_fetch_timestamps_with_auto_linked_filter(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 自動紐付けタイムスタンプ
+        $autoLinked = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Auto Linked Song',
+            'is_display' => 1,
+        ]);
+
+        $song1 = Song::factory()->create();
+        TimestampSongMapping::factory()
+            ->withSong($song1)
+            ->withText($autoLinked->text)
+            ->autoLinked()
+            ->create();
+
+        // 手動紐付けタイムスタンプ
+        $manualLinked = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Manual Linked Song',
+            'is_display' => 1,
+        ]);
+
+        $song2 = Song::factory()->create();
+        TimestampSongMapping::factory()
+            ->withSong($song2)
+            ->withText($manualLinked->text)
+            ->create();
+
+        // 未紐付けタイムスタンプ
+        TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Unlinked Song',
+            'is_display' => 1,
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson(route('songs.fetchTimestamps', [
+            'filter' => 'auto_linked',
+        ]));
+
+        $response->assertStatus(200);
+        $this->assertEquals(1, $response->json('total'));
+        $this->assertEquals('Auto Linked Song', $response->json('data.0.text'));
+    }
+
+    /**
+     * タイムスタンプ一覧取得のテスト（is_manual情報が含まれる）
+     */
+    public function test_fetch_timestamps_includes_is_manual_info(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 自動紐付けタイムスタンプ
+        $autoLinked = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Auto Linked Song',
+            'is_display' => 1,
+        ]);
+
+        $song = Song::factory()->create();
+        TimestampSongMapping::factory()
+            ->withSong($song)
+            ->withText($autoLinked->text)
+            ->autoLinked()
+            ->create();
+
+        $response = $this->actingAs($this->user)->getJson(route('songs.fetchTimestamps'));
+
+        $response->assertStatus(200);
+        $this->assertFalse($response->json('data.0.is_manual'));
+    }
+
+    /**
      * タイムスタンプ一覧取得のテスト（マッピング情報付き）
      */
     public function test_fetch_timestamps_with_mapping_info(): void

--- a/tests/Feature/SongControllerTest.php
+++ b/tests/Feature/SongControllerTest.php
@@ -249,6 +249,7 @@ class SongControllerTest extends TestCase
         TimestampSongMapping::factory()
             ->withSong($song2)
             ->withText($manualLinked->text)
+            ->manual()
             ->create();
 
         // 未紐付けタイムスタンプ
@@ -1053,5 +1054,74 @@ class SongControllerTest extends TestCase
         ])->assertStatus(401);
 
         $this->deleteJson(route('songs.deleteSong', 'test-id'))->assertStatus(401);
+    }
+
+    /**
+     * 自動紐付け確定のテスト（成功）
+     */
+    public function test_confirm_auto_link_success(): void
+    {
+        $song = Song::factory()->create();
+        $mapping = TimestampSongMapping::factory()
+            ->withSong($song)
+            ->withText('Auto Linked Song')
+            ->autoLinked()
+            ->create();
+
+        $this->assertFalse($mapping->is_manual);
+
+        $response = $this->actingAs($this->user)->postJson(route('songs.confirmAutoLink'), [
+            'normalized_text' => $mapping->normalized_text,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'message' => '自動紐付けを確定しました。',
+        ]);
+
+        $mapping->refresh();
+        $this->assertTrue($mapping->is_manual);
+        $this->assertEquals(1.0, $mapping->confidence);
+    }
+
+    /**
+     * 自動紐付け確定のテスト（手動紐付けは確定不可）
+     */
+    public function test_confirm_auto_link_manual_mapping_not_found(): void
+    {
+        $song = Song::factory()->create();
+        $mapping = TimestampSongMapping::factory()
+            ->withSong($song)
+            ->withText('Manual Linked Song')
+            ->manual()
+            ->create();
+
+        $response = $this->actingAs($this->user)->postJson(route('songs.confirmAutoLink'), [
+            'normalized_text' => $mapping->normalized_text,
+        ]);
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * 自動紐付け確定のテスト（未紐付けは確定不可）
+     */
+    public function test_confirm_auto_link_unlinked_not_found(): void
+    {
+        $response = $this->actingAs($this->user)->postJson(route('songs.confirmAutoLink'), [
+            'normalized_text' => 'nonexistent text',
+        ]);
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * 自動紐付け確定のテスト（未認証アクセス）
+     */
+    public function test_confirm_auto_link_unauthenticated(): void
+    {
+        $this->postJson(route('songs.confirmAutoLink'), [
+            'normalized_text' => 'test',
+        ])->assertStatus(401);
     }
 }

--- a/tests/Unit/Services/AutoLinkServiceTest.php
+++ b/tests/Unit/Services/AutoLinkServiceTest.php
@@ -8,8 +8,6 @@ use App\Models\Song;
 use App\Models\TimestampSongMapping;
 use App\Models\TsItem;
 use App\Services\AutoLinkService;
-use App\Services\SongSearchService;
-use App\Services\SpotifyService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
@@ -273,7 +271,7 @@ class AutoLinkServiceTest extends TestCase
                 'tracks' => [
                     'items' => [
                         [
-                            'id' => 'spotify_track_' . uniqid(),
+                            'id' => 'spotify_track_'.uniqid(),
                             'name' => 'Song',
                             'artists' => [['name' => 'Artist']],
                         ],

--- a/tests/Unit/Services/AutoLinkServiceTest.php
+++ b/tests/Unit/Services/AutoLinkServiceTest.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Archive;
+use App\Models\Channel;
+use App\Models\Song;
+use App\Models\TimestampSongMapping;
+use App\Models\TsItem;
+use App\Services\AutoLinkService;
+use App\Services\SongSearchService;
+use App\Services\SpotifyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class AutoLinkServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected AutoLinkService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(AutoLinkService::class);
+    }
+
+    /**
+     * 未紐付けタイムスタンプがない場合のテスト
+     */
+    public function test_auto_link_with_no_unlinked_timestamps(): void
+    {
+        $result = $this->service->autoLinkUnlinkedTimestamps(10);
+
+        $this->assertEquals(0, $result['processed']);
+        $this->assertEquals(0, $result['linked']);
+        $this->assertEquals(0, $result['failed']);
+        $this->assertEquals(0, $result['skipped']);
+    }
+
+    /**
+     * Spotify検索で結果が見つかり、新規楽曲マスタを作成するテスト
+     */
+    public function test_auto_link_creates_new_song_and_mapping(): void
+    {
+        // テストデータ作成
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+        TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Test Song',
+            'is_display' => 1,
+        ]);
+
+        // Spotify APIをモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+            'https://api.spotify.com/v1/search*' => Http::response([
+                'tracks' => [
+                    'items' => [
+                        [
+                            'id' => 'spotify_track_123',
+                            'name' => 'Test Song',
+                            'artists' => [['name' => 'Test Artist']],
+                            'album' => ['name' => 'Test Album'],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        config(['services.spotify.client_id' => 'test_id']);
+        config(['services.spotify.client_secret' => 'test_secret']);
+
+        $result = $this->service->autoLinkUnlinkedTimestamps(10);
+
+        $this->assertEquals(1, $result['processed']);
+        $this->assertEquals(1, $result['linked']);
+        $this->assertEquals(0, $result['failed']);
+
+        // 楽曲マスタが作成されたことを確認
+        $this->assertDatabaseHas('songs', [
+            'title' => 'Test Song',
+            'artist' => 'Test Artist',
+            'spotify_track_id' => 'spotify_track_123',
+        ]);
+
+        // マッピングが作成されたことを確認
+        $this->assertDatabaseHas('timestamp_song_mappings', [
+            'is_manual' => false,
+            'confidence' => 0.8,
+        ]);
+    }
+
+    /**
+     * 既存のSpotify Track IDがある場合、既存楽曲を使用するテスト
+     */
+    public function test_auto_link_uses_existing_song_by_spotify_id(): void
+    {
+        // 既存楽曲を作成
+        $existingSong = Song::factory()->create([
+            'title' => 'Existing Song',
+            'artist' => 'Existing Artist',
+            'spotify_track_id' => 'existing_spotify_id',
+        ]);
+
+        // テストデータ作成
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+        TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'New Timestamp Text',
+            'is_display' => 1,
+        ]);
+
+        // Spotify APIをモック（既存のspotify_track_idを返す）
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+            'https://api.spotify.com/v1/search*' => Http::response([
+                'tracks' => [
+                    'items' => [
+                        [
+                            'id' => 'existing_spotify_id',
+                            'name' => 'Existing Song',
+                            'artists' => [['name' => 'Existing Artist']],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        config(['services.spotify.client_id' => 'test_id']);
+        config(['services.spotify.client_secret' => 'test_secret']);
+
+        $result = $this->service->autoLinkUnlinkedTimestamps(10);
+
+        $this->assertEquals(1, $result['linked']);
+
+        // 新しい楽曲マスタが作成されていないことを確認
+        $this->assertDatabaseCount('songs', 1);
+
+        // 既存楽曲にマッピングされたことを確認
+        $this->assertDatabaseHas('timestamp_song_mappings', [
+            'song_id' => $existingSong->id,
+            'is_manual' => false,
+        ]);
+    }
+
+    /**
+     * Spotify検索で結果がない場合のテスト
+     */
+    public function test_auto_link_no_spotify_results(): void
+    {
+        // テストデータ作成
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+        TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Unknown Song',
+            'is_display' => 1,
+        ]);
+
+        // Spotify APIをモック（空の結果を返す）
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+            'https://api.spotify.com/v1/search*' => Http::response([
+                'tracks' => [
+                    'items' => [],
+                ],
+            ], 200),
+        ]);
+
+        config(['services.spotify.client_id' => 'test_id']);
+        config(['services.spotify.client_secret' => 'test_secret']);
+
+        $result = $this->service->autoLinkUnlinkedTimestamps(10);
+
+        $this->assertEquals(1, $result['processed']);
+        $this->assertEquals(0, $result['linked']);
+        $this->assertEquals(1, $result['failed']);
+    }
+
+    /**
+     * 紐付け済みタイムスタンプは処理対象外のテスト
+     */
+    public function test_auto_link_skips_already_linked_timestamps(): void
+    {
+        // テストデータ作成
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 紐付け済みタイムスタンプ
+        $linkedTs = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Linked Song',
+            'is_display' => 1,
+        ]);
+
+        $song = Song::factory()->create();
+        TimestampSongMapping::factory()
+            ->withSong($song)
+            ->withText($linkedTs->text)
+            ->create();
+
+        // Spotify APIをモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+        ]);
+
+        config(['services.spotify.client_id' => 'test_id']);
+        config(['services.spotify.client_secret' => 'test_secret']);
+
+        $result = $this->service->autoLinkUnlinkedTimestamps(10);
+
+        // 処理対象がないことを確認
+        $this->assertEquals(0, $result['processed']);
+    }
+
+    /**
+     * is_display=0のタイムスタンプは処理対象外のテスト
+     */
+    public function test_auto_link_skips_hidden_timestamps(): void
+    {
+        // テストデータ作成
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 非表示タイムスタンプ
+        TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Hidden Song',
+            'is_display' => 0,
+        ]);
+
+        $result = $this->service->autoLinkUnlinkedTimestamps(10);
+
+        $this->assertEquals(0, $result['processed']);
+    }
+
+    /**
+     * 処理件数上限のテスト
+     */
+    public function test_auto_link_respects_limit(): void
+    {
+        // テストデータ作成
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 5件のタイムスタンプを作成
+        for ($i = 1; $i <= 5; $i++) {
+            TsItem::factory()->create([
+                'video_id' => $archive->video_id,
+                'text' => "Song {$i}",
+                'is_display' => 1,
+            ]);
+        }
+
+        // Spotify APIをモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+            'https://api.spotify.com/v1/search*' => Http::response([
+                'tracks' => [
+                    'items' => [
+                        [
+                            'id' => 'spotify_track_' . uniqid(),
+                            'name' => 'Song',
+                            'artists' => [['name' => 'Artist']],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        config(['services.spotify.client_id' => 'test_id']);
+        config(['services.spotify.client_secret' => 'test_secret']);
+
+        // 2件だけ処理
+        $result = $this->service->autoLinkUnlinkedTimestamps(2);
+
+        $this->assertEquals(2, $result['processed']);
+    }
+
+    /**
+     * 進捗コールバックが呼び出されるテスト
+     */
+    public function test_auto_link_calls_progress_callback(): void
+    {
+        // テストデータ作成
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+        TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'text' => 'Test Song',
+            'is_display' => 1,
+        ]);
+
+        // Spotify APIをモック
+        Http::fake([
+            'https://accounts.spotify.com/api/token' => Http::response([
+                'access_token' => 'test_token',
+            ], 200),
+            'https://api.spotify.com/v1/search*' => Http::response([
+                'tracks' => [
+                    'items' => [
+                        [
+                            'id' => 'spotify_track_123',
+                            'name' => 'Test Song',
+                            'artists' => [['name' => 'Test Artist']],
+                        ],
+                    ],
+                ],
+            ], 200),
+        ]);
+
+        config(['services.spotify.client_id' => 'test_id']);
+        config(['services.spotify.client_secret' => 'test_secret']);
+
+        $messages = [];
+        $result = $this->service->autoLinkUnlinkedTimestamps(10, function ($message) use (&$messages) {
+            $messages[] = $message;
+        });
+
+        // コールバックが呼び出されたことを確認
+        $this->assertNotEmpty($messages);
+        $this->assertStringContainsString('処理します', $messages[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- 未紐付けのタイムスタンプをSpotify APIで自動検索し、トップ結果を紐付ける機能
- `php artisan songs:auto-link` コマンドで実行
- 自動紐付けは `is_manual = false` で識別
- チャンネル一覧: 自動紐付け楽曲の下に元テキストを「[自動] xxx」形式で表示
- 正規化画面: 自動紐付けは黄色、手動は緑で表示
- 正規化画面: 「自動」フィルタボタン追加
- 正規化画面: 自動紐付けを「確定」ボタンで手動紐付けに変更可能

## 追加ファイル
- `app/Console/Commands/AutoLinkSongs.php` - artisanコマンド
- `app/Services/AutoLinkService.php` - 自動紐付けサービス
- `config/songs.php` - 設定ファイル
- `tests/Unit/Services/AutoLinkServiceTest.php` - ユニットテスト

## Test plan
- [ ] `php artisan songs:auto-link --dry-run` でドライラン確認
- [ ] `php artisan songs:auto-link --limit=10` で10件処理
- [ ] チャンネル一覧で自動紐付けの表示確認
- [ ] 正規化画面で「自動」フィルタ確認
- [ ] 正規化画面で「確定」ボタン動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)