### PR TITLE
feat: タイムスタンプ正規化画面で選択時に紐づき楽曲情報を表示

### DIFF
--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -312,6 +312,10 @@ class TimestampNormalization {
             // 履歴に追加
             this.addToHistory('confirm_auto_link', [ts], ts.song);
 
+            // 選択を解除
+            this.selectedTimestamps = [];
+            this.updateSelectionDisplay();
+
             this.loadTimestamps(this.currentPage, this.currentSearchQuery);
         } catch (error) {
             console.error('確定エラー:', error);

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -373,25 +373,31 @@ class TimestampNormalization {
         const countSpan = document.getElementById('selectedCount');
         const textSpan = document.getElementById('selectedText');
         const normalizedSpan = document.getElementById('selectedNormalized');
+        const linkedSongSpan = document.getElementById('selectedLinkedSong');
+        const confirmBtn = document.getElementById('selectedConfirmBtn');
 
         container.classList.remove('hidden');
 
         if (this.selectedTimestamps.length === 0) {
-            this.displayNoSelection(countSpan, textSpan, normalizedSpan);
+            this.displayNoSelection(countSpan, textSpan, normalizedSpan, linkedSongSpan, confirmBtn);
         } else if (this.selectedTimestamps.length === 1) {
-            this.displaySingleSelection(countSpan, textSpan, normalizedSpan);
+            this.displaySingleSelection(countSpan, textSpan, normalizedSpan, linkedSongSpan, confirmBtn);
         } else {
-            this.displayMultipleSelection(countSpan, textSpan, normalizedSpan);
+            this.displayMultipleSelection(countSpan, textSpan, normalizedSpan, linkedSongSpan, confirmBtn);
         }
 
         this.updateSpotifySelectedDisplay();
         document.getElementById('linkSongBtn').disabled = !(this.selectedTimestamps.length > 0 && this.selectedSong);
     }
 
-    displayNoSelection(countSpan, textSpan, normalizedSpan) {
+    displayNoSelection(countSpan, textSpan, normalizedSpan, linkedSongSpan, confirmBtn) {
         countSpan.textContent = '未選択';
         textSpan.textContent = 'タイムスタンプを選択してください';
         normalizedSpan.textContent = '';
+        linkedSongSpan.textContent = '';
+        linkedSongSpan.classList.add('hidden');
+        confirmBtn.classList.add('hidden');
+        confirmBtn.onclick = null;
         document.getElementById('linkSongBtn').disabled = true;
         document.getElementById('markAsNotSongBtn').disabled = true;
         document.getElementById('unmarkAsNotSongBtn').disabled = true;
@@ -399,12 +405,44 @@ class TimestampNormalization {
         this.updateVideoButton(false);
     }
 
-    displaySingleSelection(countSpan, textSpan, normalizedSpan) {
+    displaySingleSelection(countSpan, textSpan, normalizedSpan, linkedSongSpan, confirmBtn) {
         const ts = this.selectedTimestamps[0];
         countSpan.textContent = '1件選択中';
         textSpan.textContent = ts.text;
         textSpan.title = ts.text;
         normalizedSpan.textContent = `正規化: ${ts.normalized_text}`;
+
+        // 紐づいている楽曲情報を表示
+        if (ts.is_not_song) {
+            linkedSongSpan.textContent = '楽曲ではない';
+            linkedSongSpan.className = 'text-xs break-words text-red-600 dark:text-red-400';
+            linkedSongSpan.classList.remove('hidden');
+            confirmBtn.classList.add('hidden');
+            confirmBtn.onclick = null;
+        } else if (ts.song) {
+            const isAutoLinked = ts.is_manual === false;
+            const prefix = isAutoLinked ? '[自動] ' : '';
+            linkedSongSpan.textContent = `紐づき: ${prefix}${ts.song.title} / ${ts.song.artist}`;
+            linkedSongSpan.className = isAutoLinked
+                ? 'text-xs break-words text-yellow-600 dark:text-yellow-400'
+                : 'text-xs break-words text-green-600 dark:text-green-400';
+            linkedSongSpan.classList.remove('hidden');
+
+            // 自動紐付けの場合は確定ボタンを表示
+            if (isAutoLinked) {
+                confirmBtn.classList.remove('hidden');
+                confirmBtn.onclick = () => this.confirmAutoLink(ts);
+            } else {
+                confirmBtn.classList.add('hidden');
+                confirmBtn.onclick = null;
+            }
+        } else {
+            linkedSongSpan.textContent = '';
+            linkedSongSpan.classList.add('hidden');
+            confirmBtn.classList.add('hidden');
+            confirmBtn.onclick = null;
+        }
+
         document.getElementById('markAsNotSongBtn').disabled = false;
         document.getElementById('unmarkAsNotSongBtn').disabled = !ts.is_not_song;
         document.getElementById('unlinkBtn').disabled = !ts.mapping;
@@ -416,7 +454,7 @@ class TimestampNormalization {
         }
     }
 
-    displayMultipleSelection(countSpan, textSpan, normalizedSpan) {
+    displayMultipleSelection(countSpan, textSpan, normalizedSpan, linkedSongSpan, confirmBtn) {
         countSpan.textContent = `${this.selectedTimestamps.length}件選択中`;
         const joinedText = this.selectedTimestamps.map(t => t.text).join(', ');
 
@@ -427,6 +465,10 @@ class TimestampNormalization {
         }
         textSpan.title = joinedText;
         normalizedSpan.textContent = '';
+        linkedSongSpan.textContent = '';
+        linkedSongSpan.classList.add('hidden');
+        confirmBtn.classList.add('hidden');
+        confirmBtn.onclick = null;
         document.getElementById('markAsNotSongBtn').disabled = false;
 
         const hasNotSong = this.selectedTimestamps.some(ts => ts.is_not_song);

--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -94,6 +94,12 @@
                             </div>
                             <div id="selectedText" class="font-medium break-words overflow-hidden" style="word-break: break-word; overflow-wrap: break-word;">タイムスタンプを選択してください</div>
                             <div id="selectedNormalized" class="text-xs text-gray-500 dark:text-gray-400 mt-1 break-words" style="word-break: break-word; overflow-wrap: break-word;"></div>
+                            <div id="selectedLinkedSongContainer" class="flex items-center gap-2 mt-1">
+                                <div id="selectedLinkedSong" class="text-xs break-words hidden" style="word-break: break-word; overflow-wrap: break-word;"></div>
+                                <button id="selectedConfirmBtn" class="px-2 py-1 text-xs bg-yellow-500 hover:bg-yellow-600 text-white rounded transition-colors hidden flex-shrink-0">
+                                    確定
+                                </button>
+                            </div>
                         </div>
 
                         <!-- Spotify選択楽曲情報表示 -->


### PR DESCRIPTION
## Summary
- タイムスタンプを選択した際に、紐づいている楽曲情報を表示する機能を追加
- 自動紐付けの場合は「確定」ボタンを表示し、ワンクリックで手動紐付けに変更可能

## 変更内容
### 表示パターン
- **楽曲ではない**: 赤色で「楽曲ではない」と表示
- **自動紐付け**: 黄色で「[自動] 曲名 / アーティスト」と表示 + 確定ボタン
- **手動紐付け**: 緑色で「紐づき: 曲名 / アーティスト」と表示
- **未紐付け**: 非表示

### 変更ファイル
- `resources/js/songs/normalize.js` - 紐づき情報表示ロジック追加
- `resources/views/songs/index.blade.php` - 表示用HTML要素追加

## Test plan
- [x] 全テスト（270件）がパス
- [x] XSS脆弱性なし（textContentを使用）
- [x] コードレビュー完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)