### PR TITLE
fix: TextNormalizerでゼロ幅スペースなどの不可視文字を除去

### DIFF
--- a/app/Helpers/TextNormalizer.php
+++ b/app/Helpers/TextNormalizer.php
@@ -36,6 +36,13 @@ class TextNormalizer
         // 連続する区切り文字を1つに
         $text = preg_replace('/\/+/', '/', $text);
 
+        // ゼロ幅スペースなどの不可視文字を除去
+        // U+200B: Zero Width Space
+        // U+200C: Zero Width Non-Joiner
+        // U+200D: Zero Width Joiner
+        // U+FEFF: Byte Order Mark (BOM)
+        $text = preg_replace('/[\x{200B}-\x{200D}\x{FEFF}]/u', '', $text);
+
         // 全角スペース・タブなどを半角スペースに統一
         $text = preg_replace('/[\s\x{3000}]+/u', ' ', $text);
 
@@ -57,13 +64,16 @@ class TextNormalizer
     }
 
     /**
-     * 先頭の全角スペース（および半角スペース）を除外
+     * 先頭の全角スペース（および半角スペース）を除外し、不可視文字を除去
      */
     public static function trimFullwidthSpace(?string $text): string
     {
         if (empty($text)) {
             return '';
         }
+
+        // ゼロ幅スペースなどの不可視文字を除去
+        $text = preg_replace('/[\x{200B}-\x{200D}\x{FEFF}]/u', '', $text);
 
         // 先頭の全角スペース（U+3000）と半角スペース、その他の空白文字を除去
         return preg_replace('/^[\s\x{3000}]+/u', '', $text);

--- a/database/migrations/2025_12_13_020101_fix_zero_width_space_in_normalized_text.php
+++ b/database/migrations/2025_12_13_020101_fix_zero_width_space_in_normalized_text.php
@@ -1,0 +1,225 @@
+<?php
+
+use App\Helpers\TextNormalizer;
+use App\Models\TimestampSongMapping;
+use App\Models\TsItem;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+return new class extends Migration
+{
+    /**
+     * ゼロ幅スペースのPHP正規表現パターン（U+200B, U+200C, U+200D, U+FEFF）
+     */
+    private string $zeroWidthPattern = '/[\x{200B}-\x{200D}\x{FEFF}]/u';
+
+    /**
+     * Run the migrations.
+     *
+     * ゼロ幅スペースなどの不可視文字を除去し、重複マッピングを統合
+     */
+    public function up(): void
+    {
+        $this->fixTsItems();
+        $this->fixTimestampSongMappings();
+    }
+
+    /**
+     * ts_items の text と normalized_text を修正
+     */
+    private function fixTsItems(): void
+    {
+        $driver = DB::getDriverName();
+
+        $query = TsItem::query();
+
+        if ($driver === 'sqlite') {
+            // SQLite: LIKEで検索（4種類全ての不可視文字を検索）
+            $query->where(function ($q) {
+                $q->where('text', 'LIKE', '%'."\xE2\x80\x8B".'%')      // U+200B
+                    ->orWhere('text', 'LIKE', '%'."\xE2\x80\x8C".'%')  // U+200C
+                    ->orWhere('text', 'LIKE', '%'."\xE2\x80\x8D".'%')  // U+200D
+                    ->orWhere('text', 'LIKE', '%'."\xEF\xBB\xBF".'%')  // U+FEFF
+                    ->orWhere('normalized_text', 'LIKE', '%'."\xE2\x80\x8B".'%')
+                    ->orWhere('normalized_text', 'LIKE', '%'."\xE2\x80\x8C".'%')
+                    ->orWhere('normalized_text', 'LIKE', '%'."\xE2\x80\x8D".'%')
+                    ->orWhere('normalized_text', 'LIKE', '%'."\xEF\xBB\xBF".'%');
+            });
+        } else {
+            // MySQL/MariaDB: BINARY LIKEで検索（REGEXPよりも確実）
+            $query->whereRaw("
+                CAST(text AS BINARY) LIKE CONCAT('%', UNHEX('E2808B'), '%')
+                OR CAST(text AS BINARY) LIKE CONCAT('%', UNHEX('E2808C'), '%')
+                OR CAST(text AS BINARY) LIKE CONCAT('%', UNHEX('E2808D'), '%')
+                OR CAST(text AS BINARY) LIKE CONCAT('%', UNHEX('EFBBBF'), '%')
+                OR CAST(normalized_text AS BINARY) LIKE CONCAT('%', UNHEX('E2808B'), '%')
+                OR CAST(normalized_text AS BINARY) LIKE CONCAT('%', UNHEX('E2808C'), '%')
+                OR CAST(normalized_text AS BINARY) LIKE CONCAT('%', UNHEX('E2808D'), '%')
+                OR CAST(normalized_text AS BINARY) LIKE CONCAT('%', UNHEX('EFBBBF'), '%')
+            ");
+        }
+
+        // メモリ効率のためchunkで処理
+        $query->chunk(100, function ($tsItems) {
+            foreach ($tsItems as $tsItem) {
+                $this->processTsItem($tsItem);
+            }
+        });
+    }
+
+    /**
+     * 個別のts_itemを処理
+     */
+    private function processTsItem(TsItem $tsItem): void
+    {
+        $originalText = $tsItem->text;
+        $originalNormalized = $tsItem->normalized_text;
+
+        $newText = preg_replace($this->zeroWidthPattern, '', $tsItem->text);
+        $newNormalized = TextNormalizer::normalize($newText);
+
+        if ($originalText === $newText && $originalNormalized === $newNormalized) {
+            return;
+        }
+
+        // イベントを発火させずに直接更新（saving イベントとの競合を回避）
+        DB::table('ts_items')
+            ->where('id', $tsItem->id)
+            ->update([
+                'text' => $newText,
+                'normalized_text' => $newNormalized,
+                'updated_at' => now(),
+            ]);
+
+        Log::info('[Migration] Fixed ts_item', [
+            'id' => $tsItem->id,
+            'original_text' => $originalText,
+            'new_text' => $newText,
+        ]);
+    }
+
+    /**
+     * timestamp_song_mappings の normalized_text を修正し、重複を統合
+     */
+    private function fixTimestampSongMappings(): void
+    {
+        $driver = DB::getDriverName();
+
+        $query = TimestampSongMapping::query();
+
+        if ($driver === 'sqlite') {
+            // SQLite: LIKEで検索（4種類全ての不可視文字を検索）
+            $query->where(function ($q) {
+                $q->where('normalized_text', 'LIKE', '%'."\xE2\x80\x8B".'%')      // U+200B
+                    ->orWhere('normalized_text', 'LIKE', '%'."\xE2\x80\x8C".'%')  // U+200C
+                    ->orWhere('normalized_text', 'LIKE', '%'."\xE2\x80\x8D".'%')  // U+200D
+                    ->orWhere('normalized_text', 'LIKE', '%'."\xEF\xBB\xBF".'%'); // U+FEFF
+            });
+        } else {
+            $query->whereRaw("
+                CAST(normalized_text AS BINARY) LIKE CONCAT('%', UNHEX('E2808B'), '%')
+                OR CAST(normalized_text AS BINARY) LIKE CONCAT('%', UNHEX('E2808C'), '%')
+                OR CAST(normalized_text AS BINARY) LIKE CONCAT('%', UNHEX('E2808D'), '%')
+                OR CAST(normalized_text AS BINARY) LIKE CONCAT('%', UNHEX('EFBBBF'), '%')
+            ");
+        }
+
+        // chunk内で削除が発生するため、IDを先に取得
+        $mappingIds = $query->pluck('id')->toArray();
+
+        foreach ($mappingIds as $mappingId) {
+            $mapping = TimestampSongMapping::find($mappingId);
+            if ($mapping) {
+                $this->processMapping($mapping);
+            }
+        }
+    }
+
+    /**
+     * 個別のマッピングを処理
+     */
+    private function processMapping(TimestampSongMapping $mapping): void
+    {
+        $originalNormalized = $mapping->normalized_text;
+        $newNormalized = preg_replace($this->zeroWidthPattern, '', $mapping->normalized_text);
+        $newNormalized = TextNormalizer::normalize($newNormalized);
+
+        if ($originalNormalized === $newNormalized) {
+            return;
+        }
+
+        // 同じ normalized_text のマッピングが既に存在するか確認（自分自身を除外）
+        $existingMapping = TimestampSongMapping::where('normalized_text', $newNormalized)
+            ->where('id', '!=', $mapping->id)
+            ->first();
+
+        if ($existingMapping) {
+            $this->mergeMappings($mapping, $existingMapping, $originalNormalized, $newNormalized);
+        } else {
+            // 既存がない場合は更新
+            $mapping->normalized_text = $newNormalized;
+            $mapping->saveQuietly();
+
+            Log::info('[Migration] Updated mapping', [
+                'id' => $mapping->id,
+                'original_normalized' => $originalNormalized,
+                'new_normalized' => $newNormalized,
+            ]);
+        }
+    }
+
+    /**
+     * 2つのマッピングを統合
+     */
+    private function mergeMappings(
+        TimestampSongMapping $mapping,
+        TimestampSongMapping $existingMapping,
+        string $originalNormalized,
+        string $newNormalized
+    ): void {
+        // 手動マッピングを優先して統合
+        // 優先順位: 手動 > 自動、同じ場合は信頼度が高い方を優先
+        $shouldUpdateExisting = false;
+
+        if ($mapping->is_manual && ! $existingMapping->is_manual) {
+            // 現在のマッピングが手動で、既存が自動の場合
+            $shouldUpdateExisting = true;
+        } elseif ($mapping->is_manual === $existingMapping->is_manual) {
+            // 両方とも手動、または両方とも自動の場合は信頼度で判断
+            if (($mapping->confidence ?? 0) > ($existingMapping->confidence ?? 0)) {
+                $shouldUpdateExisting = true;
+            }
+        }
+        // else: 既存が手動で現在が自動の場合は既存を保持
+
+        if ($shouldUpdateExisting) {
+            $existingMapping->update([
+                'song_id' => $mapping->song_id,
+                'is_manual' => $mapping->is_manual,
+                'is_not_song' => $mapping->is_not_song,
+                'confidence' => $mapping->confidence,
+            ]);
+        }
+
+        // 古いマッピングを削除
+        $mapping->delete();
+
+        Log::info('[Migration] Merged mapping', [
+            'deleted_id' => $mapping->id,
+            'merged_into_id' => $existingMapping->id,
+            'original_normalized' => $originalNormalized,
+            'new_normalized' => $newNormalized,
+            'updated_existing' => $shouldUpdateExisting,
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // データ変更のため、ロールバックは対応しない
+        Log::warning('[Migration] Rollback not supported for zero-width space fix');
+    }
+};

--- a/tests/Unit/Helpers/TextNormalizerTest.php
+++ b/tests/Unit/Helpers/TextNormalizerTest.php
@@ -116,6 +116,48 @@ class TextNormalizerTest extends TestCase
     }
 
     /**
+     * ゼロ幅スペースなどの不可視文字が除去されることをテスト
+     */
+    public function test_zero_width_character_removal(): void
+    {
+        // U+200B: Zero Width Space
+        $this->assertEquals('testvalue', TextNormalizer::normalize("test\u{200B}value"));
+
+        // U+200C: Zero Width Non-Joiner
+        $this->assertEquals('testvalue', TextNormalizer::normalize("test\u{200C}value"));
+
+        // U+200D: Zero Width Joiner
+        $this->assertEquals('testvalue', TextNormalizer::normalize("test\u{200D}value"));
+
+        // U+FEFF: BOM
+        $this->assertEquals('testvalue', TextNormalizer::normalize("\u{FEFF}testvalue"));
+
+        // 複数の不可視文字が混在
+        $this->assertEquals('abc def', TextNormalizer::normalize("a\u{200B}bc\u{200C} \u{200D}def"));
+
+        // 先頭にゼロ幅スペースがある実際のケース
+        $this->assertEquals('天野由梨 魂の扉', TextNormalizer::normalize("\u{200B} 天野由梨 魂の扉"));
+    }
+
+    /**
+     * trimFullwidthSpace で不可視文字が除去されることをテスト
+     */
+    public function test_trim_fullwidth_space_removes_zero_width_characters(): void
+    {
+        // 先頭のゼロ幅スペース
+        $this->assertEquals('test', TextNormalizer::trimFullwidthSpace("\u{200B}test"));
+
+        // 全角スペースとゼロ幅スペースの組み合わせ
+        $this->assertEquals('test', TextNormalizer::trimFullwidthSpace("　\u{200B}test"));
+
+        // 中間にあるゼロ幅スペース
+        $this->assertEquals('test value', TextNormalizer::trimFullwidthSpace("\u{200B}test\u{200B} value"));
+
+        // BOM
+        $this->assertEquals('test', TextNormalizer::trimFullwidthSpace("\u{FEFF}test"));
+    }
+
+    /**
      * エッジケースのテスト
      */
     public function test_edge_cases(): void


### PR DESCRIPTION
## Summary
- タイムスタンプ正規化画面で「確定」ボタンを押すと404エラーが発生する問題を修正
- `TextNormalizer` でゼロ幅スペース（U+200B等）を除去するように修正
- 既存データを修正するマイグレーションを追加

## 問題の詳細
- `ts_items.normalized_text` にゼロ幅スペースが含まれていたが、フロントエンドからバックエンドに送信される際に除去されていた
- その結果、`timestamp_song_mappings` テーブルで対応するマッピングが見つからず404エラーが発生

## 変更内容
- `TextNormalizer::normalize()` にゼロ幅スペース除去処理を追加
- `TextNormalizer::trimFullwidthSpace()` にも同様の処理を追加
- 既存データを修正するマイグレーションを追加
  - `ts_items.text`, `ts_items.normalized_text` からゼロ幅スペースを除去
  - `timestamp_song_mappings` の重複マッピングを統合（手動紐付けを優先）
- ゼロ幅スペース除去のテストケースを追加

## Test plan
- [x] `TextNormalizerTest` でゼロ幅スペース除去のテストが通ること
- [ ] 本番環境でマイグレーションを実行
- [ ] 「確定」ボタンが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)