### PR TITLE
feat: 楽曲マスタにYouTube URL・動画秒数を追加

### DIFF
--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -15,6 +15,7 @@ use App\Models\TsItem;
 use App\Services\SongMappingService;
 use App\Services\SongSearchService;
 use App\Services\SpotifyService;
+use App\Services\YouTubeApiService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -26,14 +27,18 @@ class SongController extends Controller
 
     protected SpotifyService $spotifyService;
 
+    protected YouTubeApiService $youtubeApiService;
+
     public function __construct(
         SongSearchService $songSearchService,
         SongMappingService $songMappingService,
-        SpotifyService $spotifyService
+        SpotifyService $spotifyService,
+        YouTubeApiService $youtubeApiService
     ) {
         $this->songSearchService = $songSearchService;
         $this->songMappingService = $songMappingService;
         $this->spotifyService = $spotifyService;
+        $this->youtubeApiService = $youtubeApiService;
     }
 
     /**
@@ -460,5 +465,63 @@ class SongController extends Controller
         $song->delete();
 
         return response()->json(['message' => '楽曲マスタを削除しました。']);
+    }
+
+    /**
+     * 楽曲マスタを更新
+     */
+    public function updateSong(Request $request, $id)
+    {
+        $validated = $request->validate([
+            'title' => 'sometimes|required|string|max:255',
+            'artist' => 'sometimes|required|string|max:255',
+            'youtube_url' => 'nullable|string|max:255',
+            'duration_ms' => 'nullable|integer|min:0',
+        ]);
+
+        $song = Song::findOrFail($id);
+        $song->update($validated);
+
+        return response()->json([
+            'message' => '楽曲マスタを更新しました。',
+            'song' => $song,
+        ]);
+    }
+
+    /**
+     * YouTube URLから動画の長さを取得
+     */
+    public function fetchYoutubeDuration(Request $request)
+    {
+        $validated = $request->validate([
+            'youtube_url' => 'required|string|max:255',
+        ]);
+
+        $videoId = $this->youtubeApiService->extractVideoId($validated['youtube_url']);
+
+        if (! $videoId) {
+            return response()->json([
+                'error' => '有効なYouTube URLではありません。',
+            ], 422);
+        }
+
+        try {
+            $durationMs = $this->youtubeApiService->getVideoDuration($videoId);
+
+            if ($durationMs === null) {
+                return response()->json([
+                    'error' => '動画情報を取得できませんでした。動画が存在しないか、非公開の可能性があります。',
+                ], 404);
+            }
+
+            return response()->json([
+                'duration_ms' => $durationMs,
+                'video_id' => $videoId,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'error' => $e->getMessage(),
+            ], 500);
+        }
     }
 }

--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -475,8 +475,8 @@ class SongController extends Controller
         $validated = $request->validate([
             'title' => 'sometimes|required|string|max:255',
             'artist' => 'sometimes|required|string|max:255',
-            'youtube_url' => 'nullable|string|max:255',
-            'duration_ms' => 'nullable|integer|min:0',
+            'youtube_url' => 'nullable|url|max:255',
+            'duration_ms' => 'nullable|integer|min:0|max:86400000', // 最大24時間
         ]);
 
         $song = Song::findOrFail($id);

--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -519,8 +519,12 @@ class SongController extends Controller
                 'video_id' => $videoId,
             ]);
         } catch (\Exception $e) {
+            $message = app()->environment('production')
+                ? '動画情報の取得に失敗しました。'
+                : $e->getMessage();
+
             return response()->json([
-                'error' => $e->getMessage(),
+                'error' => $message,
             ], 500);
         }
     }

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -20,6 +20,8 @@ class Song extends Model
         'artist',
         'spotify_track_id',
         'spotify_data',
+        'youtube_url',
+        'duration_ms',
         'normalized_title',
         'normalized_artist',
     ];

--- a/app/Services/YouTubeApiService.php
+++ b/app/Services/YouTubeApiService.php
@@ -342,13 +342,13 @@ class YouTubeApiService
      * ISO 8601形式の期間をミリ秒に変換
      *
      * @param  string  $duration  ISO 8601形式の期間（例: "PT1H2M3S"）
-     * @return int ミリ秒
+     * @return int|null ミリ秒、パース失敗時はnull
      */
