### PR TITLE
feat: 楽曲マスタの名寄せ・重複管理機能

### DIFF
--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -81,6 +81,17 @@ class SongController extends Controller
     }
 
     /**
+     * 名寄せ用の楽曲検索（部分一致）
+     */
+    public function searchSongsForMerge(Request $request)
+    {
+        $search = (string) $request->query('search', '');
+        $songs = $this->songMergeService->searchSongs($search);
+
+        return response()->json($songs);
+    }
+
+    /**
      * 楽曲をマージする
      */
     public function mergeSongs(Request $request)

--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -14,6 +14,7 @@ use App\Models\Song;
 use App\Models\TimestampSongMapping;
 use App\Models\TsItem;
 use App\Services\SongMappingService;
+use App\Services\SongMergeService;
 use App\Services\SongSearchService;
 use App\Services\SpotifyService;
 use App\Services\VideoUrlService;
@@ -28,6 +29,8 @@ class SongController extends Controller
 
     protected SongMappingService $songMappingService;
 
+    protected SongMergeService $songMergeService;
+
     protected SpotifyService $spotifyService;
 
     protected YouTubeApiService $youtubeApiService;
@@ -37,12 +40,14 @@ class SongController extends Controller
     public function __construct(
         SongSearchService $songSearchService,
         SongMappingService $songMappingService,
+        SongMergeService $songMergeService,
         SpotifyService $spotifyService,
         YouTubeApiService $youtubeApiService,
         VideoUrlService $videoUrlService
     ) {
         $this->songSearchService = $songSearchService;
         $this->songMappingService = $songMappingService;
+        $this->songMergeService = $songMergeService;
         $this->spotifyService = $spotifyService;
         $this->youtubeApiService = $youtubeApiService;
         $this->videoUrlService = $videoUrlService;
@@ -54,6 +59,50 @@ class SongController extends Controller
     public function index()
     {
         return view('songs.index');
+    }
+
+    /**
+     * 楽曲名寄せ画面を表示
+     */
+    public function duplicates()
+    {
+        return view('songs.duplicates');
+    }
+
+    /**
+     * 重複楽曲グループを取得
+     */
+    public function findDuplicates(Request $request)
+    {
+        $search = (string) $request->query('search', '');
+        $groups = $this->songMergeService->findDuplicates($search);
+
+        return response()->json($groups);
+    }
+
+    /**
+     * 楽曲をマージする
+     */
+    public function mergeSongs(Request $request)
+    {
+        $validated = $request->validate([
+            'source_song_id' => 'required|string|exists:songs,id',
+            'target_song_id' => 'required|string|exists:songs,id|different:source_song_id',
+        ]);
+
+        $result = $this->songMergeService->merge(
+            $validated['source_song_id'],
+            $validated['target_song_id']
+        );
+
+        return response()->json([
+            'message' => sprintf(
+                '楽曲をマージしました（マッピング %d件、個別紐付け %d件を移行）',
+                $result['affected_mappings'],
+                $result['affected_ts_items']
+            ),
+            ...$result,
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -101,7 +101,8 @@ class SongController extends Controller
                 $result['affected_mappings'],
                 $result['affected_ts_items']
             ),
-            ...$result,
+            'affected_mappings' => $result['affected_mappings'],
+            'affected_ts_items' => $result['affected_ts_items'],
         ]);
     }
 

--- a/app/Models/NormalizationLog.php
+++ b/app/Models/NormalizationLog.php
@@ -43,6 +43,8 @@ class NormalizationLog extends Model
 
     public const ACTION_MARK_PENDING = 'mark_pending';
 
+    public const ACTION_MERGE_SONG = 'merge_song';
+
     /**
      * ターゲット種別
      */

--- a/app/Services/SongMergeService.php
+++ b/app/Services/SongMergeService.php
@@ -34,24 +34,38 @@ class SongMergeService
 
         $groups = $query->limit(50)->get();
 
