### PR TITLE
refactor: DragManagerにドラッグ機能を抽出

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -729,7 +729,11 @@ function registerArchiveListComponent() {
                     // 位置変更時のコールバックを設定
                     dragManager.onPositionChange = (position) => {
                         this.playerPosition = position;
-                        this.isDragging = dragManager.getIsDragging();
+                    };
+
+                    // ドラッグ終了時のコールバックを設定
+                    dragManager.onDragEnd = () => {
+                        this.isDragging = false;
                     };
                 },
 

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -13,6 +13,7 @@ import { ChannelApiService } from './services/ChannelApiService.js';
 import { ReportService } from './services/ReportService.js';
 import { videoPlayerManager } from './managers/VideoPlayerManager.js';
 import { autoReshuffleManager } from './managers/AutoReshuffleManager.js';
+import { dragManager } from './managers/DragManager.js';
 
 /**
  * ユーザー操作ログをサーバーに送信
@@ -141,12 +142,9 @@ function registerArchiveListComponent() {
                 // 自動再抽選機能
                 autoReshuffle: false,
 
-                // ドラッグ機能用
+                // ドラッグ機能用（UIバインディング用）
                 isDragging: false,
                 playerPosition: { x: null, y: null },
-                dragOffset: { x: 0, y: 0 },
-                boundOnDrag: null,
-                boundStopDrag: null,
 
                 // ワイプサイズ設定
                 pipSize: 'medium',
@@ -466,6 +464,7 @@ function registerArchiveListComponent() {
                     // マネージャーの初期化
                     this._initVideoPlayerManager();
                     this._initAutoReshuffleManager();
+                    this._initDragManager();
 
                     // YouTube IFrame APIの読み込み
                     this.loadYouTubeAPI();
@@ -476,6 +475,7 @@ function registerArchiveListComponent() {
                     // ページ離脱時のクリーンアップ
                     window.addEventListener('beforeunload', () => {
                         autoReshuffleManager.cleanup();
+                        dragManager.cleanup();
                         this.destroyPlayer();
                     });
                 },
@@ -724,6 +724,15 @@ function registerArchiveListComponent() {
                     };
                 },
 
+                // DragManagerの初期化
+                _initDragManager() {
+                    // 位置変更時のコールバックを設定
+                    dragManager.onPositionChange = (position) => {
+                        this.playerPosition = position;
+                        this.isDragging = dragManager.getIsDragging();
+                    };
+                },
+
                 // YouTube IFrame APIの読み込み
                 loadYouTubeAPI() {
                     videoPlayerManager.loadAPI(() => {
@@ -896,86 +905,19 @@ function registerArchiveListComponent() {
 
                 // ドラッグ開始
                 startDrag(event) {
-                    const clientX = event.touches ? event.touches[0].clientX : event.clientX;
-                    const clientY = event.touches ? event.touches[0].clientY : event.clientY;
-
                     const playerEl = this.$refs.videoPlayer;
-                    if (!playerEl) return;
-
-                    const rect = playerEl.getBoundingClientRect();
+                    dragManager.startDrag(event, playerEl);
                     this.isDragging = true;
-                    this.dragOffset = {
-                        x: clientX - rect.left,
-                        y: clientY - rect.top
-                    };
-
-                    this.boundOnDrag = this.onDrag.bind(this);
-                    this.boundStopDrag = this.stopDrag.bind(this);
-
-                    document.addEventListener('mousemove', this.boundOnDrag);
-                    document.addEventListener('mouseup', this.boundStopDrag);
-                    document.addEventListener('touchmove', this.boundOnDrag, { passive: false });
-                    document.addEventListener('touchend', this.boundStopDrag);
-
-                    event.preventDefault();
-                },
-
-                // ドラッグ中
-                onDrag(event) {
-                    if (!this.isDragging) return;
-
-                    const clientX = event.touches ? event.touches[0].clientX : event.clientX;
-                    const clientY = event.touches ? event.touches[0].clientY : event.clientY;
-
-                    const playerEl = this.$refs.videoPlayer;
-                    if (!playerEl) return;
-
-                    const playerWidth = playerEl.offsetWidth;
-                    const playerHeight = playerEl.offsetHeight;
-
-                    let newX = clientX - this.dragOffset.x;
-                    let newY = clientY - this.dragOffset.y;
-
-                    newX = Math.max(0, Math.min(newX, window.innerWidth - playerWidth));
-                    newY = Math.max(0, Math.min(newY, window.innerHeight - playerHeight));
-
-                    this.playerPosition = { x: newX, y: newY };
-
-                    event.preventDefault();
-                },
-
-                // ドラッグ終了
-                stopDrag() {
-                    this.isDragging = false;
-
-                    if (this.boundOnDrag) {
-                        document.removeEventListener('mousemove', this.boundOnDrag);
-                        document.removeEventListener('touchmove', this.boundOnDrag);
-                    }
-                    if (this.boundStopDrag) {
-                        document.removeEventListener('mouseup', this.boundStopDrag);
-                        document.removeEventListener('touchend', this.boundStopDrag);
-                    }
-
-                    this.boundOnDrag = null;
-                    this.boundStopDrag = null;
                 },
 
                 // プレイヤーの位置スタイルを取得
                 getPlayerStyle() {
-                    if (this.playerPosition.x !== null && this.playerPosition.y !== null) {
-                        return {
-                            left: `${this.playerPosition.x}px`,
-                            top: `${this.playerPosition.y}px`,
-                            right: 'auto',
-                            bottom: 'auto'
-                        };
-                    }
-                    return {};
+                    return dragManager.getStyle();
                 },
 
                 // プレイヤー位置をリセット
                 resetPlayerPosition() {
+                    dragManager.resetPosition();
                     this.playerPosition = { x: null, y: null };
                 }
             };

--- a/resources/js/channels/managers/DragManager.js
+++ b/resources/js/channels/managers/DragManager.js
@@ -1,0 +1,160 @@
+/**
+ * ドラッグ機能を管理するマネージャークラス
+ *
+ * 責務:
+ * - マウス/タッチによるドラッグ操作の処理
+ * - 位置の計算と境界制約
+ * - イベントリスナーの管理
+ */
+export class DragManager {
+    constructor() {
+        // 状態
+        this.isDragging = false;
+        this.position = { x: null, y: null };
+        this.dragOffset = { x: 0, y: 0 };
+
+        // イベントハンドラ参照
+        this.boundOnDrag = null;
+        this.boundStopDrag = null;
+
+        // ドラッグ対象要素
+        this.targetElement = null;
+
+        // コールバック
+        this.onPositionChange = null;
+    }
+
+    /**
+     * ドラッグを開始
+     * @param {Event} event - マウスまたはタッチイベント
+     * @param {HTMLElement} element - ドラッグ対象の要素
+     */
+    startDrag(event, element) {
+        if (!element) return;
+
+        const clientX = event.touches ? event.touches[0].clientX : event.clientX;
+        const clientY = event.touches ? event.touches[0].clientY : event.clientY;
+
+        const rect = element.getBoundingClientRect();
+        this.isDragging = true;
+        this.targetElement = element;
+        this.dragOffset = {
+            x: clientX - rect.left,
+            y: clientY - rect.top
+        };
+
+        this.boundOnDrag = this._onDrag.bind(this);
+        this.boundStopDrag = this._stopDrag.bind(this);
+
+        document.addEventListener('mousemove', this.boundOnDrag);
+        document.addEventListener('mouseup', this.boundStopDrag);
+        document.addEventListener('touchmove', this.boundOnDrag, { passive: false });
+        document.addEventListener('touchend', this.boundStopDrag);
+
+        event.preventDefault();
+    }
+
+    /**
+     * ドラッグ中の処理（内部用）
+     * @private
+     */
+    _onDrag(event) {
+        if (!this.isDragging || !this.targetElement) return;
+
+        const clientX = event.touches ? event.touches[0].clientX : event.clientX;
+        const clientY = event.touches ? event.touches[0].clientY : event.clientY;
+
+        const playerWidth = this.targetElement.offsetWidth;
+        const playerHeight = this.targetElement.offsetHeight;
+
+        let newX = clientX - this.dragOffset.x;
+        let newY = clientY - this.dragOffset.y;
+
+        // 境界制約
+        newX = Math.max(0, Math.min(newX, window.innerWidth - playerWidth));
+        newY = Math.max(0, Math.min(newY, window.innerHeight - playerHeight));
+
+        this.position = { x: newX, y: newY };
+
+        // コールバックで位置変更を通知
+        if (this.onPositionChange) {
+            this.onPositionChange(this.position);
+        }
+
+        event.preventDefault();
+    }
+
+    /**
+     * ドラッグ終了（内部用）
+     * @private
+     */
+    _stopDrag() {
+        this.isDragging = false;
+        this.targetElement = null;
+
+        if (this.boundOnDrag) {
+            document.removeEventListener('mousemove', this.boundOnDrag);
+            document.removeEventListener('touchmove', this.boundOnDrag);
+        }
+        if (this.boundStopDrag) {
+            document.removeEventListener('mouseup', this.boundStopDrag);
+            document.removeEventListener('touchend', this.boundStopDrag);
+        }
+
+        this.boundOnDrag = null;
+        this.boundStopDrag = null;
+    }
+
+    /**
+     * 位置を取得
+     * @returns {Object} { x: number|null, y: number|null }
+     */
+    getPosition() {
+        return this.position;
+    }
+
+    /**
+     * 位置をリセット
+     */
+    resetPosition() {
+        this.position = { x: null, y: null };
+        if (this.onPositionChange) {
+            this.onPositionChange(this.position);
+        }
+    }
+
+    /**
+     * スタイルオブジェクトを取得
+     * @returns {Object} CSSスタイルオブジェクト
+     */
+    getStyle() {
+        if (this.position.x !== null && this.position.y !== null) {
+            return {
+                left: `${this.position.x}px`,
+                top: `${this.position.y}px`,
+                right: 'auto',
+                bottom: 'auto'
+            };
+        }
+        return {};
+    }
+
+    /**
+     * ドラッグ中かどうか
+     * @returns {boolean}
+     */
+    getIsDragging() {
+        return this.isDragging;
+    }
+
+    /**
+     * クリーンアップ
+     */
+    cleanup() {
+        this._stopDrag();
+        this.position = { x: null, y: null };
+    }
+}
+
+// シングルトンインスタンスをエクスポート
+export const dragManager = new DragManager();

