### PR TITLE
fix: タイムスタンプ個別設定がアーカイブ更新時に失われる問題を修正

### DIFF
--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -260,6 +260,13 @@ class ManageController extends Controller
                 ->whereNotNull('comment_id')
                 ->delete();
 
+            // ts_item単位の設定保存時に必要なts_text, ts_numを取得するため、
+            // 対象のTsItemをあらかじめ全件ロード
+            $tsItemIds = collect($validatedData)->pluck('id')->toArray();
+            $tsItemsById = TsItem::whereIn('id', $tsItemIds)
+                ->get()
+                ->keyBy('id');
+
             // is_display=1 と is_display=0 でグループ化してバッチ更新
             $displayItemIds = collect($validatedData)->where('is_display', '1')->pluck('id')->toArray();
             $hideItemIds = collect($validatedData)->where('is_display', '0')->pluck('id')->toArray();
@@ -290,12 +297,16 @@ class ManageController extends Controller
                 } else {
                     // 異なる設定がある→タイムスタンプ単位でchange_listを作成
                     foreach ($items as $item) {
+                        $tsItemModel = $tsItemsById->get($item['id']);
                         ChangeList::create([
                             'channel_id' => $channelId,
                             'video_id' => $videoId,
                             'comment_id' => $commentId,
                             'ts_item_id' => $item['id'],
                             'is_display' => $item['is_display'],
+                            // アーカイブ更新時にts_item_idで照合できるようにts_text, ts_numを保存
+                            'ts_text' => $tsItemModel?->ts_text,
+                            'ts_num' => $tsItemModel?->ts_num,
                         ]);
                     }
                 }

--- a/app/Models/ChangeList.php
+++ b/app/Models/ChangeList.php
@@ -17,6 +17,8 @@ class ChangeList extends Model
         'video_id',
         'comment_id',
         'ts_item_id',
+        'ts_text',
+        'ts_num',
         'is_display',
     ];
 

