### PR TITLE
fix: video_idバリデーションの一貫性統一

### DIFF
--- a/app/Http/Controllers/TimestampReportController.php
+++ b/app/Http/Controllers/TimestampReportController.php
@@ -34,7 +34,7 @@ class TimestampReportController extends Controller
         }
 
         $validated = $request->validate([
-            'video_id' => 'required|string|max:11',
+            'video_id' => ['required', 'string', 'size:11', 'regex:/^[A-Za-z0-9_-]{11}$/'],
             'ts_text' => 'required|string|max:20',
             'ts_num' => 'required|integer|min:0',
             'report_type' => 'required|string|max:20',


### PR DESCRIPTION
## Summary
- `TimestampReportController` の `video_id` バリデーションを `max:11` から `size:11` + `regex:/^[A-Za-z0-9_-]{11}$/` に変更
- `ChannelController` と同じ正規表現バリデーションに統一

## 補足
- `ManageController` は `video_id` をリクエストから直接受け取らず、DBルックアップで取得しているため変更不要

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)