### PR TITLE
fix: 絵文字を含むタイムスタンプの保存・表示を修正

### DIFF
--- a/app/Helpers/TextNormalizer.php
+++ b/app/Helpers/TextNormalizer.php
@@ -98,9 +98,9 @@ class TextNormalizer
         // ゼロ幅スペースなどの不可視文字を除去
         // U+200B: Zero Width Space
         // U+200C: Zero Width Non-Joiner
-        // U+200D: Zero Width Joiner
         // U+FEFF: Byte Order Mark (BOM)
-        $text = preg_replace('/[\x{200B}-\x{200D}\x{FEFF}]/u', '', $text);
+        // 注意: U+200D (Zero Width Joiner) は絵文字シーケンスで使用されるため除去しない
+        $text = preg_replace('/[\x{200B}\x{200C}\x{FEFF}]/u', '', $text);
 
         // 全角スペース・タブなどを半角スペースに統一
         $text = preg_replace('/[\s\x{3000}]+/u', ' ', $text);
@@ -132,7 +132,8 @@ class TextNormalizer
         }
 
         // ゼロ幅スペースなどの不可視文字を除去
-        $text = preg_replace('/[\x{200B}-\x{200D}\x{FEFF}]/u', '', $text);
+        // 注意: U+200D (Zero Width Joiner) は絵文字シーケンスで使用されるため除去しない
+        $text = preg_replace('/[\x{200B}\x{200C}\x{FEFF}]/u', '', $text);
 
         // 先頭の全角スペース（U+3000）と半角スペース、その他の空白文字を除去
         return preg_replace('/^[\s\x{3000}]+/u', '', $text);