-        // 各グループの詳細情報を取得
-        return $groups->map(function ($group) {
-            $songs = Song::where('normalized_title', $group->normalized_title)
-                ->where('normalized_artist', $group->normalized_artist)
-                ->withCount('mappings')
-                ->get()
-                ->map(function ($song) {
-                    $tsItemCount = TsItem::where('song_id', $song->id)->count();
+        // 全グループの楽曲を一括取得（N+1クエリ対策）
+        $groupKeys = $groups->map(fn ($g) => [$g->normalized_title, $g->normalized_artist]);
 
-                    return [
-                        'id' => $song->id,
-                        'title' => $song->title,
-                        'artist' => $song->artist,
-                        'spotify_track_id' => $song->spotify_track_id,
-                        'mappings_count' => $song->mappings_count,
-                        'ts_items_count' => $tsItemCount,
-                    ];
+        $allSongs = Song::where(function ($q) use ($groupKeys) {
+            foreach ($groupKeys as $key) {
+                $q->orWhere(function ($q2) use ($key) {
+                    $q2->where('normalized_title', $key[0])
+                        ->where('normalized_artist', $key[1]);
                 });
+            }
+        })
+            ->withCount('mappings')
+            ->get();
+
+        // ts_items.song_idのカウントを一括取得
+        $songIds = $allSongs->pluck('id')->toArray();
+        $tsItemCounts = TsItem::selectRaw('song_id, COUNT(*) as count')
+            ->whereIn('song_id', $songIds)
+            ->groupBy('song_id')
+            ->pluck('count', 'song_id');
+
+        return $groups->map(function ($group) use ($allSongs, $tsItemCounts) {
+            $songs = $allSongs->filter(fn ($s) => $s->normalized_title === $group->normalized_title
+                    && $s->normalized_artist === $group->normalized_artist)
+                ->map(fn ($song) => [
+                    'id' => $song->id,
+                    'title' => $song->title,
+                    'artist' => $song->artist,
+                    'spotify_track_id' => $song->spotify_track_id,
+                    'mappings_count' => $song->mappings_count,
+                    'ts_items_count' => $tsItemCounts->get($song->id, 0),
+                ])->values();
 
             return [
                 'normalized_title' => $group->normalized_title,
@@ -74,7 +88,7 @@ class SongMergeService
      */
     public function merge(string $sourceSongId, string $targetSongId, ?int $userId = null): array
     {
-        $userId = $userId ?? Auth::id();
+        $userId = $userId ?? Auth::id() ?? throw new \RuntimeException('認証されていないユーザーによるマージは許可されていません');
 
         $sourceSong = Song::findOrFail($sourceSongId);
         $targetSong = Song::findOrFail($targetSongId);
@@ -89,23 +103,21 @@ class SongMergeService
                 ->update(['song_id' => $targetSong->id]);
 
             // ログ記録
-            if ($userId) {
-                NormalizationLog::log(
-                    $userId,
-                    NormalizationLog::ACTION_MERGE_SONG,
-                    NormalizationLog::TARGET_SONG,
-                    $targetSong->id,
-                    [
-                        'source_song_id' => $sourceSong->id,
-                        'source_title' => $sourceSong->title,
-                        'source_artist' => $sourceSong->artist,
-                        'target_title' => $targetSong->title,
-                        'target_artist' => $targetSong->artist,
-                        'affected_mappings' => $affectedMappings,
-                        'affected_ts_items' => $affectedTsItems,
-                    ]
-                );
-            }
+            NormalizationLog::log(
+                $userId,
+                NormalizationLog::ACTION_MERGE_SONG,
+                NormalizationLog::TARGET_SONG,
+                $targetSong->id,
+                [
+                    'source_song_id' => $sourceSong->id,
+                    'source_title' => $sourceSong->title,
+                    'source_artist' => $sourceSong->artist,
+                    'target_title' => $targetSong->title,
+                    'target_artist' => $targetSong->artist,
+                    'affected_mappings' => $affectedMappings,
+                    'affected_ts_items' => $affectedTsItems,
+                ]
+            );
 
             // マージ元を削除
             $sourceSong->delete();

--- a/app/Services/SongMergeService.php
+++ b/app/Services/SongMergeService.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\NormalizationLog;
+use App\Models\Song;
+use App\Models\TimestampSongMapping;
+use App\Models\TsItem;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class SongMergeService
+{
+    /**
+     * 重複楽曲のグループを検出する
+     *
+     * normalized_title が同じ楽曲をグループ化して返す。
+     * 各グループには楽曲情報とマッピング数を含む。
+     *
+     * @param  string  $search  検索フィルタ（タイトルで絞り込み）
+     * @return array 重複グループの配列
+     */
+    public function findDuplicates(string $search = ''): array
+    {
+        // normalized_titleでグループ化し、2件以上のグループを取得
+        $query = Song::selectRaw('normalized_title, normalized_artist, COUNT(*) as count')
+            ->groupBy('normalized_title', 'normalized_artist')
+            ->having('count', '>', 1)
+            ->orderBy('count', 'desc');
+
+        if ($search !== '') {
+            $query->where('title', 'LIKE', "%{$search}%");
+        }
+
+        $groups = $query->limit(50)->get();
+
+        // 各グループの詳細情報を取得
+        return $groups->map(function ($group) {
+            $songs = Song::where('normalized_title', $group->normalized_title)
+                ->where('normalized_artist', $group->normalized_artist)
+                ->withCount('mappings')
+                ->get()
+                ->map(function ($song) {
+                    $tsItemCount = TsItem::where('song_id', $song->id)->count();
+
+                    return [
+                        'id' => $song->id,
+                        'title' => $song->title,
+                        'artist' => $song->artist,
+                        'spotify_track_id' => $song->spotify_track_id,
+                        'mappings_count' => $song->mappings_count,
+                        'ts_items_count' => $tsItemCount,
+                    ];
+                });
+
+            return [
+                'normalized_title' => $group->normalized_title,
+                'normalized_artist' => $group->normalized_artist,
+                'songs' => $songs,
+            ];
+        })->toArray();
+    }
+
+    /**
+     * 2つの楽曲をマージする
+     *
+     * source の楽曲に紐付くマッピングと個別ts_itemをすべて target に付け替え、
+     * source を削除する。
+     *
+     * @param  string  $sourceSongId  マージ元（削除される）楽曲ID
+     * @param  string  $targetSongId  マージ先（残る）楽曲ID
+     * @param  int|null  $userId  操作者ID
+     * @return array{affected_mappings: int, affected_ts_items: int}
+     */
+    public function merge(string $sourceSongId, string $targetSongId, ?int $userId = null): array
+    {
+        $userId = $userId ?? Auth::id();
+
+        $sourceSong = Song::findOrFail($sourceSongId);
+        $targetSong = Song::findOrFail($targetSongId);
+
+        return DB::transaction(function () use ($sourceSong, $targetSong, $userId) {
+            // マッピングを付け替え
+            $affectedMappings = TimestampSongMapping::where('song_id', $sourceSong->id)
+                ->update(['song_id' => $targetSong->id]);
+
+            // 個別ts_item.song_idを付け替え
+            $affectedTsItems = TsItem::where('song_id', $sourceSong->id)
+                ->update(['song_id' => $targetSong->id]);
+
+            // ログ記録
+            if ($userId) {
+                NormalizationLog::log(
+                    $userId,
+                    NormalizationLog::ACTION_MERGE_SONG,
+                    NormalizationLog::TARGET_SONG,
+                    $targetSong->id,
+                    [
+                        'source_song_id' => $sourceSong->id,
+                        'source_title' => $sourceSong->title,
+                        'source_artist' => $sourceSong->artist,
+                        'target_title' => $targetSong->title,
+                        'target_artist' => $targetSong->artist,
+                        'affected_mappings' => $affectedMappings,
+                        'affected_ts_items' => $affectedTsItems,
+                    ]
+                );
+            }
+
+            // マージ元を削除
+            $sourceSong->delete();
+
+            return [
+                'affected_mappings' => $affectedMappings,
+                'affected_ts_items' => $affectedTsItems,
+            ];
+        });
+    }
+}

--- a/app/Services/SongMergeService.php
+++ b/app/Services/SongMergeService.php
@@ -76,6 +76,43 @@ class SongMergeService
     }
 
     /**
+     * 楽曲を部分一致で検索する（名寄せ候補用）
+     *
+     * @param  string  $search  検索文字列（タイトル・アーティストで部分一致）
+     * @return array 楽曲の配列（マッピング数・ts_item数付き）
+     */
+    public function searchSongs(string $search): array
+    {
+        if ($search === '') {
+            return [];
+        }
+
+        $songs = Song::where(function ($q) use ($search) {
+            $q->where('title', 'LIKE', "%{$search}%")
+                ->orWhere('artist', 'LIKE', "%{$search}%");
+        })
+            ->withCount('mappings')
+            ->orderBy('title')
+            ->limit(100)
+            ->get();
+
+        $songIds = $songs->pluck('id')->toArray();
+        $tsItemCounts = TsItem::selectRaw('song_id, COUNT(*) as count')
+            ->whereIn('song_id', $songIds)
+            ->groupBy('song_id')
+            ->pluck('count', 'song_id');
+
+        return $songs->map(fn ($song) => [
+            'id' => $song->id,
+            'title' => $song->title,
+            'artist' => $song->artist,
+            'spotify_track_id' => $song->spotify_track_id,
+            'mappings_count' => $song->mappings_count,
+            'ts_items_count' => $tsItemCounts->get($song->id, 0),
+        ])->toArray();
+    }
+
+    /**
      * 2つの楽曲をマージする
      *
      * source の楽曲に紐付くマッピングと個別ts_itemをすべて target に付け替え、

--- a/resources/js/songs/duplicates.js
+++ b/resources/js/songs/duplicates.js
@@ -4,53 +4,116 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
 
-    const state = Alpine.reactive({
+    Alpine.data('duplicatesApp', () => ({
+        // 左ペイン: 重複グループ
         groups: [],
+        groupsLoading: false,
+
+        // 右ペイン: 検索結果
         search: '',
-        loading: false,
+        searchResults: [],
+        searchLoading: false,
+        selectedIds: [],
+        targetId: null,
+
+        // 共通
         merging: false,
         message: null,
         messageType: 'success',
-    });
-
-    Alpine.data('duplicatesApp', () => ({
-        ...state,
 
         async init() {
             await this.fetchDuplicates();
         },
 
+        // --- 左ペイン: 重複グループ ---
+
         async fetchDuplicates() {
-            this.loading = true;
-            this.message = null;
+            this.groupsLoading = true;
             try {
-                const params = new URLSearchParams();
-                if (this.search) params.set('search', this.search);
-                const res = await fetch(`/api/songs/duplicates?${params}`);
-                if (!res.ok) throw new Error('取得に失敗しました');
+                const res = await fetch('/api/songs/duplicates');
+                if (!res.ok) throw new Error('重複グループの取得に失敗しました');
                 this.groups = await res.json();
             } catch (e) {
                 this.message = e.message;
                 this.messageType = 'error';
             } finally {
-                this.loading = false;
+                this.groupsLoading = false;
             }
         },
 
-        async merge(group, targetSong) {
-            const sourceSongs = group.songs.filter(s => s.id !== targetSong.id);
-            if (sourceSongs.length === 0) return;
+        selectGroup(group) {
+            // グループのタイトルで検索
+            const title = group.songs[0]?.title || group.normalized_title;
+            this.search = title;
+            this.doSearch();
+        },
 
-            const confirmed = confirm(
-                `「${targetSong.title}」に統合します。${sourceSongs.length}件の楽曲が削除されます。よろしいですか？`
-            );
-            if (!confirmed) return;
+        // --- 右ペイン: 検索・選択・マージ ---
+
+        async doSearch() {
+            if (!this.search.trim()) return;
+            this.searchLoading = true;
+            this.searchResults = [];
+            this.selectedIds = [];
+            this.targetId = null;
+            this.message = null;
+            try {
+                const params = new URLSearchParams({ search: this.search });
+                const res = await fetch(`/api/songs/search-for-merge?${params}`);
+                if (!res.ok) throw new Error('検索に失敗しました');
+                this.searchResults = await res.json();
+            } catch (e) {
+                this.message = e.message;
+                this.messageType = 'error';
+            } finally {
+                this.searchLoading = false;
+            }
+        },
+
+        toggleSelect(songId) {
+            const idx = this.selectedIds.indexOf(songId);
+            if (idx === -1) {
+                this.selectedIds.push(songId);
+            } else {
+                this.selectedIds.splice(idx, 1);
+                // 選択解除されたものがtargetだったらtargetもクリア
+                if (this.targetId === songId) {
+                    this.targetId = null;
+                }
+            }
+        },
+
+        isSelected(songId) {
+            return this.selectedIds.includes(songId);
+        },
+
+        setTarget(songId) {
+            this.targetId = songId;
+        },
+
+        get canMerge() {
+            return this.targetId && this.selectedIds.length >= 2 && this.selectedIds.includes(this.targetId);
+        },
+
+        get sourceSongs() {
+            return this.selectedIds.filter(id => id !== this.targetId);
+        },
+
+        async doMerge() {
+            if (!this.canMerge) return;
+
+            const target = this.searchResults.find(s => s.id === this.targetId);
+            const sourceCount = this.sourceSongs.length;
+
+            if (!confirm(`「${target.title}」に統合します。${sourceCount}件の楽曲が削除されます。よろしいですか？`)) {
+                return;
+            }
 
             this.merging = true;
             this.message = null;
 
             try {
-                for (const source of sourceSongs) {
+                for (const sourceId of this.sourceSongs) {
                     const res = await fetch('/api/songs/merge', {
                         method: 'POST',
                         headers: {
@@ -58,8 +121,8 @@ document.addEventListener('DOMContentLoaded', () => {
                             'X-CSRF-TOKEN': csrfToken,
                         },
                         body: JSON.stringify({
-                            source_song_id: source.id,
-                            target_song_id: targetSong.id,
+                            source_song_id: sourceId,
+                            target_song_id: this.targetId,
                         }),
                     });
                     if (!res.ok) {
@@ -67,19 +130,19 @@ document.addEventListener('DOMContentLoaded', () => {
                         throw new Error(data.message || 'マージに失敗しました');
                     }
                 }
-                this.message = 'マージが完了しました';
+                this.message = `${sourceCount}件の楽曲を統合しました`;
                 this.messageType = 'success';
-                await this.fetchDuplicates();
+                this.selectedIds = [];
+                this.targetId = null;
+
+                // 両方更新
+                await Promise.all([this.fetchDuplicates(), this.doSearch()]);
             } catch (e) {
                 this.message = e.message;
                 this.messageType = 'error';
             } finally {
                 this.merging = false;
             }
-        },
-
-        totalRefs(song) {
-            return song.mappings_count + song.ts_items_count;
         },
     }));
 });

--- a/resources/js/songs/duplicates.js
+++ b/resources/js/songs/duplicates.js
@@ -1,0 +1,85 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const app = document.getElementById('duplicates-app');
+    if (!app) return;
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+
+    const state = Alpine.reactive({
+        groups: [],
+        search: '',
+        loading: false,
+        merging: false,
+        message: null,
+        messageType: 'success',
+    });
+
+    Alpine.data('duplicatesApp', () => ({
+        ...state,
+
+        async init() {
+            await this.fetchDuplicates();
+        },
+
+        async fetchDuplicates() {
+            this.loading = true;
+            this.message = null;
+            try {
+                const params = new URLSearchParams();
+                if (this.search) params.set('search', this.search);
+                const res = await fetch(`/api/songs/duplicates?${params}`);
+                if (!res.ok) throw new Error('取得に失敗しました');
+                this.groups = await res.json();
+            } catch (e) {
+                this.message = e.message;
+                this.messageType = 'error';
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        async merge(group, targetSong) {
+            const sourceSongs = group.songs.filter(s => s.id !== targetSong.id);
+            if (sourceSongs.length === 0) return;
+
+            const confirmed = confirm(
+                `「${targetSong.title}」に統合します。${sourceSongs.length}件の楽曲が削除されます。よろしいですか？`
+            );
+            if (!confirmed) return;
+
+            this.merging = true;
+            this.message = null;
+
+            try {
+                for (const source of sourceSongs) {
+                    const res = await fetch('/api/songs/merge', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-TOKEN': csrfToken,
+                        },
+                        body: JSON.stringify({
+                            source_song_id: source.id,
+                            target_song_id: targetSong.id,
+                        }),
+                    });
+                    if (!res.ok) {
+                        const data = await res.json();
+                        throw new Error(data.message || 'マージに失敗しました');
+                    }
+                }
+                this.message = 'マージが完了しました';
+                this.messageType = 'success';
+                await this.fetchDuplicates();
+            } catch (e) {
+                this.message = e.message;
+                this.messageType = 'error';
+            } finally {
+                this.merging = false;
+            }
+        },
+
+        totalRefs(song) {
+            return song.mappings_count + song.ts_items_count;
+        },
+    }));
+});

--- a/resources/views/songs/duplicates.blade.php
+++ b/resources/views/songs/duplicates.blade.php
@@ -1,0 +1,89 @@
+<x-app-layout>
+    <div class="py-4" id="duplicates-app" x-data="duplicatesApp">
+        <div class="max-w-5xl mx-auto sm:px-6 lg:px-8">
+            {{-- ヘッダー --}}
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg mb-4">
+                <div class="p-4 text-gray-900 dark:text-gray-100">
+                    <div class="flex items-center justify-between mb-3">
+                        <h3 class="text-lg font-semibold">楽曲名寄せ</h3>
+                        <div class="flex gap-2 text-sm">
+                            <a href="{{ route('songs.index') }}" class="text-blue-600 hover:underline">正規化画面</a>
+                            <a href="{{ route('songs.decompose') }}" class="text-blue-600 hover:underline">分解画面</a>
+                        </div>
+                    </div>
+
+                    {{-- 検索 --}}
+                    <div class="flex gap-2">
+                        <input type="text"
+                               x-model="search"
+                               @keydown.enter="fetchDuplicates()"
+                               placeholder="タイトルで検索..."
+                               class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm">
+                        <button @click="fetchDuplicates()"
+                                :disabled="loading"
+                                class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700 disabled:opacity-50">
+                            検索
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            {{-- メッセージ --}}
+            <template x-if="message">
+                <div class="mb-4 p-3 rounded-md text-sm"
+                     :class="messageType === 'success' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'"
+                     x-text="message"></div>
+            </template>
+
+            {{-- ローディング --}}
+            <template x-if="loading">
+                <div class="text-center py-8 text-gray-500 dark:text-gray-400">読み込み中...</div>
+            </template>
+
+            {{-- 結果なし --}}
+            <template x-if="!loading && groups.length === 0">
+                <div class="text-center py-8 text-gray-500 dark:text-gray-400">重複楽曲が見つかりませんでした</div>
+            </template>
+
+            {{-- 重複グループ一覧 --}}
+            <template x-for="(group, gi) in groups" :key="gi">
+                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg mb-4">
+                    <div class="p-4 text-gray-900 dark:text-gray-100">
+                        <div class="text-sm text-gray-500 dark:text-gray-400 mb-3">
+                            正規化タイトル: <span class="font-mono" x-text="group.normalized_title"></span>
+                            <template x-if="group.normalized_artist">
+                                <span> / <span class="font-mono" x-text="group.normalized_artist"></span></span>
+                            </template>
+                        </div>
+
+                        <div class="space-y-2">
+                            <template x-for="(song, si) in group.songs" :key="song.id">
+                                <div class="flex items-center justify-between p-3 border border-gray-200 dark:border-gray-700 rounded-md">
+                                    <div class="flex-1 min-w-0">
+                                        <div class="font-medium truncate" x-text="song.title"></div>
+                                        <div class="text-sm text-gray-500 dark:text-gray-400 truncate" x-text="song.artist || '(アーティスト未設定)'"></div>
+                                        <div class="flex gap-3 mt-1 text-xs text-gray-400 dark:text-gray-500">
+                                            <span>マッピング: <span class="font-medium" x-text="song.mappings_count"></span>件</span>
+                                            <span>個別紐付: <span class="font-medium" x-text="song.ts_items_count"></span>件</span>
+                                            <template x-if="song.spotify_track_id">
+                                                <span class="text-green-600">Spotify連携済</span>
+                                            </template>
+                                        </div>
+                                    </div>
+                                    <button @click="merge(group, song)"
+                                            :disabled="merging"
+                                            class="ml-3 flex-shrink-0 px-3 py-1.5 bg-blue-600 text-white text-xs rounded-md hover:bg-blue-700 disabled:opacity-50"
+                                            title="この楽曲を残して他を統合">
+                                        これに統合
+                                    </button>
+                                </div>
+                            </template>
+                        </div>
+                    </div>
+                </div>
+            </template>
+        </div>
+    </div>
+
+    @vite(['resources/js/songs/duplicates.js'])
+</x-app-layout>

--- a/resources/views/songs/duplicates.blade.php
+++ b/resources/views/songs/duplicates.blade.php
@@ -1,29 +1,15 @@
 <x-app-layout>
     <div class="py-4" id="duplicates-app" x-data="duplicatesApp">
-        <div class="max-w-5xl mx-auto sm:px-6 lg:px-8">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             {{-- ヘッダー --}}
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg mb-4">
                 <div class="p-4 text-gray-900 dark:text-gray-100">
-                    <div class="flex items-center justify-between mb-3">
+                    <div class="flex items-center justify-between">
                         <h3 class="text-lg font-semibold">楽曲名寄せ</h3>
                         <div class="flex gap-2 text-sm">
                             <a href="{{ route('songs.index') }}" class="text-blue-600 hover:underline">正規化画面</a>
                             <a href="{{ route('songs.decompose') }}" class="text-blue-600 hover:underline">分解画面</a>
                         </div>
-                    </div>
-
-                    {{-- 検索 --}}
-                    <div class="flex gap-2">
-                        <input type="text"
-                               x-model="search"
-                               @keydown.enter="fetchDuplicates()"
-                               placeholder="タイトルで検索..."
-                               class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm">
-                        <button @click="fetchDuplicates()"
-                                :disabled="loading"
-                                class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700 disabled:opacity-50">
-                            検索
-                        </button>
                     </div>
                 </div>
             </div>
@@ -35,53 +21,129 @@
                      x-text="message"></div>
             </template>
 
-            {{-- ローディング --}}
-            <template x-if="loading">
-                <div class="text-center py-8 text-gray-500 dark:text-gray-400">読み込み中...</div>
-            </template>
-
-            {{-- 結果なし --}}
-            <template x-if="!loading && groups.length === 0">
-                <div class="text-center py-8 text-gray-500 dark:text-gray-400">重複楽曲が見つかりませんでした</div>
-            </template>
-
-            {{-- 重複グループ一覧 --}}
-            <template x-for="(group, gi) in groups" :key="gi">
-                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg mb-4">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                {{-- 左ペイン: 重複グループ --}}
+                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
                     <div class="p-4 text-gray-900 dark:text-gray-100">
-                        <div class="text-sm text-gray-500 dark:text-gray-400 mb-3">
-                            正規化タイトル: <span class="font-mono" x-text="group.normalized_title"></span>
-                            <template x-if="group.normalized_artist">
-                                <span> / <span class="font-mono" x-text="group.normalized_artist"></span></span>
+                        <h4 class="font-semibold mb-3">重複検出グループ</h4>
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">クリックで検索欄にタイトルを入力し、名寄せ候補を検索します</p>
+
+                        <template x-if="groupsLoading">
+                            <div class="text-center py-4 text-gray-500 dark:text-gray-400 text-sm">読み込み中...</div>
+                        </template>
+
+                        <template x-if="!groupsLoading && groups.length === 0">
+                            <div class="text-center py-4 text-gray-500 dark:text-gray-400 text-sm">重複楽曲はありません</div>
+                        </template>
+
+                        <div class="space-y-2 max-h-[70vh] overflow-y-auto">
+                            <template x-for="(group, gi) in groups" :key="gi">
+                                <button @click="selectGroup(group)"
+                                        class="w-full text-left p-3 border border-gray-200 dark:border-gray-700 rounded-md hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors">
+                                    <div class="font-medium text-sm truncate" x-text="group.songs[0]?.title || group.normalized_title"></div>
+                                    <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                                        <span x-text="group.songs.length"></span>件の楽曲
+                                        <template x-if="group.normalized_artist">
+                                            <span> / <span x-text="group.normalized_artist"></span></span>
+                                        </template>
+                                    </div>
+                                </button>
                             </template>
                         </div>
+                    </div>
+                </div>
 
-                        <div class="space-y-2">
-                            <template x-for="(song, si) in group.songs" :key="song.id">
-                                <div class="flex items-center justify-between p-3 border border-gray-200 dark:border-gray-700 rounded-md">
+                {{-- 右ペイン: 検索・選択・マージ --}}
+                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-4 text-gray-900 dark:text-gray-100">
+                        <h4 class="font-semibold mb-3">名寄せ候補</h4>
+
+                        {{-- 検索欄 --}}
+                        <div class="flex gap-2 mb-3">
+                            <input type="text"
+                                   x-model="search"
+                                   @keydown.enter="doSearch()"
+                                   placeholder="タイトル・アーティストで検索..."
+                                   class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm">
+                            <button @click="doSearch()"
+                                    :disabled="searchLoading"
+                                    class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700 disabled:opacity-50">
+                                検索
+                            </button>
+                        </div>
+
+                        {{-- マージボタン --}}
+                        <div x-show="selectedIds.length >= 2" class="mb-3 p-2 bg-blue-50 dark:bg-blue-900/20 rounded-md">
+                            <div class="text-xs text-gray-600 dark:text-gray-400 mb-1">
+                                <span x-text="selectedIds.length"></span>件選択中
+                                <template x-if="targetId">
+                                    <span> (マージ先を選択済み)</span>
+                                </template>
+                            </div>
+                            <button @click="doMerge()"
+                                    :disabled="!canMerge || merging"
+                                    class="px-4 py-1.5 bg-orange-600 text-white text-sm rounded-md hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed">
+                                <span x-show="!merging">選択した楽曲をマージ</span>
+                                <span x-show="merging">マージ中...</span>
+                            </button>
+                            <span x-show="selectedIds.length >= 2 && !targetId" class="text-xs text-orange-600 ml-2">マージ先を選んでください</span>
+                        </div>
+
+                        {{-- 検索結果 --}}
+                        <template x-if="searchLoading">
+                            <div class="text-center py-4 text-gray-500 dark:text-gray-400 text-sm">検索中...</div>
+                        </template>
+
+                        <template x-if="!searchLoading && searchResults.length === 0 && search">
+                            <div class="text-center py-4 text-gray-500 dark:text-gray-400 text-sm">該当する楽曲がありません</div>
+                        </template>
+
+                        <template x-if="!searchLoading && !search">
+                            <div class="text-center py-4 text-gray-500 dark:text-gray-400 text-sm">左のグループをクリックするか、検索してください</div>
+                        </template>
+
+                        <div class="space-y-1 max-h-[60vh] overflow-y-auto">
+                            <template x-for="song in searchResults" :key="song.id">
+                                <div class="flex items-center gap-2 p-2 border rounded-md transition-colors"
+                                     :class="{
+                                         'border-blue-500 bg-blue-50 dark:bg-blue-900/20': isSelected(song.id),
+                                         'border-orange-500 bg-orange-50 dark:bg-orange-900/20 ring-2 ring-orange-300': targetId === song.id,
+                                         'border-gray-200 dark:border-gray-700': !isSelected(song.id)
+                                     }">
+                                    {{-- チェックボックス --}}
+                                    <input type="checkbox"
+                                           :checked="isSelected(song.id)"
+                                           @change="toggleSelect(song.id)"
+                                           class="w-4 h-4 flex-shrink-0 text-blue-600 rounded focus:ring-blue-500">
+
+                                    {{-- 楽曲情報 --}}
                                     <div class="flex-1 min-w-0">
-                                        <div class="font-medium truncate" x-text="song.title"></div>
-                                        <div class="text-sm text-gray-500 dark:text-gray-400 truncate" x-text="song.artist || '(アーティスト未設定)'"></div>
-                                        <div class="flex gap-3 mt-1 text-xs text-gray-400 dark:text-gray-500">
-                                            <span>マッピング: <span class="font-medium" x-text="song.mappings_count"></span>件</span>
-                                            <span>個別紐付: <span class="font-medium" x-text="song.ts_items_count"></span>件</span>
+                                        <div class="text-sm font-medium truncate" x-text="song.title"></div>
+                                        <div class="text-xs text-gray-500 dark:text-gray-400 truncate" x-text="song.artist || '(アーティスト未設定)'"></div>
+                                        <div class="flex gap-2 mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+                                            <span>MP: <span x-text="song.mappings_count"></span></span>
+                                            <span>TS: <span x-text="song.ts_items_count"></span></span>
                                             <template x-if="song.spotify_track_id">
-                                                <span class="text-green-600">Spotify連携済</span>
+                                                <span class="text-green-600">Spotify</span>
                                             </template>
                                         </div>
                                     </div>
-                                    <button @click="merge(group, song)"
-                                            :disabled="merging"
-                                            class="ml-3 flex-shrink-0 px-3 py-1.5 bg-blue-600 text-white text-xs rounded-md hover:bg-blue-700 disabled:opacity-50"
-                                            title="この楽曲を残して他を統合">
-                                        これに統合
+
+                                    {{-- マージ先ボタン --}}
+                                    <button x-show="isSelected(song.id)"
+                                            @click="setTarget(song.id)"
+                                            class="flex-shrink-0 px-2 py-1 text-xs rounded-md transition-colors"
+                                            :class="targetId === song.id
+                                                ? 'bg-orange-600 text-white'
+                                                : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 hover:bg-orange-100 dark:hover:bg-orange-900/30'"
+                                            x-text="targetId === song.id ? 'マージ先' : '残す'">
                                     </button>
                                 </div>
                             </template>
                         </div>
                     </div>
                 </div>
-            </template>
+            </div>
         </div>
     </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -89,6 +89,7 @@ Route::middleware(['auth', 'admin'])->group(function () {
     Route::delete('api/songs/unlink-ts-item', [SongController::class, 'unlinkTsItem'])->name('songs.unlinkTsItem');
     Route::get('api/songs/ts-items-by-normalized-text', [SongController::class, 'getTsItemsByNormalizedText'])->name('songs.getTsItemsByNormalizedText');
     Route::get('api/songs/duplicates', [SongController::class, 'findDuplicates'])->name('songs.findDuplicates');
+    Route::get('api/songs/search-for-merge', [SongController::class, 'searchSongsForMerge'])->name('songs.searchForMerge');
     Route::post('api/songs/merge', [SongController::class, 'mergeSongs'])->name('songs.mergeSongs');
     // Parameterized route - must be last to avoid capturing specific route names
     Route::put('api/songs/{id}', [SongController::class, 'updateSong'])->name('songs.updateSong');

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,6 +37,7 @@ Route::middleware(['auth', 'admin'])->group(function () {
 
     // 楽曲マスタ管理
     Route::get('/songs/normalize', [SongController::class, 'index'])->name('songs.index');
+    Route::get('/songs/duplicates', [SongController::class, 'duplicates'])->name('songs.duplicates');
 
     // タイムスタンプ分解・選別
     Route::get('/songs/decompose', [TimestampDecompositionController::class, 'index'])->name('songs.decompose');
@@ -87,6 +88,8 @@ Route::middleware(['auth', 'admin'])->group(function () {
     Route::post('api/songs/link-ts-item', [SongController::class, 'linkTsItemToSong'])->name('songs.linkTsItemToSong');
     Route::delete('api/songs/unlink-ts-item', [SongController::class, 'unlinkTsItem'])->name('songs.unlinkTsItem');
     Route::get('api/songs/ts-items-by-normalized-text', [SongController::class, 'getTsItemsByNormalizedText'])->name('songs.getTsItemsByNormalizedText');
+    Route::get('api/songs/duplicates', [SongController::class, 'findDuplicates'])->name('songs.findDuplicates');
+    Route::post('api/songs/merge', [SongController::class, 'mergeSongs'])->name('songs.mergeSongs');
     // Parameterized route - must be last to avoid capturing specific route names
     Route::put('api/songs/{id}', [SongController::class, 'updateSong'])->name('songs.updateSong');
     Route::delete('api/songs/{id}', [SongController::class, 'deleteSong'])->name('songs.deleteSong');

--- a/tests/Feature/SongMergeTest.php
+++ b/tests/Feature/SongMergeTest.php
@@ -169,4 +169,29 @@ class SongMergeTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonCount(0);
     }
+
+    public function test_search_songs_for_merge_returns_partial_matches(): void
+    {
+        Song::factory()->create(['title' => '夜に駆ける', 'artist' => 'YOASOBI']);
+        Song::factory()->create(['title' => '夜に駆ける / YOASOBI', 'artist' => '']);
+        Song::factory()->create(['title' => '全く関係ない曲', 'artist' => 'Other']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/songs/search-for-merge?search=夜に駆ける');
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertCount(2, $data);
+    }
+
+    public function test_search_songs_for_merge_empty_search_returns_empty(): void
+    {
+        Song::factory()->create(['title' => 'Test']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/songs/search-for-merge?search=');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(0);
+    }
 }

--- a/tests/Feature/SongMergeTest.php
+++ b/tests/Feature/SongMergeTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Song;
+use App\Models\TimestampSongMapping;
+use App\Models\TsItem;
+use App\Models\User;
+use App\Models\Archive;
+use App\Models\Channel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SongMergeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create([
+            'email_verified_at' => now(),
+            'role' => User::ROLE_SUPER_ADMIN,
+        ]);
+    }
+
+    public function test_find_duplicates_returns_groups(): void
+    {
+        // 同じnormalized_titleを持つ2曲を作成
+        Song::factory()->create(['title' => 'Test Song', 'artist' => 'Artist A']);
+        Song::factory()->create(['title' => 'test song', 'artist' => 'artist a']);
+
+        // 別の曲（重複なし）
+        Song::factory()->create(['title' => 'Unique Song', 'artist' => 'Artist B']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/songs/duplicates');
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertCount(1, $data);
+        $this->assertCount(2, $data[0]['songs']);
+    }
+
+    public function test_find_duplicates_with_search(): void
+    {
+        Song::factory()->create(['title' => 'Test Song', 'artist' => 'Artist']);
+        Song::factory()->create(['title' => 'test song', 'artist' => 'artist']);
+        Song::factory()->create(['title' => 'Other Song', 'artist' => 'Other']);
+        Song::factory()->create(['title' => 'other song', 'artist' => 'other']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/songs/duplicates?search=Test');
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertCount(1, $data);
+    }
+
+    public function test_merge_songs_happy_path(): void
+    {
+        $targetSong = Song::factory()->create(['title' => 'Test Song', 'artist' => 'Artist']);
+        $sourceSong = Song::factory()->create(['title' => 'test song', 'artist' => 'artist']);
+
+        // sourceSongにマッピングを紐付け
+        TimestampSongMapping::factory()
+            ->withSong($sourceSong)
+            ->withText('test text 1')
+            ->create();
+        TimestampSongMapping::factory()
+            ->withSong($sourceSong)
+            ->withText('test text 2')
+            ->create();
+
+        // sourceSongに個別ts_itemを紐付け
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+        TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'song_id' => $sourceSong->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/songs/merge', [
+                'source_song_id' => $sourceSong->id,
+                'target_song_id' => $targetSong->id,
+            ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'affected_mappings' => 2,
+            'affected_ts_items' => 1,
+        ]);
+
+        // sourceSongが削除されていること
+        $this->assertDatabaseMissing('songs', ['id' => $sourceSong->id]);
+
+        // マッピングがtargetSongに移行されていること
+        $this->assertEquals(2, TimestampSongMapping::where('song_id', $targetSong->id)->count());
+
+        // ts_itemがtargetSongに移行されていること
+        $this->assertEquals(1, TsItem::where('song_id', $targetSong->id)->count());
+
+        // ログが記録されていること
+        $this->assertDatabaseHas('normalization_logs', [
+            'action' => 'merge_song',
+            'target_id' => $targetSong->id,
+        ]);
+    }
+
+    public function test_merge_songs_with_no_references(): void
+    {
+        $targetSong = Song::factory()->create(['title' => 'Target']);
+        $sourceSong = Song::factory()->create(['title' => 'Source']);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/songs/merge', [
+                'source_song_id' => $sourceSong->id,
+                'target_song_id' => $targetSong->id,
+            ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'affected_mappings' => 0,
+            'affected_ts_items' => 0,
+        ]);
+
+        $this->assertDatabaseMissing('songs', ['id' => $sourceSong->id]);
+    }
+
+    public function test_merge_songs_rejects_same_id(): void
+    {
+        $song = Song::factory()->create();
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/songs/merge', [
+                'source_song_id' => $song->id,
+                'target_song_id' => $song->id,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['target_song_id']);
+    }
+
+    public function test_merge_songs_rejects_nonexistent_id(): void
+    {
+        $song = Song::factory()->create();
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/songs/merge', [
+                'source_song_id' => 'nonexistent-id',
+                'target_song_id' => $song->id,
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['source_song_id']);
+    }
+
+    public function test_find_duplicates_returns_empty_when_no_duplicates(): void
+    {
+        Song::factory()->create(['title' => 'Song A']);
+        Song::factory()->create(['title' => 'Song B']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/songs/duplicates');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(0);
+    }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig(() => {
                     'resources/js/channels/play-history.js',
                     'resources/js/songs/normalize.js',
                     'resources/js/songs/decompose.js',
+                    'resources/js/songs/duplicates.js',
                 ],
                 refresh: true,
             }),


### PR DESCRIPTION
## Summary
- normalized_title + normalized_artist が同じ楽曲をグループ化して重複検出
- マージ操作で、マッピングと個別ts_item紐付けを自動でターゲット楽曲に移行し、マージ元を削除
- `/songs/duplicates` に管理画面を追加（検索、マージ操作）
- 監査ログ（NormalizationLog）でマージ操作を記録

## 変更ファイル
- `SongMergeService` (新規): 重複検出・マージロジック
- `SongController`: duplicates/findDuplicates/mergeSongsメソッド追加
- `NormalizationLog`: ACTION_MERGE_SONG定数追加
- `songs/duplicates.blade.php` + `duplicates.js` (新規): UI
- `routes/web.php`: 3ルート追加
- `vite.config.js`: JSエントリ追加

Closes #426

## Test plan
- [ ] `/songs/duplicates` 画面が表示されること
- [ ] 重複楽曲がグループ表示されること
- [ ] 「これに統合」ボタンでマージが実行されること
- [ ] マージ後にマッピング・個別紐付けがターゲットに移行されていること
- [ ] 自分自身へのマージがバリデーションエラーになること
- [ ] テスト6件がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)