--- a/app/Services/ChangeListService.php
+++ b/app/Services/ChangeListService.php
@@ -6,6 +6,7 @@ use App\Models\Archive;
 use App\Models\ChangeList;
 use App\Models\TsItem;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class ChangeListService
 {
@@ -136,6 +137,38 @@ class ChangeListService
     }
 
     /**
+     * アーカイブ更新後、change_listのts_item_idを新しいts_item.idに更新する
+     * タイムスタンプの内容（video_id, comment_id, ts_text, ts_num）で照合
+     *
+     * Note: This method should be called within a database transaction,
+     * BEFORE applyChangeListToTsItems and deleteObsoleteChangeLists.
+     */
+    public function updateTsItemIdsAfterRefresh(string $channelId): void
+    {
+        // ts_item_id が設定されている change_list レコードを取得
+        $tsItemChangeLists = ChangeList::where('channel_id', $channelId)
+            ->whereNotNull('ts_item_id')
+            ->whereNotNull('ts_text')
+            ->whereNotNull('ts_num')
+            ->get();
+
+        foreach ($tsItemChangeLists as $changeList) {
+            // 対応する新しい ts_item を検索
+            // video_id + comment_id + ts_text + ts_num の組み合わせで照合
+            $newTsItem = TsItem::where('video_id', $changeList->video_id)
+                ->where('comment_id', $changeList->comment_id)
+                ->where('ts_text', $changeList->ts_text)
+                ->where('ts_num', $changeList->ts_num)
+                ->first();
+
+            if ($newTsItem && $newTsItem->id !== $changeList->ts_item_id) {
+                // 新しいts_item_idに更新
+                $changeList->update(['ts_item_id' => $newTsItem->id]);
+            }
+        }
+    }
+
+    /**
      * 不要なchange_listレコードを削除
      * 以下の条件に該当するレコードを削除:
      * a. タイムスタンプ単位(ts_item_id IS NOT NULL)でts_itemsに紐づかないレコード
@@ -188,6 +221,17 @@ class ChangeListService
 
                         foreach ($tsItemChangeLists as $changeList) {
                             if (! in_array($changeList->ts_item_id, $existingTsItemIds)) {
+                                // ts_item_idで照合できなかったレコードを削除
+                                // updateTsItemIdsAfterRefreshで更新されなかった = ts_text/ts_numが変わった可能性
+                                Log::info('Deleting orphaned ts_item-level change_list', [
+                                    'change_list_id' => $changeList->id,
+                                    'channel_id' => $changeList->channel_id,
+                                    'video_id' => $changeList->video_id,
+                                    'comment_id' => $changeList->comment_id,
+                                    'ts_item_id' => $changeList->ts_item_id,
+                                    'ts_text' => $changeList->ts_text,
+                                    'ts_num' => $changeList->ts_num,
+                                ]);
                                 $idsToDelete[] = $changeList->id;
                             }
                         }

--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -175,7 +175,11 @@ class RefreshArchiveService
                 }
             }
 
-            // 4.2.履歴情報から、タイムスタンプの表示非表示を反映させる
+            // 4.2.1.アーカイブ更新でts_item_idが変わったので、change_listのts_item_idを更新
+            // ts_text + ts_num の組み合わせで新旧ts_itemをマッチング
+            $this->changeListService->updateTsItemIdsAfterRefresh($channel->channel_id);
+
+            // 4.2.2.履歴情報から、タイムスタンプの表示非表示を反映させる
             $this->changeListService->applyChangeListToTsItems($channel->channel_id);
 
             // 4.3.履歴情報から、動画の表示非表示を反映させる

--- a/database/migrations/2025_12_10_144825_add_ts_match_columns_to_change_list_table.php
+++ b/database/migrations/2025_12_10_144825_add_ts_match_columns_to_change_list_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('change_list', function (Blueprint $table) {
+            // タイムスタンプのマッチング用カラム
+            // アーカイブ更新時にts_item_idが変わっても、これらの値で照合できる
+            $table->string('ts_text', 20)->nullable()->after('ts_item_id');
+            $table->integer('ts_num')->nullable()->after('ts_text');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('change_list', function (Blueprint $table) {
+            $table->dropColumn(['ts_text', 'ts_num']);
+        });
+    }
+};

--- a/tests/Unit/Services/ChangeListServiceTest.php
+++ b/tests/Unit/Services/ChangeListServiceTest.php
@@ -260,4 +260,111 @@ class ChangeListServiceTest extends TestCase
         $this->assertDatabaseHas('change_list', ['id' => $validCommentChangeList->id]);
         $this->assertDatabaseHas('change_list', ['id' => $validArchiveChangeList->id]);
     }
+
+    /**
+     * updateTsItemIdsAfterRefresh: ts_text+ts_numで照合して新しいts_item_idに更新される
+     */
+    public function test_update_ts_item_ids_after_refresh_updates_matched_record(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        // 古いts_item（実際にはアーカイブ更新で削除される想定）
+        $oldTsItemId = '01HTEST_OLD_TSITEM_ID_1234';
+
+        // 新しいts_item（アーカイブ更新で再作成された想定）
+        $newTsItem = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-refresh-test',
+            'ts_text' => '1:23:45',
+            'ts_num' => 5025,
+        ]);
+
+        // ts_text, ts_numを持つchange_listレコード（古いts_item_idを参照）
+        $changeList = ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-refresh-test',
+            'ts_item_id' => $oldTsItemId,
+            'ts_text' => '1:23:45',
+            'ts_num' => 5025,
+            'is_display' => 0,
+        ]);
+
+        $this->service->updateTsItemIdsAfterRefresh($channel->channel_id);
+
+        // change_listのts_item_idが新しいts_itemのIDに更新される
+        $this->assertDatabaseHas('change_list', [
+            'id' => $changeList->id,
+            'ts_item_id' => $newTsItem->id,
+        ]);
+    }
+
+    /**
+     * updateTsItemIdsAfterRefresh: ts_text/ts_numが異なる場合は更新されない
+     */
+    public function test_update_ts_item_ids_after_refresh_does_not_update_unmatched_record(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        $oldTsItemId = '01HTEST_OLD_TSITEM_ID_5678';
+
+        // 新しいts_item（ts_textが異なる）
+        TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-unmatched-test',
+            'ts_text' => '0:00:30',
+            'ts_num' => 30,
+        ]);
+
+        // 古いts_textを持つchange_listレコード
+        $changeList = ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-unmatched-test',
+            'ts_item_id' => $oldTsItemId,
+            'ts_text' => '0:00:25',  // 異なるts_text
+            'ts_num' => 25,          // 異なるts_num
+            'is_display' => 0,
+        ]);
+
+        $this->service->updateTsItemIdsAfterRefresh($channel->channel_id);
+
+        // change_listのts_item_idは更新されない
+        $this->assertDatabaseHas('change_list', [
+            'id' => $changeList->id,
+            'ts_item_id' => $oldTsItemId,
+        ]);
+    }
+
+    /**
+     * updateTsItemIdsAfterRefresh: ts_text/ts_numがNULLの場合はスキップされる
+     */
+    public function test_update_ts_item_ids_after_refresh_skips_records_without_ts_text_ts_num(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+
+        $oldTsItemId = '01HTEST_OLD_TSITEM_ID_9999';
+
+        // ts_text, ts_numがNULLのchange_listレコード
+        $changeList = ChangeList::create([
+            'channel_id' => $channel->channel_id,
+            'video_id' => $archive->video_id,
+            'comment_id' => 'comment-null-test',
+            'ts_item_id' => $oldTsItemId,
+            'ts_text' => null,
+            'ts_num' => null,
+            'is_display' => 0,
+        ]);
+
+        $this->service->updateTsItemIdsAfterRefresh($channel->channel_id);
+
+        // ts_item_idは変更されない
+        $this->assertDatabaseHas('change_list', [
+            'id' => $changeList->id,
+            'ts_item_id' => $oldTsItemId,
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary
- タイムスタンプ単位で表示/非表示を設定しても、アーカイブ更新後に設定が失われる問題を修正
- `change_list`テーブルに`ts_text`, `ts_num`カラムを追加してタイムスタンプの内容で照合できるようにした
- アーカイブ更新時に`updateTsItemIdsAfterRefresh`で新しいts_item_idにマッピングを更新

## 根本原因
`RefreshArchiveService::refreshArchives()`でアーカイブ更新時に:
1. 既存ts_itemsが全削除される
2. 新しいts_itemsが新しいULIDで再作成される
3. `change_list.ts_item_id`は古いULIDを参照したまま
4. `applyChangeListToTsItems()`で古いts_item_idを探すが、該当なし
5. `deleteObsoleteChangeLists()`で「存在しないts_item_id」として削除される

## 変更内容
- `database/migrations/2025_12_10_144825_add_ts_match_columns_to_change_list_table.php` - ts_text, ts_numカラム追加
- `app/Services/ChangeListService.php` - `updateTsItemIdsAfterRefresh()`メソッド追加、ログ出力追加
- `app/Services/RefreshArchiveService.php` - change_list適用前にts_item_id更新処理を実行
- `app/Http/Controllers/ManageController.php` - editTimestampsでts_text, ts_numを保存
- `app/Models/ChangeList.php` - fillableにts_text, ts_num追加
- `tests/Unit/Services/ChangeListServiceTest.php` - 新機能のテスト追加

## Test plan
- [x] 全テスト通過確認（263 tests passed）
- [ ] タイムスタンプ単位で非表示設定 → アーカイブ更新 → 設定が維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)