### PR TITLE
feat: 音量調節機能と再生履歴のコピー機能を追加

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -163,6 +163,9 @@ function registerArchiveListComponent() {
                 pipSize: 'medium',
                 pipSizes: PIP_SIZES,
 
+                // 音量設定
+                volume: 100,
+
                 // computed property
                 get maxPage() {
                     if (!this.archives.total || !this.archives.per_page) return 1;
@@ -481,6 +484,15 @@ function registerArchiveListComponent() {
                         this.pipSize = pipSizeSaved;
                     }
 
+                    // 音量設定を読み込み（sessionStorageから、デフォルト100）
+                    const volumeSaved = sessionStorage.getItem('videoVolume');
+                    if (volumeSaved !== null) {
+                        const vol = parseInt(volumeSaved, 10);
+                        if (!isNaN(vol) && vol >= 0 && vol <= 100) {
+                            this.volume = vol;
+                        }
+                    }
+
                     // YouTube IFrame APIの読み込み
                     this.loadYouTubeAPI();
 
@@ -735,6 +747,10 @@ function registerArchiveListComponent() {
                                 if (this.youtubePlayer.setPlaybackQuality) {
                                     this.youtubePlayer.setPlaybackQuality(YOUTUBE_PLAYER_CONFIG.suggestedQuality);
                                 }
+                                // 保存された音量を適用
+                                if (typeof this.youtubePlayer.setVolume === 'function') {
+                                    this.youtubePlayer.setVolume(this.volume);
+                                }
                                 // 待機中の動画があれば再生
                                 // isPlayingはonStateChangeで更新されるため、ここでは設定しない
                                 if (this.pendingVideo) {
@@ -905,6 +921,20 @@ function registerArchiveListComponent() {
                 // 自動再生設定の保存
                 saveAutoPlay() {
                     sessionStorage.setItem('videoAutoPlay', this.autoPlay.toString());
+                },
+
+                // 音量変更
+                changeVolume(value) {
+                    const vol = parseInt(value, 10);
+                    if (isNaN(vol) || vol < 0 || vol > 100) return;
+
+                    this.volume = vol;
+                    sessionStorage.setItem('videoVolume', vol.toString());
+
+                    // プレイヤーの音量を更新
+                    if (this.youtubePlayer && typeof this.youtubePlayer.setVolume === 'function') {
+                        this.youtubePlayer.setVolume(vol);
+                    }
                 },
 
                 // ワイプサイズの変更

--- a/resources/js/channels/play-history.js
+++ b/resources/js/channels/play-history.js
@@ -1,8 +1,9 @@
 import { getYoutubeUrl } from '../utils/youtube.js';
+import toast from '../utils/toast.js';
 
 /**
  * 再生履歴表示コンポーネント
- * チャンネル一覧ページでsessionStorageに保存された再生履歴を表示
+ * チャンネル個別ページでsessionStorageに保存された再生履歴を表示
  */
 class PlayHistory {
     constructor() {
@@ -144,18 +145,31 @@ class PlayHistory {
         const content = document.createElement('div');
         content.className = 'text-gray-900 dark:text-gray-100';
 
+        // コピー用テキストを生成
+        const copyText = entry.artist
+            ? `${entry.title} / ${entry.artist}`
+            : entry.title || '-';
+
         const titleDiv = document.createElement('div');
-        titleDiv.className = 'font-medium truncate';
+        titleDiv.className = 'font-medium truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400';
         titleDiv.textContent = entry.title || '-';
-        titleDiv.title = entry.title || '-';
+        titleDiv.title = `クリックでコピー: ${copyText}`;
+        titleDiv.addEventListener('click', () => {
+            navigator.clipboard.writeText(copyText);
+            toast.success('コピーしました');
+        });
 
         content.appendChild(titleDiv);
 
         if (entry.artist) {
             const artistDiv = document.createElement('div');
-            artistDiv.className = 'text-xs text-gray-500 dark:text-gray-400 truncate';
+            artistDiv.className = 'text-xs text-gray-500 dark:text-gray-400 truncate cursor-pointer hover:text-blue-600 dark:hover:text-blue-400';
             artistDiv.textContent = entry.artist;
-            artistDiv.title = entry.artist;
+            artistDiv.title = `クリックでコピー: ${copyText}`;
+            artistDiv.addEventListener('click', () => {
+                navigator.clipboard.writeText(copyText);
+                toast.success('コピーしました');
+            });
             content.appendChild(artistDiv);
         }
 

--- a/resources/views/channels/partials/distribution-panel.blade.php
+++ b/resources/views/channels/partials/distribution-panel.blade.php
@@ -48,6 +48,34 @@
                         </button>
                     </template>
                 </div>
+                {{-- 音量調節 --}}
+                <div class="inline-flex items-center gap-1">
+                    <button @click="changeVolume(volume > 0 ? 0 : 100)"
+                            class="p-1 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+                            :title="volume > 0 ? 'ミュート' : 'ミュート解除'">
+                        {{-- 音量アイコン（ミュート時） --}}
+                        <svg x-show="volume === 0" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z" clip-rule="evenodd"/>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2"/>
+                        </svg>
+                        {{-- 音量アイコン（低音量） --}}
+                        <svg x-show="volume > 0 && volume < 50" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072M12 6v12m0-12L7.5 9H4v6h3.5L12 18V6z"/>
+                        </svg>
+                        {{-- 音量アイコン（高音量） --}}
+                        <svg x-show="volume >= 50" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.536 8.464a5 5 0 010 7.072m2.828-9.9a9 9 0 010 12.728M5.586 15H4a1 1 0 01-1-1v-4a1 1 0 011-1h1.586l4.707-4.707C10.923 3.663 12 4.109 12 5v14c0 .891-1.077 1.337-1.707.707L5.586 15z"/>
+                        </svg>
+                    </button>
+                    <input type="range"
+                           min="0"
+                           max="100"
+                           step="5"
+                           x-model="volume"
+                           @input="changeVolume($event.target.value)"
+                           class="w-16 sm:w-20 h-1 bg-gray-300 dark:bg-gray-600 rounded-lg appearance-none cursor-pointer accent-blue-500"
+                           title="音量">
+                </div>
             </div>
             {{-- 楽曲タイトル --}}
             <div class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate flex-1"


### PR DESCRIPTION
## Summary
- 配信リンクパネルに音量調節機能を追加
- 再生履歴の楽曲名をクリックでコピーできる機能を追加

## Changes

### 音量調節機能
- 配信リンクパネルに音量スライダーを追加（0-100%、5%刻み）
- ミュート/解除ボタン追加（クリックで切り替え）
- 音量状態に応じて3種類のアイコン表示（ミュート/低音量/高音量）
- sessionStorageに音量設定を保存・復元

### 再生履歴のコピー機能
- 楽曲名・アーティスト名をクリックでクリップボードにコピー
- 「タイトル / アーティスト」形式でコピー
- ホバー時にカーソルとテキスト色が変化
- コピー成功時にトースト通知表示

## Files Changed
- `resources/views/channels/partials/distribution-panel.blade.php`: 音量コントロールUI追加
- `resources/js/channels/archive-list.js`: 音量状態管理、changeVolume()メソッド追加
- `resources/js/channels/play-history.js`: コピー機能追加、toastインポート

## Test plan
- [ ] 配信リンクパネルで音量スライダーが表示されることを確認
- [ ] 音量スライダーで動画の音量が変わることを確認
- [ ] ミュートボタンでミュート/解除が切り替わることを確認
- [ ] 音量設定がページリロード後も保持されることを確認
- [ ] 再生履歴の楽曲名をクリックでコピーされることを確認
- [ ] コピー後にトースト通知が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)