### PR TITLE
fix: 報告機能をts_item_idから複合キーに変更

### DIFF
--- a/app/Http/Controllers/TimestampReportController.php
+++ b/app/Http/Controllers/TimestampReportController.php
@@ -34,17 +34,31 @@ class TimestampReportController extends Controller
         }
 
         $validated = $request->validate([
-            'ts_item_id' => 'required|string|max:26|exists:ts_items,id',
             'video_id' => 'required|string|max:11',
+            'ts_text' => 'required|string|max:20',
+            'ts_num' => 'required|integer|min:0',
             'report_type' => 'required|string|max:20',
             'comment' => 'nullable|string|max:1000',
         ]);
 
+        // ts_itemが存在するか確認
+        $tsItemExists = \App\Models\TsItem::where('video_id', $validated['video_id'])
+            ->where('ts_text', $validated['ts_text'])
+            ->where('ts_num', $validated['ts_num'])
+            ->exists();
+
+        if (! $tsItemExists) {
+            return response()->json([
+                'message' => '報告対象のタイムスタンプが見つかりません。',
+            ], 422);
+        }
+
         RateLimiter::hit($key, 60);
 
         $report = TimestampReport::create([
-            'ts_item_id' => $validated['ts_item_id'],
             'video_id' => $validated['video_id'],
+            'ts_text' => $validated['ts_text'],
+            'ts_num' => $validated['ts_num'],
             'report_type' => $validated['report_type'],
             'comment' => $validated['comment'] ?? null,
             'reporter_ip' => $request->ip(),
@@ -61,8 +75,7 @@ class TimestampReportController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        $query = TimestampReport::with(['tsItem.archive'])
-            ->orderBy('created_at', 'desc');
+        $query = TimestampReport::orderBy('created_at', 'desc');
 
         // ステータスフィルター
         if ($request->has('status') && in_array($request->status, ['pending', 'resolved'])) {
@@ -71,7 +84,48 @@ class TimestampReportController extends Controller
 
         $reports = $query->paginate(20);
 
+        // N+1回避: 報告に対応するts_itemsをまとめて取得
+        $this->loadTsItemsForReports($reports->getCollection());
+
         return response()->json($reports);
+    }
+
+    /**
+     * 報告のコレクションに対応するts_itemsを一括で読み込む（N+1回避）
+     */
+    private function loadTsItemsForReports(\Illuminate\Support\Collection $reports): void
+    {
+        if ($reports->isEmpty()) {
+            return;
+        }
+
+        // 報告に対応するts_itemsを一括取得
+        $conditions = $reports->map(fn ($report) => [
+            'video_id' => $report->video_id,
+            'ts_text' => $report->ts_text,
+            'ts_num' => $report->ts_num,
+        ])->toArray();
+
+        $tsItems = \App\Models\TsItem::with('archive')
+            ->where(function ($query) use ($conditions) {
+                foreach ($conditions as $cond) {
+                    $query->orWhere(function ($q) use ($cond) {
+                        $q->where('video_id', $cond['video_id'])
+                            ->where('ts_text', $cond['ts_text'])
+                            ->where('ts_num', $cond['ts_num']);
+                    });
+                }
+            })
+            ->get()
+            ->keyBy(fn ($item) => $item->video_id.'|'.$item->ts_text.'|'.$item->ts_num);
+
+        // 各報告にts_itemをセット
+        $reports->transform(function ($report) use ($tsItems) {
+            $key = $report->video_id.'|'.$report->ts_text.'|'.$report->ts_num;
+            $report->ts_item = $tsItems->get($key);
+
+            return $report;
+        });
     }
 
     /**
@@ -92,7 +146,11 @@ class TimestampReportController extends Controller
      */
     public function show(TimestampReport $report): JsonResponse
     {
-        $report->load(['tsItem.archive']);
+        // 対応するts_itemを取得
+        $report->ts_item = $report->tsItem;
+        if ($report->ts_item) {
+            $report->ts_item->load('archive');
+        }
 
         return response()->json($report);
     }

--- a/app/Models/TimestampReport.php
+++ b/app/Models/TimestampReport.php
@@ -5,15 +5,15 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class TimestampReport extends Model
 {
     use HasFactory, HasUlids;
 
     protected $fillable = [
-        'ts_item_id',
         'video_id',
+        'ts_text',
+        'ts_num',
         'report_type',
         'comment',
         'status',
@@ -23,14 +23,19 @@ class TimestampReport extends Model
 
     protected $casts = [
         'resolved_at' => 'datetime',
+        'ts_num' => 'integer',
     ];
 
     /**
-     * 報告対象のタイムスタンプ
+     * 対応するts_itemを取得（複合キーでの検索）
+     * belongsToリレーションは複合キーに対応していないため、アクセサで実装
      */
-    public function tsItem(): BelongsTo
+    public function getTsItemAttribute()
     {
-        return $this->belongsTo(TsItem::class, 'ts_item_id');
+        return TsItem::where('video_id', $this->video_id)
+            ->where('ts_text', $this->ts_text)
+            ->where('ts_num', $this->ts_num)
+            ->first();
     }
 
     /**

--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -5,11 +5,13 @@ namespace App\Services;
 use App\Helpers\TextNormalizer;
 use App\Models\Archive;
 use App\Models\Channel;
+use App\Models\TimestampReport;
 use App\Models\TsItem;
 use App\Models\User;
 use Exception;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class RefreshArchiveService
@@ -187,9 +189,74 @@ class RefreshArchiveService
 
             // 4.4.不要な履歴は削除する
             $this->changeListService->deleteObsoleteChangeLists($channel->channel_id);
+
+            // 4.5.不要な報告を削除する（対応するts_itemが存在しなくなった報告）
+            $this->deleteObsoleteReports($channel->channel_id);
         });
 
         return count($rtn_archives);
+    }
+
+    /**
+     * 対応するts_itemが存在しなくなった報告を削除
+     * video_id + ts_text + ts_num で照合し、ts_itemsに存在しない報告を削除
+     */
+    protected function deleteObsoleteReports(string $channelId): void
+    {
+        $driver = DB::getDriverName();
+
+        if ($driver === 'mysql') {
+            // MySQL用の最適化クエリ
+            $deletedCount = DB::affectingStatement('
+                DELETE r FROM timestamp_reports r
+                INNER JOIN archives a ON a.video_id = r.video_id
+                LEFT JOIN ts_items t ON t.video_id = r.video_id
+                    AND t.ts_text = r.ts_text
+                    AND t.ts_num = r.ts_num
+                WHERE a.channel_id = ?
+                    AND t.id IS NULL
+            ', [$channelId]);
+
+            if ($deletedCount > 0) {
+                Log::info('Deleted obsolete timestamp reports', [
+                    'channel_id' => $channelId,
+                    'deleted_count' => $deletedCount,
+                ]);
+            }
+        } else {
+            // SQLite/PostgreSQL用（テスト環境）- N+1回避版
+            $videoIds = Archive::where('channel_id', $channelId)->pluck('video_id')->toArray();
+
+            if (empty($videoIds)) {
+                return;
+            }
+
+            // 存在するts_itemsの複合キーを一括取得
+            $existingKeys = TsItem::whereIn('video_id', $videoIds)
+                ->select('video_id', 'ts_text', 'ts_num')
+                ->get()
+                ->map(fn ($item) => $item->video_id.'|'.$item->ts_text.'|'.$item->ts_num)
+                ->flip();
+
+            // 対応するts_itemが存在しない報告を抽出
+            $reportsToDelete = TimestampReport::whereIn('video_id', $videoIds)
+                ->get()
+                ->filter(function ($report) use ($existingKeys) {
+                    $key = $report->video_id.'|'.$report->ts_text.'|'.$report->ts_num;
+
+                    return ! $existingKeys->has($key);
+                });
+
+            if ($reportsToDelete->isNotEmpty()) {
+                $deleteIds = $reportsToDelete->pluck('id')->toArray();
+                TimestampReport::whereIn('id', $deleteIds)->delete();
+
+                Log::info('Deleted obsolete timestamp reports', [
+                    'channel_id' => $channelId,
+                    'deleted_count' => count($deleteIds),
+                ]);
+            }
+        }
     }
 
     /**

--- a/app/Services/TimestampService.php
+++ b/app/Services/TimestampService.php
@@ -6,7 +6,6 @@ use App\Helpers\CharacterCategorizer;
 use App\Helpers\QueryHelper;
 use App\Helpers\ValidationHelper;
 use App\Models\Channel;
-use App\Models\TimestampReport;
 use App\Models\TsItem;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
@@ -419,9 +418,15 @@ class TimestampService
         }
 
         try {
-            return TimestampReport::whereIn('ts_item_id', $tsItemIds)
-                ->where('status', 'pending')
-                ->pluck('ts_item_id')
+            // ts_itemsと複合キー(video_id, ts_text, ts_num)でJOINして報告のあるts_item.idを取得
+            return TsItem::whereIn('ts_items.id', $tsItemIds)
+                ->join('timestamp_reports', function ($join) {
+                    $join->on('ts_items.video_id', '=', 'timestamp_reports.video_id')
+                        ->on('ts_items.ts_text', '=', 'timestamp_reports.ts_text')
+                        ->on('ts_items.ts_num', '=', 'timestamp_reports.ts_num');
+                })
+                ->where('timestamp_reports.status', 'pending')
+                ->pluck('ts_items.id')
                 ->unique()
                 ->toArray();
         } catch (\Exception $e) {

--- a/database/migrations/2025_11_24_044436_create_timestamp_reports_table.php
+++ b/database/migrations/2025_11_24_044436_create_timestamp_reports_table.php
@@ -13,8 +13,9 @@ return new class extends Migration
     {
         Schema::create('timestamp_reports', function (Blueprint $table) {
             $table->ulid('id')->primary();
-            $table->string('ts_item_id', 26);
             $table->string('video_id', 11);
+            $table->string('ts_text', 20)->nullable();
+            $table->integer('ts_num')->nullable();
             $table->string('report_type', 20);
             $table->text('comment')->nullable();
             $table->enum('status', ['pending', 'resolved'])->default('pending');
@@ -22,8 +23,7 @@ return new class extends Migration
             $table->timestamp('resolved_at')->nullable();
             $table->timestamps();
 
-            $table->foreign('ts_item_id')->references('id')->on('ts_items')
-                ->onDelete('cascade');
+            $table->index(['video_id', 'ts_text', 'ts_num'], 'timestamp_reports_composite_key');
             $table->index(['status', 'created_at']);
             $table->index('reporter_ip');
         });

--- a/database/migrations/2025_12_12_134859_add_composite_key_columns_to_timestamp_reports_table.php
+++ b/database/migrations/2025_12_12_134859_add_composite_key_columns_to_timestamp_reports_table.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     * ts_item_idから複合キー(video_id+ts_text+ts_num)への移行
+     * 注: 元のマイグレーションが既に新スキーマの場合はスキップ
+     */
+    public function up(): void
+    {
+        // 既に新スキーマの場合（ts_textカラムが存在する場合）はスキップ
+        if (Schema::hasColumn('timestamp_reports', 'ts_text')) {
+            return;
+        }
+
+        Schema::table('timestamp_reports', function (Blueprint $table) {
+            // 新しいカラムを追加
+            $table->string('ts_text', 20)->nullable()->after('video_id');
+            $table->integer('ts_num')->nullable()->after('ts_text');
+        });
+
+        // 既存データのts_text, ts_numを埋める（ts_item_idから取得）
+        DB::statement('
+            UPDATE timestamp_reports r
+            INNER JOIN ts_items t ON r.ts_item_id = t.id
+            SET r.ts_text = t.ts_text, r.ts_num = t.ts_num
+        ');
+
+        Schema::table('timestamp_reports', function (Blueprint $table) {
+            // ts_item_idを削除し、インデックスを追加
+            $table->dropForeign(['ts_item_id']);
+            $table->dropColumn('ts_item_id');
+            $table->index(['video_id', 'ts_text', 'ts_num'], 'timestamp_reports_composite_key');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // ts_item_idが存在しない場合のみロールバック
+        if (Schema::hasColumn('timestamp_reports', 'ts_item_id')) {
+            return;
+        }
+
+        Schema::table('timestamp_reports', function (Blueprint $table) {
+            $table->dropIndex('timestamp_reports_composite_key');
+            $table->ulid('ts_item_id')->nullable()->after('id');
+        });
+
+        // ts_item_idを復元（ts_text, ts_numからマッチするts_itemを探す）
+        DB::statement('
+            UPDATE timestamp_reports r
+            INNER JOIN ts_items t ON r.video_id = t.video_id
+                AND r.ts_text = t.ts_text
+                AND r.ts_num = t.ts_num
+            SET r.ts_item_id = t.id
+        ');
+
+        Schema::table('timestamp_reports', function (Blueprint $table) {
+            $table->dropColumn(['ts_text', 'ts_num']);
+            $table->foreign('ts_item_id')->references('id')->on('ts_items')->onDelete('cascade');
+        });
+    }
+};

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -453,8 +453,9 @@ function registerArchiveListComponent() {
                     }
 
                     const result = await ReportService.submitReport({
-                        ts_item_id: this.reportTarget.id,
                         video_id: this.reportTarget.video_id,
+                        ts_text: this.reportTarget.ts_text,
+                        ts_num: this.reportTarget.ts_num,
                         report_type: this.reportType,
                         comment: this.reportComment || null,
                     });

--- a/resources/js/channels/services/ReportService.js
+++ b/resources/js/channels/services/ReportService.js
@@ -5,8 +5,9 @@ export class ReportService {
     /**
      * タイムスタンプの問題を報告
      * @param {Object} reportData - 報告データ
-     * @param {string} reportData.ts_item_id - タイムスタンプアイテムID
      * @param {string} reportData.video_id - 動画ID
+     * @param {string} reportData.ts_text - タイムスタンプテキスト（例: "1:23:45"）
+     * @param {number} reportData.ts_num - タイムスタンプ秒数
      * @param {string} reportData.report_type - 報告タイプ
      * @param {string|null} reportData.comment - コメント
      * @returns {Promise<{success: boolean, message: string}>} 送信結果

--- a/tests/Feature/ChannelArchiveTest.php
+++ b/tests/Feature/ChannelArchiveTest.php
@@ -465,8 +465,9 @@ class ChannelArchiveTest extends TestCase
 
         // 報告を作成（pending状態）
         TimestampReport::create([
-            'ts_item_id' => $reportedTs->id,
             'video_id' => $archive->video_id,
+            'ts_text' => $reportedTs->ts_text,
+            'ts_num' => $reportedTs->ts_num,
             'report_type' => 'wrong_song',
             'status' => 'pending',
             'reporter_ip' => '127.0.0.1',
@@ -505,8 +506,9 @@ class ChannelArchiveTest extends TestCase
 
         // 解決済みの報告を作成
         TimestampReport::create([
-            'ts_item_id' => $ts->id,
             'video_id' => $archive->video_id,
+            'ts_text' => $ts->ts_text,
+            'ts_num' => $ts->ts_num,
             'report_type' => 'wrong_song',
             'status' => 'resolved',
             'resolved_at' => now(),

--- a/tests/Feature/TimestampReportTest.php
+++ b/tests/Feature/TimestampReportTest.php
@@ -72,8 +72,9 @@ class TimestampReportTest extends TestCase
         RateLimiter::clear('timestamp-report:127.0.0.1');
 
         $response = $this->postJson('/api/timestamp-reports', [
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'comment' => 'テストコメント',
         ]);
@@ -85,8 +86,9 @@ class TimestampReportTest extends TestCase
             ->assertJsonStructure(['report_id']);
 
         $this->assertDatabaseHas('timestamp_reports', [
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'comment' => 'テストコメント',
             'status' => 'pending',
@@ -101,15 +103,18 @@ class TimestampReportTest extends TestCase
         RateLimiter::clear('timestamp-report:127.0.0.1');
 
         $response = $this->postJson('/api/timestamp-reports', [
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'not_song',
         ]);
 
         $response->assertStatus(201);
 
         $this->assertDatabaseHas('timestamp_reports', [
-            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'not_song',
             'comment' => null,
         ]);
@@ -125,24 +130,27 @@ class TimestampReportTest extends TestCase
         $response = $this->postJson('/api/timestamp-reports', []);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['ts_item_id', 'video_id', 'report_type']);
+            ->assertJsonValidationErrors(['video_id', 'ts_text', 'ts_num', 'report_type']);
     }
 
     /**
-     * 存在しないts_item_idでバリデーションエラーになることをテスト
+     * 存在しないts_itemでエラーになることをテスト
      */
-    public function test_validation_fails_with_invalid_ts_item_id(): void
+    public function test_validation_fails_with_invalid_ts_item(): void
     {
         RateLimiter::clear('timestamp-report:127.0.0.1');
 
         $response = $this->postJson('/api/timestamp-reports', [
-            'ts_item_id' => 'nonexistent_id',
             'video_id' => 'video123',
+            'ts_text' => '99:99',
+            'ts_num' => 9999,
             'report_type' => 'wrong_song',
         ]);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['ts_item_id']);
+            ->assertJson([
+                'message' => '報告対象のタイムスタンプが見つかりません。',
+            ]);
     }
 
     /**
@@ -155,8 +163,9 @@ class TimestampReportTest extends TestCase
         // 5回の報告を送信（制限内）
         for ($i = 0; $i < 5; $i++) {
             $response = $this->postJson('/api/timestamp-reports', [
-                'ts_item_id' => $this->tsItem->id,
                 'video_id' => 'video123',
+                'ts_text' => '1:23',
+                'ts_num' => 83,
                 'report_type' => 'wrong_song',
             ]);
             $response->assertStatus(201);
@@ -164,8 +173,9 @@ class TimestampReportTest extends TestCase
 
         // 6回目の報告はレートリミットエラー
         $response = $this->postJson('/api/timestamp-reports', [
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
         ]);
 
@@ -180,8 +190,9 @@ class TimestampReportTest extends TestCase
     {
         // 報告を作成
         TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'comment' => 'テスト',
             'reporter_ip' => '127.0.0.1',
@@ -195,8 +206,9 @@ class TimestampReportTest extends TestCase
                 'data' => [
                     '*' => [
                         'id',
-                        'ts_item_id',
                         'video_id',
+                        'ts_text',
+                        'ts_num',
                         'report_type',
                         'comment',
                         'status',
@@ -226,8 +238,9 @@ class TimestampReportTest extends TestCase
     {
         // pending報告を作成
         TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'status' => 'pending',
             'reporter_ip' => '127.0.0.1',
@@ -235,8 +248,9 @@ class TimestampReportTest extends TestCase
 
         // resolved報告を作成
         TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'not_song',
             'status' => 'resolved',
             'resolved_at' => now(),
@@ -258,8 +272,9 @@ class TimestampReportTest extends TestCase
     public function test_can_resolve_report(): void
     {
         $report = TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'reporter_ip' => '127.0.0.1',
         ]);
@@ -287,8 +302,9 @@ class TimestampReportTest extends TestCase
     public function test_guest_cannot_resolve_report(): void
     {
         $report = TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'reporter_ip' => '127.0.0.1',
         ]);
@@ -304,8 +320,9 @@ class TimestampReportTest extends TestCase
     public function test_can_view_report_detail(): void
     {
         $report = TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'comment' => 'テストコメント',
             'reporter_ip' => '127.0.0.1',
@@ -317,7 +334,9 @@ class TimestampReportTest extends TestCase
         $response->assertStatus(200)
             ->assertJson([
                 'id' => $report->id,
-                'ts_item_id' => $this->tsItem->id,
+                'video_id' => 'video123',
+                'ts_text' => '1:23',
+                'ts_num' => 83,
                 'report_type' => 'wrong_song',
                 'comment' => 'テストコメント',
             ]);
@@ -329,8 +348,9 @@ class TimestampReportTest extends TestCase
     public function test_guest_cannot_view_report_detail(): void
     {
         $report = TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'reporter_ip' => '127.0.0.1',
         ]);
@@ -349,15 +369,18 @@ class TimestampReportTest extends TestCase
 
         $response = $this->withServerVariables(['REMOTE_ADDR' => '192.168.1.1'])
             ->postJson('/api/timestamp-reports', [
-                'ts_item_id' => $this->tsItem->id,
                 'video_id' => 'video123',
+                'ts_text' => '1:23',
+                'ts_num' => 83,
                 'report_type' => 'wrong_song',
             ]);
 
         $response->assertStatus(201);
 
         $this->assertDatabaseHas('timestamp_reports', [
-            'ts_item_id' => $this->tsItem->id,
+            'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'reporter_ip' => '192.168.1.1',
         ]);
     }
@@ -372,8 +395,9 @@ class TimestampReportTest extends TestCase
         $longComment = str_repeat('あ', 1001);
 
         $response = $this->postJson('/api/timestamp-reports', [
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'comment' => $longComment,
         ]);
@@ -383,13 +407,15 @@ class TimestampReportTest extends TestCase
     }
 
     /**
-     * TsItemが削除されると関連する報告も削除されることをテスト
+     * 報告はts_itemが削除されても維持されることをテスト（複合キーで紐付けのため）
+     * 不要な報告の削除はRefreshArchiveServiceで行う
      */
-    public function test_reports_are_deleted_when_ts_item_is_deleted(): void
+    public function test_reports_persist_when_ts_item_is_deleted(): void
     {
         $report = TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'reporter_ip' => '127.0.0.1',
         ]);
@@ -399,8 +425,8 @@ class TimestampReportTest extends TestCase
         // TsItemを削除
         $this->tsItem->delete();
 
-        // 報告も削除されていることを確認
-        $this->assertDatabaseMissing('timestamp_reports', [
+        // 報告は維持されている（外部キー制約がないため）
+        $this->assertDatabaseHas('timestamp_reports', [
             'id' => $reportId,
         ]);
     }
@@ -411,16 +437,18 @@ class TimestampReportTest extends TestCase
     public function test_pending_scope_works(): void
     {
         TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'status' => 'pending',
             'reporter_ip' => '127.0.0.1',
         ]);
 
         TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'not_song',
             'status' => 'resolved',
             'resolved_at' => now(),
@@ -439,16 +467,18 @@ class TimestampReportTest extends TestCase
     public function test_resolved_scope_works(): void
     {
         TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'wrong_song',
             'status' => 'pending',
             'reporter_ip' => '127.0.0.1',
         ]);
 
         TimestampReport::create([
-            'ts_item_id' => $this->tsItem->id,
             'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
             'report_type' => 'not_song',
             'status' => 'resolved',
             'resolved_at' => now(),
@@ -481,5 +511,43 @@ class TimestampReportTest extends TestCase
         $response = $this->get('/manage/reports');
 
         $response->assertRedirect('/login');
+    }
+
+    /**
+     * 報告に対応するts_itemを取得できることをテスト
+     */
+    public function test_can_get_ts_item_from_report(): void
+    {
+        $report = TimestampReport::create([
+            'video_id' => 'video123',
+            'ts_text' => '1:23',
+            'ts_num' => 83,
+            'report_type' => 'wrong_song',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        $tsItem = $report->tsItem;
+
+        $this->assertNotNull($tsItem);
+        $this->assertEquals($this->tsItem->id, $tsItem->id);
+        $this->assertEquals('Test Song', $tsItem->text);
+    }
+
+    /**
+     * ts_itemが存在しない場合はnullが返ることをテスト
+     */
+    public function test_ts_item_returns_null_when_not_exists(): void
+    {
+        $report = TimestampReport::create([
+            'video_id' => 'video123',
+            'ts_text' => '99:99',
+            'ts_num' => 9999,
+            'report_type' => 'wrong_song',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        $tsItem = $report->tsItem;
+
+        $this->assertNull($tsItem);
     }
 }

--- a/tests/Unit/Services/RefreshArchiveServiceTest.php
+++ b/tests/Unit/Services/RefreshArchiveServiceTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Services;
 use App\Models\Archive;
 use App\Models\ChangeList;
 use App\Models\Channel;
+use App\Models\TimestampReport;
 use App\Models\TsItem;
 use App\Services\ChangeListService;
 use App\Services\ChannelQueryService;
@@ -959,5 +960,253 @@ class RefreshArchiveServiceTest extends TestCase
 
         // 合計3件のts_itemが登録されていること
         $this->assertEquals(3, TsItem::where('video_id', 'cover_video')->count());
+    }
+
+    /**
+     * アーカイブ更新時に報告が維持されることをテスト
+     */
+    public function test_refresh_archives_preserves_reports(): void
+    {
+        $channel = Channel::factory()->create(['channel_id' => 'UC123456789']);
+
+        // 既存のアーカイブとタイムスタンプを作成
+        Archive::create([
+            'id' => 'video123',
+            'video_id' => 'video123',
+            'channel_id' => $channel->channel_id,
+            'title' => 'Test Archive',
+            'thumbnail' => 'https://example.com/thumb.jpg',
+            'is_public' => true,
+            'is_display' => true,
+            'published_at' => now(),
+            'comments_updated_at' => now(),
+        ]);
+
+        TsItem::create([
+            'id' => Str::ulid(),
+            'video_id' => 'video123',
+            'type' => '1',
+            'ts_text' => '1:00',
+            'ts_num' => 60,
+            'text' => 'Test Song',
+            'is_display' => true,
+        ]);
+
+        // 報告を作成
+        $report = TimestampReport::create([
+            'video_id' => 'video123',
+            'ts_text' => '1:00',
+            'ts_num' => 60,
+            'report_type' => 'wrong_song',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        // YouTubeServiceのモック設定（同じタイムスタンプを返す）
+        $this->youtubeService
+            ->shouldReceive('getArchivesAndTsItems')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => Str::uuid()->toString(),
+                    'video_id' => 'video123',
+                    'channel_id' => $channel->channel_id,
+                    'title' => 'Test Archive Updated',
+                    'thumbnail' => 'https://example.com/thumb.jpg',
+                    'is_public' => true,
+                    'is_display' => true,
+                    'published_at' => now(),
+                    'comments_updated_at' => now(),
+                    'description' => '',
+                    'ts_items' => [
+                        [
+                            'id' => Str::uuid()->toString(),
+                            'video_id' => 'video123',
+                            'type' => '1',
+                            'ts_text' => '1:00',
+                            'ts_num' => 60,
+                            'text' => 'Test Song Updated',
+                            'is_display' => true,
+                        ],
+                    ],
+                ],
+            ]);
+
+        $this->service->refreshArchives($channel);
+
+        // 報告が維持されていることを確認
+        $this->assertDatabaseHas('timestamp_reports', [
+            'id' => $report->id,
+            'video_id' => 'video123',
+            'ts_text' => '1:00',
+            'ts_num' => 60,
+        ]);
+    }
+
+    /**
+     * アーカイブ更新時にts_itemが消えた報告が削除されることをテスト
+     */
+    public function test_refresh_archives_deletes_obsolete_reports(): void
+    {
+        $channel = Channel::factory()->create(['channel_id' => 'UC123456789']);
+
+        // 既存のアーカイブとタイムスタンプを作成
+        Archive::create([
+            'id' => 'video123',
+            'video_id' => 'video123',
+            'channel_id' => $channel->channel_id,
+            'title' => 'Test Archive',
+            'thumbnail' => 'https://example.com/thumb.jpg',
+            'is_public' => true,
+            'is_display' => true,
+            'published_at' => now(),
+            'comments_updated_at' => now(),
+        ]);
+
+        TsItem::create([
+            'id' => Str::ulid(),
+            'video_id' => 'video123',
+            'type' => '1',
+            'ts_text' => '1:00',
+            'ts_num' => 60,
+            'text' => 'Test Song',
+            'is_display' => true,
+        ]);
+
+        // 報告を作成
+        $report = TimestampReport::create([
+            'video_id' => 'video123',
+            'ts_text' => '1:00',
+            'ts_num' => 60,
+            'report_type' => 'wrong_song',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        // YouTubeServiceのモック設定（タイムスタンプが変更された）
+        $this->youtubeService
+            ->shouldReceive('getArchivesAndTsItems')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => Str::uuid()->toString(),
+                    'video_id' => 'video123',
+                    'channel_id' => $channel->channel_id,
+                    'title' => 'Test Archive',
+                    'thumbnail' => 'https://example.com/thumb.jpg',
+                    'is_public' => true,
+                    'is_display' => true,
+                    'published_at' => now(),
+                    'comments_updated_at' => now(),
+                    'description' => '',
+                    'ts_items' => [
+                        [
+                            'id' => Str::uuid()->toString(),
+                            'video_id' => 'video123',
+                            'type' => '1',
+                            'ts_text' => '2:00', // 時間が変更された
+                            'ts_num' => 120,
+                            'text' => 'Test Song',
+                            'is_display' => true,
+                        ],
+                    ],
+                ],
+            ]);
+
+        $this->service->refreshArchives($channel);
+
+        // 古いタイムスタンプに紐づく報告が削除されていることを確認
+        $this->assertDatabaseMissing('timestamp_reports', [
+            'id' => $report->id,
+        ]);
+    }
+
+    /**
+     * 他のチャンネルの報告は削除されないことをテスト
+     */
+    public function test_refresh_archives_does_not_delete_other_channel_reports(): void
+    {
+        $channel1 = Channel::factory()->create(['channel_id' => 'UC111111111']);
+        $channel2 = Channel::factory()->create(['channel_id' => 'UC222222222']);
+
+        // チャンネル1のアーカイブとタイムスタンプ
+        Archive::create([
+            'id' => 'video111',
+            'video_id' => 'video111',
+            'channel_id' => $channel1->channel_id,
+            'title' => 'Channel 1 Archive',
+            'thumbnail' => 'https://example.com/thumb.jpg',
+            'is_public' => true,
+            'is_display' => true,
+            'published_at' => now(),
+            'comments_updated_at' => now(),
+        ]);
+
+        TsItem::create([
+            'id' => Str::ulid(),
+            'video_id' => 'video111',
+            'type' => '1',
+            'ts_text' => '1:00',
+            'ts_num' => 60,
+            'text' => 'Song 1',
+            'is_display' => true,
+        ]);
+
+        // チャンネル2のアーカイブとタイムスタンプ
+        Archive::create([
+            'id' => 'video222',
+            'video_id' => 'video222',
+            'channel_id' => $channel2->channel_id,
+            'title' => 'Channel 2 Archive',
+            'thumbnail' => 'https://example.com/thumb.jpg',
+            'is_public' => true,
+            'is_display' => true,
+            'published_at' => now(),
+            'comments_updated_at' => now(),
+        ]);
+
+        TsItem::create([
+            'id' => Str::ulid(),
+            'video_id' => 'video222',
+            'type' => '1',
+            'ts_text' => '3:00',
+            'ts_num' => 180,
+            'text' => 'Song 2',
+            'is_display' => true,
+        ]);
+
+        // チャンネル2の報告を作成
+        $report2 = TimestampReport::create([
+            'video_id' => 'video222',
+            'ts_text' => '3:00',
+            'ts_num' => 180,
+            'report_type' => 'wrong_song',
+            'reporter_ip' => '127.0.0.1',
+        ]);
+
+        // YouTubeServiceのモック設定（チャンネル1のみ更新）
+        $this->youtubeService
+            ->shouldReceive('getArchivesAndTsItems')
+            ->once()
+            ->andReturn([
+                [
+                    'id' => Str::uuid()->toString(),
+                    'video_id' => 'video111',
+                    'channel_id' => $channel1->channel_id,
+                    'title' => 'Channel 1 Archive Updated',
+                    'thumbnail' => 'https://example.com/thumb.jpg',
+                    'is_public' => true,
+                    'is_display' => true,
+                    'published_at' => now(),
+                    'comments_updated_at' => now(),
+                    'description' => '',
+                    'ts_items' => [],
+                ],
+            ]);
+
+        $this->service->refreshArchives($channel1);
+
+        // チャンネル2の報告は残っていることを確認
+        $this->assertDatabaseHas('timestamp_reports', [
+            'id' => $report2->id,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- 報告機能をts_item_idから複合キー(video_id+ts_text+ts_num)に変更
- アーカイブ更新時に報告が消える問題を修正
- 対応するts_itemが存在しなくなった報告のクリーンアップ処理を追加
- N+1クエリ問題を修正

## 変更詳細
### スキーマ変更
- `timestamp_reports`テーブルから`ts_item_id`を削除
- `video_id`、`ts_text`、`ts_num`の複合キーで紐付け

### バックエンド修正
- `TimestampReport`モデル: `belongsTo`リレーションを削除し、アクセサのみに変更
- `TimestampReportController`: N+1回避の一括取得処理を追加
- `RefreshArchiveService`: 不要な報告のクリーンアップ処理を追加
- `TimestampService`: 複合キーJOINで報告IDを取得

### フロントエンド修正
- 報告作成時に`ts_text`と`ts_num`を送信

## Test plan
- [x] 全268テスト通過
- [x] 報告作成が正しく動作する
- [x] アーカイブ更新後も報告が維持される
- [x] ts_itemが削除された場合に報告もクリーンアップされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)