### PR TITLE
fix: 再生履歴をチャンネル個別ページに移動 & フリッカー対策

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Alpine.js x-cloak: 初期化前に要素を非表示にする */
+[x-cloak] {
+    display: none !important;
+}
+
 .pagination-button {
     padding: 4px 20px;
     border: 1px solid #ccc;

--- a/resources/views/channels/index.blade.php
+++ b/resources/views/channels/index.blade.php
@@ -1,6 +1,5 @@
 <x-app-layout>
     <x-slot name="alpine_script">
-        @vite('resources/js/channels/play-history.js')
         <script>
             window.channels = @json($channels['data'] ?? []);
         </script>

--- a/resources/views/channels/partials/distribution-panel.blade.php
+++ b/resources/views/channels/partials/distribution-panel.blade.php
@@ -1,5 +1,6 @@
 {{-- 配信リンクパネル（タイムスタンプタブのみ表示） --}}
 <div x-show="showDistributionPanel && selectedSong && activeTab === 'timestamps'"
+     x-cloak
      x-transition:enter="transition ease-out duration-300"
      x-transition:enter-start="transform translate-y-full"
      x-transition:enter-end="transform translate-y-0"

--- a/resources/views/channels/show.blade.php
+++ b/resources/views/channels/show.blade.php
@@ -6,6 +6,7 @@
             // window.archives = @json($archives ?? []);
         </script>
         @vite('resources/js/channels/archive-list.js')
+        @vite('resources/js/channels/play-history.js')
     </x-slot>
 
     <div class="px-2 sm:px-6 py-2 sm:py-6 transition-all duration-300"


### PR DESCRIPTION
## Summary
- 再生履歴の表示をチャンネル一覧ページ(`/channels`)からチャンネル個別ページ(`/channels/[handle]`)に移動
- Alpine.jsのx-cloak属性を使ってページ読み込み時のモーダル/パネルのフリッカーを防止

## Changes
- `resources/views/channels/index.blade.php`: play-history.jsの読み込みを削除
- `resources/views/channels/show.blade.php`: play-history.jsの読み込みを追加
- `resources/css/app.css`: `[x-cloak]`スタイルを追加
- `resources/views/channels/partials/distribution-panel.blade.php`: x-cloak属性を追加

## Test plan
- [ ] チャンネル一覧ページ(`/channels`)を開いて再生履歴ボタンが表示されないことを確認
- [ ] チャンネル個別ページ(`/channels/[handle]`)を開いて再生履歴ボタンが表示されることを確認
- [ ] チャンネル個別ページを開いた際にモーダルやパネルがフリッカーしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)