### PR TITLE
fix: チャンネル個別ページのUI問題を修正

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -667,6 +667,8 @@ function registerArchiveListComponent() {
                 loadYouTubeAPI() {
                     if (window.YT && window.YT.Player) {
                         this.playerReady = true;
+                        // 既にAPIが読み込まれている場合は即座に事前初期化
+                        this.$nextTick(() => this.preInitializePlayer());
                         return;
                     }
 
@@ -679,6 +681,8 @@ function registerArchiveListComponent() {
 
                     window.youtubeAPIReadyCallbacks.push(() => {
                         this.playerReady = true;
+                        // API準備完了時に事前初期化（モバイルの自動再生制限対策）
+                        this.$nextTick(() => this.preInitializePlayer());
                     });
 
                     if (!document.querySelector('script[src*="youtube.com/iframe_api"]')) {
@@ -691,6 +695,22 @@ function registerArchiveListComponent() {
                         const firstScriptTag = document.getElementsByTagName('script')[0];
                         firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
                     }
+                },
+
+                // プレイヤーの事前初期化（モバイルの自動再生制限対策）
+                // ページロード時にプレイヤーを初期化しておくことで、
+                // ユーザーの最初のタップ時に即座に再生できるようにする
+                preInitializePlayer() {
+                    if (this.youtubePlayer) return; // 既に初期化済み
+
+                    const playerElement = document.getElementById('youtube-player');
+                    if (!playerElement) {
+                        // 要素がまだ存在しない場合は少し待ってリトライ
+                        setTimeout(() => this.preInitializePlayer(), 100);
+                        return;
+                    }
+
+                    this.initPlayer();
                 },
 
                 // 動画プレイヤーの初期化

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -892,6 +892,16 @@ function registerArchiveListComponent() {
                     if (PIP_SIZES[size]) {
                         this.pipSize = size;
                         sessionStorage.setItem('pipSize', size);
+                        // YouTube Playerのサイズも更新
+                        this.updatePlayerSize();
+                    }
+                },
+
+                // YouTube Playerのサイズを更新
+                updatePlayerSize() {
+                    if (this.youtubePlayer && typeof this.youtubePlayer.setSize === 'function') {
+                        const currentSize = this.getCurrentPipSize();
+                        this.youtubePlayer.setSize(currentSize.width, currentSize.height);
                     }
                 },
 

--- a/resources/views/channels/partials/video-player.blade.php
+++ b/resources/views/channels/partials/video-player.blade.php
@@ -1,5 +1,6 @@
 {{-- PIP風動画プレイヤー --}}
 <div x-show="showVideoPlayer"
+     x-cloak
      x-ref="videoPlayer"
      x-transition:enter="transition ease-out duration-300"
      x-transition:enter-start="opacity-0 scale-95"
@@ -59,6 +60,7 @@
 
 {{-- 戻すボタン（パネル非表示時、タイムスタンプタブのみ） --}}
 <button x-show="panelDismissed && !showDistributionPanel && activeTab === 'timestamps'"
+        x-cloak
         @click="openPanel()"
         x-transition:enter="transition ease-out duration-200"
         x-transition:enter-start="opacity-0 scale-95"
@@ -66,7 +68,7 @@
         x-transition:leave="transition ease-in duration-150"
         x-transition:leave-start="opacity-100 scale-100"
         x-transition:leave-end="opacity-0 scale-95"
-        class="fixed bottom-4 right-4 p-2 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg z-40 transition-colors"
+        class="fixed bottom-24 right-6 p-2 bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-lg z-40 transition-colors"
         title="配信リンクを表示"
         aria-label="配信リンクを表示">
     <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">


### PR DESCRIPTION
## Summary
- video-playerとopen-panelボタンにx-cloakを追加してフリッカーを防止
- 配信リンク戻すボタンの位置を調整（`bottom-4 right-4` → `bottom-24 right-6`）して再生履歴ボタンとの重なりを解消
- PiPサイズ変更時にYouTube Playerの`setSize()`を呼び出して動画サイズも更新されるように修正
- **モバイルでの初回楽曲ガチャ再生問題を修正**: YouTube APIロード完了時にプレイヤーを事前初期化することで、ユーザーの最初のタップでも即座に再生開始できるようにした

## Changes
- `resources/views/channels/partials/video-player.blade.php`: x-cloak追加、ボタン位置調整
- `resources/js/channels/archive-list.js`: 
  - `updatePlayerSize()`メソッド追加、`changePipSize()`から呼び出し
  - `preInitializePlayer()`メソッド追加、YouTube API準備完了時に呼び出し

## Test plan
- [ ] チャンネル個別ページを開いた際にPiPプレイヤーや戻すボタンがフリッカーしないことを確認
- [ ] 再生履歴ボタンと配信リンク戻すボタンが重ならないことを確認
- [ ] PiPサイズ（小/中/大）を切り替えた際に動画のサイズが変わることを確認
- [ ] **スマホで**チャンネル個別ページを開き、楽曲ガチャを初回タップした際に動画が再生されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)