### PR TITLE
refactor: isRandomPlaying を isPlaybackTransitioning にリネーム

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -135,8 +135,8 @@ function registerArchiveListComponent() {
                 isPlaying: false,
                 playerReady: false,
                 playerInitialized: false,
-                // ランダム再生機能
-                isRandomPlaying: false,
+                // 再生遷移中フラグ（ランダム再生・次の曲再生など）
+                isPlaybackTransitioning: false,
                 // 次の曲スキップ中フラグ
                 isSkippingToNext: false,
 
@@ -851,10 +851,10 @@ function registerArchiveListComponent() {
 
                 // ランダム再生
                 async playRandomTimestamp() {
-                    if (this.isRandomPlaying) return;
+                    if (this.isPlaybackTransitioning) return;
 
                     try {
-                        this.isRandomPlaying = true;
+                        this.isPlaybackTransitioning = true;
 
                         const timestamp = await ChannelApiService.fetchRandomTimestamp(this.channel.handle);
 
@@ -916,7 +916,7 @@ function registerArchiveListComponent() {
                         console.error('ランダム再生に失敗しました:', error);
                         toast.error(error.message || 'ランダム再生に失敗しました');
                     } finally {
-                        this.isRandomPlaying = false;
+                        this.isPlaybackTransitioning = false;
                     }
                 },
 
@@ -958,7 +958,7 @@ function registerArchiveListComponent() {
                  * 同じアーカイブ内の次の曲に飛ばす。次の曲がなければアーカイブ末尾と同じ挙動。
                  */
                 async skipToNextSong() {
-                    if (this.isSkippingToNext || this.isRandomPlaying) return;
+                    if (this.isSkippingToNext || this.isPlaybackTransitioning) return;
 
                     // 現在再生中のタイムスタンプ情報がなければ何もしない
                     if (!this.channel?.handle ||
@@ -1058,10 +1058,10 @@ function registerArchiveListComponent() {
                  * @param {boolean} showToast - トースト表示するか
                  */
                 async playTimestamp(timestamp, showToast = true) {
-                    if (this.isRandomPlaying) return;
+                    if (this.isPlaybackTransitioning) return;
 
                     try {
-                        this.isRandomPlaying = true;
+                        this.isPlaybackTransitioning = true;
 
                         logUserAction('playNextInArchive', {
                             timestampId: timestamp.id,
@@ -1107,7 +1107,7 @@ function registerArchiveListComponent() {
                             autoReshuffleManager.startMonitor();
                         }
                     } finally {
-                        this.isRandomPlaying = false;
+                        this.isPlaybackTransitioning = false;
                     }
                 },
 

--- a/resources/views/channels/partials/tabs.blade.php
+++ b/resources/views/channels/partials/tabs.blade.php
@@ -68,9 +68,9 @@
              class="flex items-center gap-1 sm:gap-2">
             {{-- ガチャボタン --}}
             <button @click="playRandomTimestamp()"
-                    :disabled="isRandomPlaying"
+                    :disabled="isPlaybackTransitioning"
                     class="inline-flex items-center gap-1 sm:gap-2 px-3 sm:px-4 py-1.5 sm:py-2 bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white font-bold rounded-lg shadow transition-all duration-200 hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 text-sm">
-                <template x-if="!isRandomPlaying">
+                <template x-if="!isPlaybackTransitioning">
                     <span class="flex items-center gap-1 sm:gap-2">
                         <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -79,7 +79,7 @@
                         <span class="sm:hidden">ガチャ</span>
                     </span>
                 </template>
-                <template x-if="isRandomPlaying">
+                <template x-if="isPlaybackTransitioning">
                     <span class="flex items-center gap-1 sm:gap-2">
                         <svg class="animate-spin w-4 h-4 sm:w-5 sm:h-5" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>


### PR DESCRIPTION
## Summary
- `archive-list.js` の `isRandomPlaying` フラグを `isPlaybackTransitioning` にリネーム
- `tabs.blade.php` のテンプレート参照も同時に更新
- ランダム再生・次の曲再生など再生遷移の排他制御に使われるフラグの名前を実際の用途に合わせて変更

## 補足
- PR #491（次の曲スキップ機能）とコンフリクトが発生するため、マージ順序に注意が必要。本PRを先にマージし、#491をrebaseする想定

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)