### PR TITLE
feat: 配信パネルに「次の曲」スキップボタンを追加

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -137,6 +137,8 @@ function registerArchiveListComponent() {
                 playerInitialized: false,
                 // ランダム再生機能
                 isRandomPlaying: false,
+                // 次の曲スキップ中フラグ
+                isSkippingToNext: false,
 
                 // 自動再抽選機能
                 autoReshuffle: false,
@@ -948,6 +950,51 @@ function registerArchiveListComponent() {
                         console.error('次の楽曲の取得に失敗しました:', error);
                         // エラー時はランダム再生にフォールバック
                         this.playRandomTimestamp();
+                    }
+                },
+
+                /**
+                 * ユーザー操作で次の曲にスキップ
+                 * 同じアーカイブ内の次の曲に飛ばす。次の曲がなければアーカイブ末尾と同じ挙動。
+                 */
+                async skipToNextSong() {
+                    if (this.isSkippingToNext || this.isRandomPlaying) return;
+
+                    // 現在再生中のタイムスタンプ情報がなければ何もしない
+                    if (!this.channel?.handle ||
+                        !this.selectedTimestamp?.video_id ||
+                        this.selectedTimestamp?.ts_num === undefined) {
+                        return;
+                    }
+
+                    try {
+                        this.isSkippingToNext = true;
+
+                        logUserAction('skipToNextSong', {
+                            videoId: this.selectedTimestamp.video_id,
+                            tsNum: this.selectedTimestamp.ts_num,
+                        });
+
+                        // 同じアーカイブ内の次の楽曲を取得
+                        const nextTimestamp = await ChannelApiService.fetchNextTimestampInArchive(
+                            this.channel.handle,
+                            this.selectedTimestamp.video_id,
+                            this.selectedTimestamp.ts_num
+                        );
+
+                        if (nextTimestamp) {
+                            // 同じアーカイブ内の次の曲を再生
+                            await this.playTimestamp(nextTimestamp, true);
+                        } else {
+                            // アーカイブ内に次の曲がない場合、アーカイブ末尾到達と同じ挙動
+                            toast.info('このアーカイブの再生が終わりました');
+                            this.playRandomTimestamp();
+                        }
+                    } catch (error) {
+                        console.error('次の曲へのスキップに失敗しました:', error);
+                        toast.error('次の曲へのスキップに失敗しました');
+                    } finally {
+                        this.isSkippingToNext = false;
                     }
                 },
 

--- a/resources/views/channels/partials/distribution-panel.blade.php
+++ b/resources/views/channels/partials/distribution-panel.blade.php
@@ -37,6 +37,17 @@
                     </svg>
                     <span class="hidden sm:inline" x-text="isPlaying ? '停止' : '再生'"></span>
                 </button>
+                {{-- 次の曲ボタン --}}
+                <button @click="skipToNextSong()"
+                        :disabled="!selectedTimestamp?.video_id || isSkippingToNext"
+                        :class="(!selectedTimestamp?.video_id || isSkippingToNext) ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-200 dark:hover:bg-gray-600'"
+                        class="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded text-xs transition-colors"
+                        title="次の曲">
+                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/>
+                    </svg>
+                    <span class="hidden sm:inline">次の曲</span>
+                </button>
                 {{-- ワイプサイズ選択（モバイルでは非表示） --}}
                 <div x-show="!isMobile" class="hidden sm:inline-flex items-center rounded overflow-hidden border border-gray-300 dark:border-gray-600">
                     <template x-for="(config, size) in pipSizes" :key="size">


### PR DESCRIPTION
## Summary
- 配信パネルの再生/停止ボタンの隣に「次の曲」ボタンを追加
- 同じアーカイブ内の次のタイムスタンプにジャンプして再生
- 次の曲がない場合はアーカイブ末尾到達時と同じ挙動（トースト表示→ランダム再生）

## 変更内容
- `distribution-panel.blade.php`: 次の曲ボタン（スキップアイコン）をUIに追加
- `archive-list.js`: `skipToNextSong()` メソッドと `isSkippingToNext` フラグを追加

## Test plan
- [ ] タイムスタンプ選択後、配信パネルに「次の曲」ボタンが表示されること
- [ ] ボタン押下で同じアーカイブ内の次の曲にジャンプすること
- [ ] アーカイブの最後の曲で押下した場合、「このアーカイブの再生が終わりました」トースト表示後にランダム再生されること
- [ ] スキップ処理中はボタンが無効化されること（連打防止）
- [ ] モバイル表示ではアイコンのみ、PC表示では「次の曲」テキストも表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)