-    protected function parseDuration(string $duration): int
+    protected function parseDuration(string $duration): ?int
     {
         try {
             $interval = new \DateInterval($duration);
-            $seconds = ($interval->h * 3600) + ($interval->i * 60) + $interval->s;
+            $seconds = ($interval->d * 86400) + ($interval->h * 3600) + ($interval->i * 60) + $interval->s;
 
             return $seconds * 1000; // ミリ秒に変換
         } catch (\Exception $e) {
@@ -357,7 +357,7 @@ class YouTubeApiService
                 'error' => $e->getMessage(),
             ]);
 
-            return 0;
+            return null;
         }
     }
 }

--- a/app/Services/YouTubeApiService.php
+++ b/app/Services/YouTubeApiService.php
@@ -285,4 +285,79 @@ class YouTubeApiService
 
         return $comments;
     }
+
+    /**
+     * YouTubeのURLからVideo IDを抽出
+     *
+     * @param  string  $url  YouTube URL
+     * @return string|null Video ID、抽出できない場合null
+     */
+    public function extractVideoId(string $url): ?string
+    {
+        // 対応フォーマット:
+        // https://www.youtube.com/watch?v=VIDEO_ID
+        // https://youtu.be/VIDEO_ID
+        // https://www.youtube.com/embed/VIDEO_ID
+        // https://www.youtube.com/v/VIDEO_ID
+        $pattern = '/(?:youtube\.com\/(?:watch\?v=|embed\/|v\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/';
+
+        if (preg_match($pattern, $url, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * 動画IDから動画の長さ（ミリ秒）を取得
+     *
+     * @param  string  $videoId  動画ID
+     * @return int|null 動画の長さ（ミリ秒）、取得できない場合null
+     *
+     * @throws Exception API quota超過またはレート制限時
+     */
+    public function getVideoDuration(string $videoId): ?int
+    {
+        $this->setApiKey();
+
+        try {
+            $response = $this->youtube->videos->listVideos('contentDetails', [
+                'id' => $videoId,
+            ]);
+        } catch (Exception $e) {
+            $this->handleApiError($e, 'getVideoDuration', ['video_id' => $videoId]);
+        }
+
+        if (count($response->getItems()) > 0) {
+            $contentDetails = $response->getItems()[0]->getContentDetails();
+            $duration = $contentDetails->getDuration(); // ISO 8601形式: "PT1H2M3S"
+
+            return $this->parseDuration($duration);
+        }
+
+        return null;
+    }
+
+    /**
+     * ISO 8601形式の期間をミリ秒に変換
+     *
+     * @param  string  $duration  ISO 8601形式の期間（例: "PT1H2M3S"）
+     * @return int ミリ秒
+     */
+    protected function parseDuration(string $duration): int
+    {
+        try {
+            $interval = new \DateInterval($duration);
+            $seconds = ($interval->h * 3600) + ($interval->i * 60) + $interval->s;
+
+            return $seconds * 1000; // ミリ秒に変換
+        } catch (\Exception $e) {
+            Log::warning('Failed to parse duration', [
+                'duration' => $duration,
+                'error' => $e->getMessage(),
+            ]);
+
+            return 0;
+        }
+    }
 }

--- a/database/migrations/2025_12_15_012311_add_youtube_columns_to_songs_table.php
+++ b/database/migrations/2025_12_15_012311_add_youtube_columns_to_songs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->string('youtube_url', 255)->nullable()->after('spotify_data');
+            $table->unsignedInteger('duration_ms')->nullable()->after('youtube_url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->dropColumn(['youtube_url', 'duration_ms']);
+        });
+    }
+};

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -109,6 +109,25 @@ class TimestampNormalization {
         document.getElementById('unmarkAsNotSongBtn').addEventListener('click', () => this.unmarkAsNotSong());
         document.getElementById('unlinkBtn').addEventListener('click', () => this.unlinkTimestamps());
         document.getElementById('clearSelectionBtn').addEventListener('click', () => this.clearSelection());
+
+        // 編集モーダル
+        document.getElementById('closeEditModalBtn').addEventListener('click', () => this.closeEditModal());
+        document.getElementById('cancelEditBtn').addEventListener('click', () => this.closeEditModal());
+        document.getElementById('editSongForm').addEventListener('submit', (e) => {
+            e.preventDefault();
+            this.updateSong();
+        });
+        document.getElementById('fetchDurationBtn').addEventListener('click', () => this.fetchYoutubeDuration());
+        document.getElementById('editSongDurationMs').addEventListener('input', (e) => {
+            this.updateDurationDisplay(e.target.value);
+        });
+
+        // モーダル外クリックで閉じる
+        document.getElementById('editSongModal').addEventListener('click', (e) => {
+            if (e.target.id === 'editSongModal') {
+                this.closeEditModal();
+            }
+        });
     }
 
     setFilter(filter) {
@@ -540,13 +559,19 @@ class TimestampNormalization {
     async createSong() {
         const title = document.getElementById('songTitle').value.trim();
         const artist = document.getElementById('songArtist').value.trim();
+        const youtubeUrl = document.getElementById('songYoutubeUrl')?.value.trim() || '';
 
         if (!title || !artist) {
             toast.warning('楽曲名とアーティスト名を入力してください。');
             return;
         }
 
-        await this.registerSong({ title, artist });
+        const songData = { title, artist };
+        if (youtubeUrl) {
+            songData.youtube_url = youtubeUrl;
+        }
+
+        await this.registerSong(songData);
     }
 
     async registerSong(songData, options = {}) {
@@ -671,7 +696,7 @@ class TimestampNormalization {
         }`;
 
         const contentDiv = document.createElement('div');
-        contentDiv.className = 'flex-1';
+        contentDiv.className = 'flex-1 min-w-0';
 
         const songInfo = document.createElement('div');
         songInfo.className = 'text-sm truncate';
@@ -690,9 +715,30 @@ class TimestampNormalization {
 
         contentDiv.appendChild(songInfo);
 
+        // 楽曲の長さを表示（ある場合）
+        if (song.duration_ms) {
+            const durationSpan = document.createElement('span');
+            durationSpan.className = 'text-xs text-gray-400 dark:text-gray-500 ml-2';
+            durationSpan.textContent = this.formatDuration(song.duration_ms);
+            songInfo.appendChild(durationSpan);
+        }
+
+        // ボタンコンテナ
+        const buttonContainer = document.createElement('div');
+        buttonContainer.className = 'flex items-center gap-1 flex-shrink-0 ml-2';
+
+        // 編集ボタン
+        const editBtn = document.createElement('button');
+        editBtn.className = 'px-2 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700';
+        editBtn.textContent = '編集';
+        editBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.openEditModal(song);
+        });
+
         // 削除ボタン
         const deleteBtn = document.createElement('button');
-        deleteBtn.className = 'px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700 flex-shrink-0 ml-2';
+        deleteBtn.className = 'px-2 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700';
         deleteBtn.textContent = '削除';
         deleteBtn.addEventListener('click', async (e) => {
             e.stopPropagation();
@@ -701,8 +747,11 @@ class TimestampNormalization {
             }
         });
 
+        buttonContainer.appendChild(editBtn);
+        buttonContainer.appendChild(deleteBtn);
+
         div.appendChild(contentDiv);
-        div.appendChild(deleteBtn);
+        div.appendChild(buttonContainer);
 
         div.addEventListener('click', () => {
             this.selectedSong = song;
@@ -1198,6 +1247,135 @@ class TimestampNormalization {
         this.operationHistory = [];
         this.updateHistoryDisplay();
         toast.info('履歴をクリアしました');
+    }
+
+    // ===== 楽曲編集機能 =====
+
+    /**
+     * 編集モーダルを開く
+     * @param {Object} song - 編集対象の楽曲
+     */
+    openEditModal(song) {
+        this.editingSong = song;
+        document.getElementById('editSongId').value = song.id;
+        document.getElementById('editSongTitle').value = song.title;
+        document.getElementById('editSongArtist').value = song.artist;
+        document.getElementById('editSongYoutubeUrl').value = song.youtube_url || '';
+        document.getElementById('editSongDurationMs').value = song.duration_ms || '';
+        this.updateDurationDisplay(song.duration_ms);
+        document.getElementById('editSongModal').classList.remove('hidden');
+    }
+
+    /**
+     * 編集モーダルを閉じる
+     */
+    closeEditModal() {
+        this.editingSong = null;
+        document.getElementById('editSongModal').classList.add('hidden');
+        document.getElementById('editSongForm').reset();
+        document.getElementById('editSongDurationFormatted').textContent = '';
+    }
+
+    /**
+     * 楽曲マスタを更新
+     */
+    async updateSong() {
+        const songId = document.getElementById('editSongId').value;
+        const title = document.getElementById('editSongTitle').value.trim();
+        const artist = document.getElementById('editSongArtist').value.trim();
+        const youtubeUrl = document.getElementById('editSongYoutubeUrl').value.trim();
+        const durationMs = document.getElementById('editSongDurationMs').value;
+
+        if (!title || !artist) {
+            toast.warning('楽曲名とアーティスト名を入力してください。');
+            return;
+        }
+
+        const updateData = { title, artist };
+        if (youtubeUrl) {
+            updateData.youtube_url = youtubeUrl;
+        } else {
+            updateData.youtube_url = null;
+        }
+        if (durationMs) {
+            updateData.duration_ms = parseInt(durationMs, 10);
+        } else {
+            updateData.duration_ms = null;
+        }
+
+        try {
+            this.showLoading();
+            const response = await songApiService.updateSong(songId, updateData);
+            toast.success('楽曲マスタを更新しました。');
+            this.closeEditModal();
+            await this.loadSongs(document.getElementById('songsSearch').value);
+
+            // 選択中の楽曲が更新された場合は更新
+            if (this.selectedSong?.id === songId) {
+                this.selectedSong = response.song;
+                this.updateSelectionDisplay();
+            }
+        } catch (error) {
+            console.error('更新に失敗しました:', error);
+            toast.error('更新に失敗しました。');
+        } finally {
+            this.hideLoading();
+        }
+    }
+
+    /**
+     * YouTube URLから秒数を取得
+     */
+    async fetchYoutubeDuration() {
+        const youtubeUrl = document.getElementById('editSongYoutubeUrl').value.trim();
+
+        if (!youtubeUrl) {
+            toast.warning('YouTube URLを入力してください。');
+            return;
+        }
+
+        try {
+            this.showLoading();
+            const response = await songApiService.fetchYoutubeDuration(youtubeUrl);
+            document.getElementById('editSongDurationMs').value = response.duration_ms;
+            this.updateDurationDisplay(response.duration_ms);
+            toast.success('秒数を取得しました。');
+        } catch (error) {
+            console.error('秒数取得に失敗しました:', error);
+            const errorMessage = error.response?.data?.error || '秒数の取得に失敗しました。';
+            toast.error(errorMessage);
+        } finally {
+            this.hideLoading();
+        }
+    }
+
+    /**
+     * 秒数表示を更新
+     * @param {number|string} durationMs - ミリ秒
+     */
+    updateDurationDisplay(durationMs) {
+        const formatted = durationMs ? this.formatDuration(durationMs) : '';
+        document.getElementById('editSongDurationFormatted').textContent = formatted;
+    }
+
+    /**
+     * ミリ秒を時間フォーマットに変換
+     * @param {number|string} durationMs - ミリ秒
+     * @returns {string} フォーマットされた時間（例: "3:45" または "1:23:45"）
+     */
+    formatDuration(durationMs) {
+        const ms = parseInt(durationMs, 10);
+        if (isNaN(ms) || ms <= 0) return '';
+
+        const totalSeconds = Math.floor(ms / 1000);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+
+        if (hours > 0) {
+            return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+        }
+        return `${minutes}:${seconds.toString().padStart(2, '0')}`;
     }
 }
 

--- a/resources/js/songs/services/SongApiService.js
+++ b/resources/js/songs/services/SongApiService.js
@@ -47,6 +47,33 @@ export class SongApiService {
     }
 
     /**
+     * 楽曲マスタを更新
+     * @param {string} songId - 楽曲ID
+     * @param {Object} songData - 更新データ
+     * @param {string} songData.title - 楽曲名
+     * @param {string} songData.artist - アーティスト名
+     * @param {string} songData.youtube_url - YouTube URL
+     * @param {number} songData.duration_ms - 動画の長さ（ミリ秒）
+     * @returns {Promise<Object>} 更新結果
+     */
+    async updateSong(songId, songData) {
+        const response = await axios.put(`/api/songs/${songId}`, songData);
+        return response.data;
+    }
+
+    /**
+     * YouTube URLから動画の長さを取得
+     * @param {string} youtubeUrl - YouTube URL
+     * @returns {Promise<Object>} duration_ms と video_id を含むオブジェクト
+     */
+    async fetchYoutubeDuration(youtubeUrl) {
+        const response = await axios.post('/api/songs/youtube-duration', {
+            youtube_url: youtubeUrl
+        });
+        return response.data;
+    }
+
+    /**
      * Spotify APIで楽曲を検索
      * @param {string} query - 検索クエリ
      * @param {number} limit - 取得件数

--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -144,6 +144,10 @@
                                     <label class="block text-sm font-medium mb-2">アーティスト名 *</label>
                                     <input type="text" id="songArtist" name="artist" required class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
                                 </div>
+                                <div>
+                                    <label class="block text-sm font-medium mb-2">YouTube URL（任意）</label>
+                                    <input type="text" id="songYoutubeUrl" name="youtube_url" placeholder="https://www.youtube.com/watch?v=..." class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                </div>
                                 <div class="flex gap-2">
                                     <button type="submit" class="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">
                                         楽曲マスタ作成
@@ -196,6 +200,56 @@
                 <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mr-3"></div>
                 <span class="text-gray-900 dark:text-gray-100">処理中...</span>
             </div>
+        </div>
+    </div>
+
+    <!-- 楽曲編集モーダル -->
+    <div id="editSongModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden z-50">
+        <div class="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md mx-4">
+            <div class="flex justify-between items-center mb-4">
+                <h3 class="text-lg font-semibold text-gray-900 dark:text-gray-100">楽曲マスタ編集</h3>
+                <button id="closeEditModalBtn" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+            <form id="editSongForm" class="space-y-4">
+                <input type="hidden" id="editSongId" name="id">
+                <div>
+                    <label class="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">楽曲名 *</label>
+                    <input type="text" id="editSongTitle" name="title" required class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+                </div>
+                <div>
+                    <label class="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">アーティスト名 *</label>
+                    <input type="text" id="editSongArtist" name="artist" required class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+                </div>
+                <div>
+                    <label class="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">YouTube URL（任意）</label>
+                    <div class="flex gap-2">
+                        <input type="text" id="editSongYoutubeUrl" name="youtube_url" placeholder="https://www.youtube.com/watch?v=..." class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+                        <button type="button" id="fetchDurationBtn" class="px-3 py-2 bg-red-600 text-white text-sm rounded-md hover:bg-red-700 whitespace-nowrap">
+                            秒数取得
+                        </button>
+                    </div>
+                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">※ 秒数取得ボタンでYouTube APIを使用します（クォータ消費）</p>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">楽曲の長さ</label>
+                    <div class="flex items-center gap-2">
+                        <input type="number" id="editSongDurationMs" name="duration_ms" placeholder="ミリ秒" class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+                        <span id="editSongDurationFormatted" class="text-sm text-gray-500 dark:text-gray-400 min-w-[80px]"></span>
+                    </div>
+                </div>
+                <div class="flex gap-2 pt-2">
+                    <button type="submit" class="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">
+                        保存
+                    </button>
+                    <button type="button" id="cancelEditBtn" class="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600">
+                        キャンセル
+                    </button>
+                </div>
+            </form>
         </div>
     </div>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,7 +60,9 @@ Route::middleware(['auth'])->group(function () {
     Route::delete('api/songs/unlink', [SongController::class, 'unlinkTimestamp'])->name('songs.unlinkTimestamp');
     Route::get('api/songs/fuzzy-search', [SongController::class, 'fuzzySearch'])->name('songs.fuzzySearch');
     Route::get('api/songs/search-spotify', [SongController::class, 'searchSpotify'])->name('songs.searchSpotify');
+    Route::post('api/songs/youtube-duration', [SongController::class, 'fetchYoutubeDuration'])->name('songs.fetchYoutubeDuration');
     // Parameterized route - must be last to avoid capturing specific route names
+    Route::put('api/songs/{id}', [SongController::class, 'updateSong'])->name('songs.updateSong');
     Route::delete('api/songs/{id}', [SongController::class, 'deleteSong'])->name('songs.deleteSong');
 
     // タイムスタンプ報告管理API


### PR DESCRIPTION
## Summary
- 楽曲マスタにYouTube URL・動画秒数カラムを追加
- YouTubeApiServiceに動画長さ取得機能を追加
- 楽曲編集モーダルの実装

## 変更内容
### バックエンド
- `updateSong()` - 楽曲マスタの更新エンドポイント
- `fetchYoutubeDuration()` - YouTube URLから動画の長さを取得
- `YouTubeApiService::extractVideoId()` - URL解析
- `YouTubeApiService::getVideoDuration()` - 動画長さ取得
- マイグレーション - `youtube_url`, `duration_ms` カラム追加

### フロントエンド
- 楽曲編集モーダルの追加
- YouTube秒数取得ボタン
- 楽曲の長さ表示

## Test plan
- [x] 全テスト（270件）がパス
- [x] コードレビュー完了
- [x] 本番環境での例外メッセージ隠蔽を実装

## 関連Issue
- テスト追加: #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)