--- a/resources/js/channels/managers/DragManager.js
+++ b/resources/js/channels/managers/DragManager.js
@@ -22,6 +22,7 @@ export class DragManager {
 
         // コールバック
         this.onPositionChange = null;
+        this.onDragEnd = null;
     }
 
     /**
@@ -103,6 +104,11 @@ export class DragManager {
 
         this.boundOnDrag = null;
         this.boundStopDrag = null;
+
+        // ドラッグ終了を通知
+        if (this.onDragEnd) {
+            this.onDragEnd();
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- `archive-list.js`からドラッグ関連の機能を`DragManager.js`に抽出
- archive-list.js: 1001行 → 943行（58行削減）
- PR #395 （AutoReshuffleManager抽出）に続くPhase 1の3番目のPR

## 変更内容

### 新規ファイル
- `resources/js/channels/managers/DragManager.js`
  - マウス/タッチによるドラッグ操作の処理
  - 位置の計算と境界制約
  - イベントリスナーの管理
  - スタイルオブジェクト生成

### 修正ファイル
- `resources/js/channels/archive-list.js`
  - 不要な状態変数を削除（dragOffset, boundOnDrag, boundStopDrag）
  - `onDrag()`, `stopDrag()`メソッドを削除（Manager内部で処理）
  - `startDrag()`, `getPlayerStyle()`, `resetPlayerPosition()`をManagerへの委譲に簡略化
  - `_initDragManager()`でコールバック設定

## Test plan
- [x] 全テスト通過（282 passed）
- [x] ビルド成功
- [ ] 手動テスト: ワイプ（PiP）のドラッグ移動が正常に動作するか
- [ ] 手動テスト: ワイプを画面端にドラッグした際の境界制約が正常に動作するか

🤖 Generated with [Claude Code](https://claude.com/claude-code)