### PR TITLE
fix: 楽曲切り替え時のフェードイン機能を追加

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -95,7 +95,9 @@ function registerArchiveListComponent() {
                 reshuffleMonitorId: null,
                 currentSongEndTime: null,
                 fadeOutIntervalId: null,
+                fadeInIntervalId: null,
                 originalVolume: 100,
+                needsFadeIn: false,
 
                 // ドラッグ機能用
                 isDragging: false,
@@ -648,6 +650,10 @@ function registerArchiveListComponent() {
                             },
                             'onStateChange': (event) => {
                                 this.isPlaying = event.data === YT.PlayerState.PLAYING;
+                                // 再生開始時にフェードインが必要な場合は開始
+                                if (event.data === YT.PlayerState.PLAYING && this.needsFadeIn) {
+                                    this.startFadeIn();
+                                }
                                 // 自動再抽選: 再生状態に応じて監視を開始/停止
                                 if (this.autoReshuffle && this.currentSongEndTime !== null) {
                                     if (event.data === YT.PlayerState.PLAYING) {
@@ -950,14 +956,58 @@ function registerArchiveListComponent() {
                 },
 
                 /**
-                 * フェードアウトを停止して音量を復元
+                 * フェードアウトを停止（音量は復元しない）
                  */
                 stopFadeOut() {
                     if (this.fadeOutIntervalId) {
                         clearInterval(this.fadeOutIntervalId);
                         this.fadeOutIntervalId = null;
+                        // フェードアウト中だった場合、次の曲でフェードインが必要
+                        this.needsFadeIn = true;
                     }
-                    // 音量を復元
+                },
+
+                /**
+                 * フェードインを開始
+                 */
+                startFadeIn() {
+                    if (this.fadeInIntervalId || !this.youtubePlayer) return;
+                    if (!this.needsFadeIn) return;
+
+                    this.needsFadeIn = false;
+
+                    // 音量0から開始
+                    if (typeof this.youtubePlayer.setVolume === 'function') {
+                        this.youtubePlayer.setVolume(0);
+                    }
+
+                    const FADE_STEPS = 10;
+                    const FADE_INTERVAL = 200; // 2秒 / 10ステップ = 200ms（フェードアウトより短め）
+                    let step = 0;
+
+                    this.fadeInIntervalId = setInterval(() => {
+                        step++;
+                        const newVolume = Math.min(this.originalVolume, this.originalVolume * (step / FADE_STEPS));
+
+                        if (this.youtubePlayer && typeof this.youtubePlayer.setVolume === 'function') {
+                            this.youtubePlayer.setVolume(newVolume);
+                        }
+
+                        if (step >= FADE_STEPS) {
+                            this.stopFadeIn();
+                        }
+                    }, FADE_INTERVAL);
+                },
+
+                /**
+                 * フェードインを停止
+                 */
+                stopFadeIn() {
+                    if (this.fadeInIntervalId) {
+                        clearInterval(this.fadeInIntervalId);
+                        this.fadeInIntervalId = null;
+                    }
+                    // 最終的に元の音量に設定
                     if (this.youtubePlayer && typeof this.youtubePlayer.setVolume === 'function') {
                         this.youtubePlayer.setVolume(this.originalVolume);
                     }


### PR DESCRIPTION
## Summary
- フェードアウト後に音量が急に戻る問題を修正
- 次の曲の再生開始時にフェードインで徐々に音量を復元

## 変更内容
- フェードアウト完了後は音量を0のまま維持（即座に復元しない）
- 次の曲の再生開始時に2秒かけてフェードイン（10ステップ × 200ms）
- フェードアウトが3秒、フェードインが2秒で自然な切り替わりを実現

## Test plan
- [ ] 自動再抽選ONで楽曲終了時にフェードアウト→フェードインが滑らかに動作することを確認
- [ ] フェードアウト中に手動で楽曲を選択した場合も正しくフェードインすることを確認
- [ ] フェードアウトしていない状態で手動選択した場合は通常再生されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)