### PR TITLE
feat: チャンネル管理画面にタイムスタンプの紐づけ状態を表示

### DIFF
--- a/app/Http/Controllers/ManageController.php
+++ b/app/Http/Controllers/ManageController.php
@@ -10,6 +10,7 @@ use App\Jobs\RefreshChannelArchivesJob;
 use App\Models\Archive;
 use App\Models\ChangeList;
 use App\Models\Channel;
+use App\Models\TimestampSongMapping;
 use App\Models\TsItem;
 use App\Services\GetArchiveService;
 use App\Services\ImageService;
@@ -141,7 +142,85 @@ class ManageController extends Controller
         )
             ->appends($request->query());
 
+        // ts_itemsのマッピング状態を付加
+        $this->appendMappingStatus($archives);
+
         return response()->json($archives);
+    }
+
+    /**
+     * アーカイブ一覧のts_itemsにマッピング状態を付加
+     */
+    private function appendMappingStatus($archives): void
+    {
+        // 全ts_itemsのnormalized_textを収集
+        $normalizedTexts = collect();
+        foreach ($archives->items() as $archive) {
+            foreach ($archive->tsItems as $tsItem) {
+                if ($tsItem->normalized_text) {
+                    $normalizedTexts->push($tsItem->normalized_text);
+                }
+            }
+        }
+
+        if ($normalizedTexts->isEmpty()) {
+            return;
+        }
+
+        // マッピング情報を一括取得
+        $mappings = TimestampSongMapping::with('song')
+            ->whereIn('normalized_text', $normalizedTexts->unique())
+            ->get()
+            ->keyBy('normalized_text');
+
+        // 各ts_itemにマッピング情報を付加
+        foreach ($archives->items() as $archive) {
+            foreach ($archive->tsItems as $tsItem) {
+                $mapping = $mappings->get($tsItem->normalized_text);
+                $tsItem->mapping_status = $this->getMappingStatus($mapping);
+            }
+        }
+    }
+
+    /**
+     * マッピング状態を判定して返す
+     *
+     * @return array{status: string, label: string, song_info: string|null}
+     */
+    private function getMappingStatus($mapping): array
+    {
+        if (! $mapping) {
+            return [
+                'status' => 'unlinked',
+                'label' => '未紐付',
+                'song_info' => null,
+            ];
+        }
+
+        if ($mapping->is_not_song) {
+            return [
+                'status' => 'not_song',
+                'label' => '楽曲ではない',
+                'song_info' => null,
+            ];
+        }
+
+        if ($mapping->song) {
+            $prefix = $mapping->is_manual ? '' : '[自動] ';
+            $songInfo = $prefix.$mapping->song->title.' / '.$mapping->song->artist;
+
+            return [
+                'status' => $mapping->is_manual ? 'linked' : 'auto_linked',
+                'label' => '紐付済',
+                'song_info' => $songInfo,
+            ];
+        }
+
+        return [
+            'status' => 'unlinked',
+            'label' => '未紐付',
+            'song_info' => null,
+        ];
     }
 
     public function addArchives(Request $request)

--- a/resources/js/manage/archives.js
+++ b/resources/js/manage/archives.js
@@ -526,6 +526,9 @@ function getTsItems(tsItems) {
     let html = '';
     let lastCommentId = '';
     tsItems.forEach(tsItem => {
+        // マッピング状態に応じたスタイルとテキストを決定
+        const mappingStatus = getMappingStatusDisplay(tsItem.mapping_status);
+
         html += `
                 <div class="timestamp text-sm ${tsItem.is_display ? 'text-gray-700 is-display default-display' : 'text-gray-500 pl-4 bg-gray-200'}
                     ${lastCommentId != tsItem.comment_id && lastCommentId != '' ? 'mt-2' : ''}" data-key="${tsItem.id}" data-comment="${tsItem.comment_id}">
@@ -537,11 +540,33 @@ function getTsItems(tsItems) {
                         ${tsItem.ts_text || '0:00:00'}
                     </span>
                     <span class="ml-2">${escapeHTML(tsItem.text || '')}</span>
+                    <span class="ml-2 text-xs ${mappingStatus.class}" title="${escapeHTML(mappingStatus.title)}">${escapeHTML(mappingStatus.text)}</span>
                 </div>
         `;
         lastCommentId = tsItem.comment_id;
     });
     return html;
+}
+
+/**
+ * マッピング状態に応じた表示情報を返す
+ */
+function getMappingStatusDisplay(mappingStatus) {
+    if (!mappingStatus) {
+        return { class: 'text-gray-400', text: '[未紐付]', title: '未紐付' };
+    }
+
+    switch (mappingStatus.status) {
+        case 'not_song':
+            return { class: 'text-red-500 font-semibold', text: '[楽曲ではない]', title: '楽曲ではない' };
+        case 'linked':
+            return { class: 'text-green-600', text: '[紐付済]', title: mappingStatus.song_info || '紐付済' };
+        case 'auto_linked':
+            return { class: 'text-yellow-600', text: '[自動]', title: mappingStatus.song_info || '自動紐付' };
+        case 'unlinked':
+        default:
+            return { class: 'text-gray-400', text: '[未紐付]', title: '未紐付' };
+    }
 }
 
 // ページネーション関連を追加する


### PR DESCRIPTION
## Summary
- チャンネル管理画面の各タイムスタンプに紐づけ状態を表示
- ホバーで楽曲情報（曲名/アーティスト）を確認可能

## 表示状態
- **[未紐付]**: グレー - まだ楽曲と紐付けられていない
- **[紐付済]**: 緑 - 手動で楽曲と紐付け済み
- **[自動]**: 黄色 - 自動紐付け機能で紐付けられた
- **[楽曲ではない]**: 赤 - 楽曲ではないとマークされた

## 変更ファイル
- `app/Http/Controllers/ManageController.php`: マッピング状態取得処理を追加
- `resources/js/manage/archives.js`: マッピング状態表示処理を追加

## Test plan
- [x] 全268テスト通過
- [x] 各状態が正しく表示される
- [x] ホバーで楽曲情報が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)