--- a/database/migrations/2026_03_09_000001_convert_tables_to_utf8mb4.php
+++ b/database/migrations/2026_03_09_000001_convert_tables_to_utf8mb4.php
@@ -8,9 +8,15 @@ return new class extends Migration
     /**
      * 絵文字対応: テーブルのcharsetをutf8mb4に変換
      *
-     * MySQLのデフォルトcharsetがutf8(3バイト)の場合、
-     * 絵文字(4バイトUTF-8)が「??」に化けるため、
-     * utf8mb4に変換して絵文字を正しく保存できるようにする。
+     * Laravelの接続設定(config/database.php)は既にutf8mb4だが、
+     * テーブル自体のデフォルトcharsetがutf8(3バイト)で作成されている場合、
+     * カラム定義がutf8のままとなり絵文字(4バイトUTF-8)が正しく保存できない。
+     * このマイグレーションでテーブルとカラムのcharsetをutf8mb4に統一する。
+     *
+     * 注意: CONVERT TO CHARACTER SETはテーブル全体のコピーが発生し、
+     * 実行中はテーブルにメタデータロックがかかるため、
+     * データ量が多いテーブル(ts_items, archives等)ではダウンタイムが発生する。
+     * 本番適用時はメンテナンスウィンドウで実施すること。
      */
     public function up(): void
     {

--- a/database/migrations/2026_03_09_000001_convert_tables_to_utf8mb4.php
+++ b/database/migrations/2026_03_09_000001_convert_tables_to_utf8mb4.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * 絵文字対応: テーブルのcharsetをutf8mb4に変換
+     *
+     * MySQLのデフォルトcharsetがutf8(3バイト)の場合、
+     * 絵文字(4バイトUTF-8)が「??」に化けるため、
+     * utf8mb4に変換して絵文字を正しく保存できるようにする。
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        $tables = [
+            'archives',
+            'ts_items',
+            'channels',
+            'songs',
+            'timestamp_song_mappings',
+            'change_list',
+            'timestamp_reports',
+        ];
+
+        foreach ($tables as $table) {
+            DB::statement(
+                "ALTER TABLE `{$table}` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+            );
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // charsetの変換は元に戻さない（データロスの可能性があるため）
+    }
+};

--- a/database/migrations/2026_03_09_234844_delete_emoji_timestamp_song_mappings.php
+++ b/database/migrations/2026_03_09_234844_delete_emoji_timestamp_song_mappings.php
@@ -1,7 +1,7 @@
 <?php
 
-use App\Models\TimestampSongMapping;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 return new class extends Migration
@@ -18,11 +18,15 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // 注意: このパターンは主要な絵文字範囲をカバーするが、
+        // Unicode全絵文字を網羅するものではない（例: U+1F900-1F9FF等は未含）。
+        // 削除漏れがあってもマッピング不一致が残るだけで機能上の問題はない。
         $emojiPattern = '/[\x{1F000}-\x{1FFFF}\x{2600}-\x{27BF}\x{2300}-\x{23FF}\x{2B50}-\x{2B55}\x{FE00}-\x{FE0F}\x{20E3}\x{E0020}-\x{E007F}]/u';
 
         $deletedCount = 0;
 
-        TimestampSongMapping::chunk(500, function ($mappings) use ($emojiPattern, &$deletedCount) {
+        DB::table('timestamp_song_mappings')->orderBy('id')->chunk(500, function ($mappings) use ($emojiPattern, &$deletedCount) {
+            $idsToDelete = [];
             foreach ($mappings as $mapping) {
                 if (preg_match($emojiPattern, $mapping->normalized_text)) {
                     Log::info('[Migration] Deleting emoji mapping', [
@@ -30,9 +34,12 @@ return new class extends Migration
                         'normalized_text' => $mapping->normalized_text,
                         'song_id' => $mapping->song_id,
                     ]);
-                    $mapping->delete();
-                    $deletedCount++;
+                    $idsToDelete[] = $mapping->id;
                 }
+            }
+            if (! empty($idsToDelete)) {
+                DB::table('timestamp_song_mappings')->whereIn('id', $idsToDelete)->delete();
+                $deletedCount += count($idsToDelete);
             }
         });
 

--- a/database/migrations/2026_03_09_234844_delete_emoji_timestamp_song_mappings.php
+++ b/database/migrations/2026_03_09_234844_delete_emoji_timestamp_song_mappings.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\TimestampSongMapping;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Log;
+
+return new class extends Migration
+{
+    /**
+     * 絵文字を含むtimestamp_song_mappingsを削除
+     *
+     * 以前のマイグレーション(2025_12_13)でZWJ(U+200D)が除去されたため、
+     * 絵文字を含むマッピングのnormalized_textはZWJ無しの状態になっている。
+     * 一方、TextNormalizerはZWJを保持するよう変更されたため、
+     * refresh後のts_items.normalized_textにはZWJが含まれ、マッピングと不一致になる。
+     * 取り込みフローの見直しでタイムスタンプは作り直しになるため、
+     * 該当マッピングを削除して不整合を解消する。
+     */
+    public function up(): void
+    {
+        $emojiPattern = '/[\x{1F000}-\x{1FFFF}\x{2600}-\x{27BF}\x{2300}-\x{23FF}\x{2B50}-\x{2B55}\x{FE00}-\x{FE0F}\x{20E3}\x{E0020}-\x{E007F}]/u';
+
+        $deletedCount = 0;
+
+        TimestampSongMapping::chunk(500, function ($mappings) use ($emojiPattern, &$deletedCount) {
+            foreach ($mappings as $mapping) {
+                if (preg_match($emojiPattern, $mapping->normalized_text)) {
+                    Log::info('[Migration] Deleting emoji mapping', [
+                        'id' => $mapping->id,
+                        'normalized_text' => $mapping->normalized_text,
+                        'song_id' => $mapping->song_id,
+                    ]);
+                    $mapping->delete();
+                    $deletedCount++;
+                }
+            }
+        });
+
+        Log::info("[Migration] Deleted {$deletedCount} emoji-containing timestamp_song_mappings");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Log::warning('[Migration] Rollback not supported for emoji mapping deletion');
+    }
+};

--- a/tests/Unit/Helpers/TextNormalizerTest.php
+++ b/tests/Unit/Helpers/TextNormalizerTest.php
@@ -132,14 +132,14 @@ class TextNormalizerTest extends TestCase
         // U+200C: Zero Width Non-Joiner
         $this->assertEquals('testvalue', TextNormalizer::normalize("test\u{200C}value"));
 
-        // U+200D: Zero Width Joiner
-        $this->assertEquals('testvalue', TextNormalizer::normalize("test\u{200D}value"));
+        // U+200D: Zero Width Joiner（絵文字シーケンスで使用されるため保持）
+        $this->assertEquals("test\u{200D}value", TextNormalizer::normalize("test\u{200D}value"));
 
         // U+FEFF: BOM
         $this->assertEquals('testvalue', TextNormalizer::normalize("\u{FEFF}testvalue"));
 
-        // 複数の不可視文字が混在
-        $this->assertEquals('abc def', TextNormalizer::normalize("a\u{200B}bc\u{200C} \u{200D}def"));
+        // 複数の不可視文字が混在（U+200Dは保持される）
+        $this->assertEquals("abc \u{200D}def", TextNormalizer::normalize("a\u{200B}bc\u{200C} \u{200D}def"));
 
         // 先頭にゼロ幅スペースがある実際のケース
         $this->assertEquals('天野由梨 魂の扉', TextNormalizer::normalize("\u{200B} 天野由梨 魂の扉"));
@@ -401,5 +401,32 @@ class TextNormalizerTest extends TestCase
         $this->assertTrue(TextNormalizer::hasSeparators('コーヒー / カフェラテ'));
         $result = TextNormalizer::splitBySeparators('コーヒー / カフェラテ');
         $this->assertEquals(['コーヒー', 'カフェラテ'], $result['parts']);
+    }
+
+    /**
+     * normalizeメソッドが絵文字を保持することをテスト
+     */
+    public function test_normalize_preserves_emoji(): void
+    {
+        // 絵文字のみ
+        $this->assertEquals('🎵', TextNormalizer::normalize('🎵'));
+
+        // 絵文字を含むタイムスタンプテキスト
+        $this->assertEquals('🎵 アーティスト / 曲名 🎶', TextNormalizer::normalize('🎵 アーティスト / 曲名 🎶'));
+
+        // 複合絵文字（肌色修飾子付き等）
+        $this->assertEquals('hello 👋🏻 world', TextNormalizer::normalize('Hello 👋🏻 World'));
+
+        // 各種絵文字が混在
+        $this->assertEquals('🔥 fire 🔥', TextNormalizer::normalize('🔥 FIRE 🔥'));
+    }
+
+    /**
+     * trimFullwidthSpaceが絵文字を保持することをテスト
+     */
+    public function test_trim_fullwidth_space_preserves_emoji(): void
+    {
+        $this->assertEquals('🎵 テスト', TextNormalizer::trimFullwidthSpace('　🎵 テスト'));
+        $this->assertEquals('🎶 曲名', TextNormalizer::trimFullwidthSpace('🎶 曲名'));
     }
 }

--- a/tests/Unit/Helpers/TextNormalizerTest.php
+++ b/tests/Unit/Helpers/TextNormalizerTest.php
@@ -419,6 +419,10 @@ class TextNormalizerTest extends TestCase
 
         // 各種絵文字が混在
         $this->assertEquals('🔥 fire 🔥', TextNormalizer::normalize('🔥 FIRE 🔥'));
+
+        // ZWJ結合絵文字（🏳️‍🌈 = 🏳 + VS16 + ZWJ + 🌈）
+        $zwjEmoji = "\u{1F3F3}\u{FE0F}\u{200D}\u{1F308}";
+        $this->assertEquals($zwjEmoji, TextNormalizer::normalize($zwjEmoji));
     }
 
     /**

--- a/tests/Unit/Services/TimestampExtractorServiceTest.php
+++ b/tests/Unit/Services/TimestampExtractorServiceTest.php
@@ -21,7 +21,7 @@ class TimestampExtractorServiceTest extends TestCase
     public function test_extract_timestamps_preserves_emoji(): void
     {
         $description = "0:00 🎵 オープニング\n1:30 🔥 アーティスト / 曲名 🎶\n3:00 ⭐ エンディング";
-        $results = $this->service->extractTimestamps('test_video1', '1', $description, 'test_video1');
+        $results = $this->service->extractTimestamps('test_video1', '1', $description, 'dummy_comment_id');
 
         $this->assertCount(3, $results);
         $this->assertEquals('🎵 オープニング', $results[0]['text']);
@@ -35,7 +35,7 @@ class TimestampExtractorServiceTest extends TestCase
     public function test_extract_timestamps_preserves_complex_emoji(): void
     {
         $description = "0:00 👋🏻 あいさつ\n1:00 🏳️‍🌈 テスト";
-        $results = $this->service->extractTimestamps('test_video2', '1', $description, 'test_video2');
+        $results = $this->service->extractTimestamps('test_video2', '1', $description, 'dummy_comment_id');
 
         $this->assertCount(2, $results);
         $this->assertEquals('👋🏻 あいさつ', $results[0]['text']);

--- a/tests/Unit/Services/TimestampExtractorServiceTest.php
+++ b/tests/Unit/Services/TimestampExtractorServiceTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\TimestampExtractorService;
+use Tests\TestCase;
+
+class TimestampExtractorServiceTest extends TestCase
+{
+    private TimestampExtractorService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new TimestampExtractorService;
+    }
+
+    /**
+     * 絵文字を含むタイムスタンプテキストが正しく抽出されることをテスト
+     */
+    public function test_extract_timestamps_preserves_emoji(): void
+    {
+        $description = "0:00 🎵 オープニング\n1:30 🔥 アーティスト / 曲名 🎶\n3:00 ⭐ エンディング";
+        $results = $this->service->extractTimestamps('test_video1', '1', $description, 'test_video1');
+
+        $this->assertCount(3, $results);
+        $this->assertEquals('🎵 オープニング', $results[0]['text']);
+        $this->assertEquals('🔥 アーティスト / 曲名 🎶', $results[1]['text']);
+        $this->assertEquals('⭐ エンディング', $results[2]['text']);
+    }
+
+    /**
+     * 複合絵文字（ZWJ結合など）を含むテキストが正しく抽出されることをテスト
+     */
+    public function test_extract_timestamps_preserves_complex_emoji(): void
+    {
+        $description = "0:00 👋🏻 あいさつ\n1:00 🏳️‍🌈 テスト";
+        $results = $this->service->extractTimestamps('test_video2', '1', $description, 'test_video2');
+
+        $this->assertCount(2, $results);
+        $this->assertEquals('👋🏻 あいさつ', $results[0]['text']);
+        $this->assertEquals('🏳️‍🌈 テスト', $results[1]['text']);
+    }
+}


### PR DESCRIPTION
## Summary
- 絵文字を含むタイムスタンプテキストが正しく保存・表示されるよう修正
- TextNormalizerでZWJ(U+200D)を保持するよう変更し、複合絵文字の分離を防止
- テーブルのcharsetをutf8mb4に変換するマイグレーションを追加
- 不整合な絵文字マッピングを削除するマイグレーションを追加（DB::table使用、一括削除最適化済み）

## 関連Issue
- #485 既存マイグレーション(2025_12_13)のZWJパターンが現行方針と矛盾
- #486 ZWJ除去済みの古いts_items.textデータの再正規化検討

## Test plan
- [ ] TextNormalizerTest: 絵文字保持テスト（ZWJ結合絵文字含む）が通ること
- [ ] TimestampExtractorServiceTest: 絵文字含むタイムスタンプ抽出テストが通ること
- [ ] utf8mb4マイグレーション: 本番適用時はメンテナンスウィンドウで実施すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)