### PR TITLE
feat: チャンネル別テキスト除去パターン機能

### DIFF
--- a/app/Http/Controllers/ManageSettingsApiController.php
+++ b/app/Http/Controllers/ManageSettingsApiController.php
@@ -134,21 +134,17 @@ class ManageSettingsApiController extends Controller
         }
 
         $validated = $request->validate([
-            'pattern' => 'required|string|max:255',
+            'pattern' => ['required', 'string', 'max:255', 'regex:/\S/'],
         ]);
 
-        $exists = ChannelStripPattern::where('channel_id', $channel->channel_id)
-            ->where('pattern', $validated['pattern'])
-            ->exists();
-
-        if ($exists) {
+        try {
+            $pattern = ChannelStripPattern::create([
+                'channel_id' => $channel->channel_id,
+                'pattern' => $validated['pattern'],
+            ]);
+        } catch (\Illuminate\Database\UniqueConstraintViolationException $e) {
             return response()->json(['message' => '既に登録されています'], 422);
         }
-
-        $pattern = ChannelStripPattern::create([
-            'channel_id' => $channel->channel_id,
-            'pattern' => $validated['pattern'],
-        ]);
 
         return response()->json($pattern, 201);
     }
@@ -190,34 +186,52 @@ class ManageSettingsApiController extends Controller
 
         $updatedCount = 0;
 
-        // チャンネルのts_itemsをチャンクで処理
-        TsItem::whereHas('archive', function ($q) use ($channel) {
-            $q->where('channel_id', $channel->channel_id);
-        })
-            ->chunk(200, function ($tsItems) use ($stripPatterns, &$updatedCount) {
-                foreach ($tsItems as $tsItem) {
-                    $text = $tsItem->text;
-                    if (! $text) {
-                        continue;
-                    }
+        \Log::info('reapplyStripPatterns: 処理開始', [
+            'channel_id' => $channel->channel_id,
+            'strip_patterns_count' => count($stripPatterns),
+        ]);
 
-                    // 除去パターンを適用してからnormalize
-                    $textForNormalize = ! empty($stripPatterns)
-                        ? TimestampExtractorService::applyStripPatterns($text, $stripPatterns)
-                        : $text;
-                    $newNormalized = TextNormalizer::normalize($textForNormalize);
+        DB::transaction(function () use ($channel, $stripPatterns, &$updatedCount) {
+            // チャンネルのts_itemsをチャンクで処理
+            TsItem::whereHas('archive', function ($q) use ($channel) {
+                $q->where('channel_id', $channel->channel_id);
+            })
+                ->chunk(200, function ($tsItems) use ($stripPatterns, &$updatedCount) {
+                    foreach ($tsItems as $tsItem) {
+                        // アクセサを経由せず生のtext値を使用（TsItem::savingと同じ）
+                        $rawText = $tsItem->attributes['text'] ?? null;
+                        if (! $rawText) {
+                            continue;
+                        }
 
-                    if ($tsItem->normalized_text !== $newNormalized) {
-                        DB::table('ts_items')
-                            ->where('id', $tsItem->id)
-                            ->update([
-                                'normalized_text' => $newNormalized,
-                                'updated_at' => now(),
-                            ]);
-                        $updatedCount++;
+                        // 除去パターンを適用してからnormalize
+                        $textForNormalize = ! empty($stripPatterns)
+                            ? TimestampExtractorService::applyStripPatterns($rawText, $stripPatterns)
+                            : $rawText;
+                        $newNormalized = TextNormalizer::normalize($textForNormalize);
+
+                        // 正規化結果が空の場合のフォールバック（TsItem::savingと同じロジック）
+                        if ($newNormalized === '' && trim($textForNormalize) !== '') {
+                            $newNormalized = mb_strtolower(trim($textForNormalize), 'UTF-8');
+                        }
+
+                        if ($tsItem->normalized_text !== $newNormalized) {
+                            DB::table('ts_items')
+                                ->where('id', $tsItem->id)
+                                ->update([
+                                    'normalized_text' => $newNormalized,
+                                    'updated_at' => now(),
+                                ]);
+                            $updatedCount++;
+                        }
                     }
-                }
-            });
+                });
+        });
+
+        \Log::info('reapplyStripPatterns: 処理完了', [
+            'channel_id' => $channel->channel_id,
+            'updated_count' => $updatedCount,
+        ]);
 
         return response()->json([
             'message' => sprintf('除去パターンを再適用しました（%d件更新）', $updatedCount),

--- a/app/Http/Controllers/ManageSettingsApiController.php
+++ b/app/Http/Controllers/ManageSettingsApiController.php
@@ -191,52 +191,79 @@ class ManageSettingsApiController extends Controller
             'strip_patterns_count' => count($stripPatterns),
         ]);
 
-        DB::transaction(function () use ($channel, $stripPatterns, &$updatedCount) {
-            // チャンネルのts_itemsをチャンクで処理
-            TsItem::whereHas('archive', function ($q) use ($channel) {
-                $q->where('channel_id', $channel->channel_id);
-            })
-                ->chunk(200, function ($tsItems) use ($stripPatterns, &$updatedCount) {
-                    foreach ($tsItems as $tsItem) {
-                        // アクセサを経由せず生のtext値を使用（TsItem::savingと同じ）
-                        $rawText = $tsItem->attributes['text'] ?? null;
-                        if (! $rawText) {
-                            continue;
+        try {
+            DB::transaction(function () use ($channel, $stripPatterns, &$updatedCount) {
+                // 変更前のnormalized_textを収集（自動紐付けリセット用）
+                $oldNormalizedTexts = [];
+
+                // チャンネルのts_itemsをチャンクで処理
+                TsItem::whereHas('archive', function ($q) use ($channel) {
+                    $q->where('channel_id', $channel->channel_id);
+                })
+                    ->chunk(200, function ($tsItems) use ($stripPatterns, &$updatedCount, &$oldNormalizedTexts) {
+                        foreach ($tsItems as $tsItem) {
+                            // アクセサを経由せず生のtext値を使用（TsItem::savingと同じ）
+                            $rawText = $tsItem->attributes['text'] ?? null;
+                            if (! $rawText) {
+                                continue;
+                            }
+
+                            // 除去パターンを適用してからnormalize
+                            $textForNormalize = ! empty($stripPatterns)
+                                ? TimestampExtractorService::applyStripPatterns($rawText, $stripPatterns)
+                                : $rawText;
+                            $newNormalized = TextNormalizer::normalize($textForNormalize);
+
+                            // 正規化結果が空の場合のフォールバック（TsItem::savingと同じロジック）
+                            if ($newNormalized === '' && trim($textForNormalize) !== '') {
+                                $newNormalized = mb_strtolower(trim($textForNormalize), 'UTF-8');
+                            }
+
+                            if ($tsItem->normalized_text !== $newNormalized) {
+                                $oldNormalizedTexts[] = $tsItem->normalized_text;
+
+                                DB::table('ts_items')
+                                    ->where('id', $tsItem->id)
+                                    ->update([
+                                        'normalized_text' => $newNormalized,
+                                        'updated_at' => now(),
+                                    ]);
+                                $updatedCount++;
+                            }
                         }
+                    });
 
-                        // 除去パターンを適用してからnormalize
-                        $textForNormalize = ! empty($stripPatterns)
-                            ? TimestampExtractorService::applyStripPatterns($rawText, $stripPatterns)
-                            : $rawText;
-                        $newNormalized = TextNormalizer::normalize($textForNormalize);
+                // 自動紐付け（is_manual=false）をリセット
+                if (! empty($oldNormalizedTexts)) {
+                    $oldNormalizedTexts = array_unique($oldNormalizedTexts);
+                    TimestampSongMapping::whereIn('normalized_text', $oldNormalizedTexts)
+                        ->where('is_manual', false)
+                        ->delete();
+                }
+            });
 
-                        // 正規化結果が空の場合のフォールバック（TsItem::savingと同じロジック）
-                        if ($newNormalized === '' && trim($textForNormalize) !== '') {
-                            $newNormalized = mb_strtolower(trim($textForNormalize), 'UTF-8');
-                        }
+            \Log::info('reapplyStripPatterns: 処理完了', [
+                'channel_id' => $channel->channel_id,
+                'updated_count' => $updatedCount,
+            ]);
 
-                        if ($tsItem->normalized_text !== $newNormalized) {
-                            DB::table('ts_items')
-                                ->where('id', $tsItem->id)
-                                ->update([
-                                    'normalized_text' => $newNormalized,
-                                    'updated_at' => now(),
-                                ]);
-                            $updatedCount++;
-                        }
-                    }
-                });
-        });
+            return response()->json([
+                'message' => sprintf('除去パターンを再適用しました（%d件更新）', $updatedCount),
+                'updated_count' => $updatedCount,
+            ]);
+        } catch (\Exception $e) {
+            \Log::error('reapplyStripPatterns: エラー発生', [
+                'channel_id' => $channel->channel_id,
+                'error_message' => $e->getMessage(),
+                'error_file' => $e->getFile(),
+                'error_line' => $e->getLine(),
+            ]);
 
-        \Log::info('reapplyStripPatterns: 処理完了', [
-            'channel_id' => $channel->channel_id,
-            'updated_count' => $updatedCount,
-        ]);
-
-        return response()->json([
-            'message' => sprintf('除去パターンを再適用しました（%d件更新）', $updatedCount),
-            'updated_count' => $updatedCount,
-        ]);
+            return response()->json([
+                'message' => '処理中にエラーが発生しました。ログを確認してください。',
+                'error' => true,
+            ], 500);
+        }
     }
 
     /**

--- a/app/Http/Controllers/ManageSettingsApiController.php
+++ b/app/Http/Controllers/ManageSettingsApiController.php
@@ -7,7 +7,9 @@ use App\Http\Controllers\Concerns\ManageAccessControl;
 use App\Models\Archive;
 use App\Models\Channel;
 use App\Models\ChannelExcludedWord;
+use App\Models\ChannelStripPattern;
 use App\Models\TimestampSongMapping;
+use App\Services\TimestampExtractorService;
 use App\Models\TsItem;
 use App\Services\CoverSongTitleExtractorService;
 use App\Services\VideoAnalyzerService;
@@ -100,6 +102,127 @@ class ManageSettingsApiController extends Controller
         $excludedWord->delete();
 
         return response()->json(['message' => '削除しました']);
+    }
+
+    /**
+     * 除去パターン一覧を取得
+     */
+    public function fetchStripPatterns(string $id)
+    {
+        $handle = Crypt::decryptString($id);
+        $channel = Channel::where('handle', $handle)->firstOrFail();
+
+        if (! $this->canAccessChannel($channel)) {
+            abort(403, 'このチャンネルへのアクセス権限がありません');
+        }
+
+        $patterns = $channel->stripPatterns()->orderBy('pattern')->get();
+
+        return response()->json($patterns);
+    }
+
+    /**
+     * 除去パターンを追加
+     */
+    public function addStripPattern(Request $request, string $id)
+    {
+        $handle = Crypt::decryptString($id);
+        $channel = Channel::where('handle', $handle)->firstOrFail();
+
+        if (! $this->canAccessChannel($channel)) {
+            abort(403, 'このチャンネルへのアクセス権限がありません');
+        }
+
+        $validated = $request->validate([
+            'pattern' => 'required|string|max:255',
+        ]);
+
+        $exists = ChannelStripPattern::where('channel_id', $channel->channel_id)
+            ->where('pattern', $validated['pattern'])
+            ->exists();
+
+        if ($exists) {
+            return response()->json(['message' => '既に登録されています'], 422);
+        }
+
+        $pattern = ChannelStripPattern::create([
+            'channel_id' => $channel->channel_id,
+            'pattern' => $validated['pattern'],
+        ]);
+
+        return response()->json($pattern, 201);
+    }
+
+    /**
+     * 除去パターンを削除
+     */
+    public function deleteStripPattern(string $id, string $patternId)
+    {
+        $handle = Crypt::decryptString($id);
+        $channel = Channel::where('handle', $handle)->firstOrFail();
+
+        if (! $this->canAccessChannel($channel)) {
+            abort(403, 'このチャンネルへのアクセス権限がありません');
+        }
+
+        $pattern = ChannelStripPattern::where('id', $patternId)
+            ->where('channel_id', $channel->channel_id)
+            ->firstOrFail();
+
+        $pattern->delete();
+
+        return response()->json(['message' => '削除しました']);
+    }
+
+    /**
+     * 除去パターンをすべてのts_itemsに再適用（normalized_textを再生成）
+     */
+    public function reapplyStripPatterns(string $id)
+    {
+        $handle = Crypt::decryptString($id);
+        $channel = Channel::where('handle', $handle)->firstOrFail();
+
+        if (! $this->canAccessChannel($channel)) {
+            abort(403, 'このチャンネルへのアクセス権限がありません');
+        }
+
+        $stripPatterns = $channel->stripPatterns()->pluck('pattern')->toArray();
+
+        $updatedCount = 0;
+
+        // チャンネルのts_itemsをチャンクで処理
+        TsItem::whereHas('archive', function ($q) use ($channel) {
+            $q->where('channel_id', $channel->channel_id);
+        })
+            ->chunk(200, function ($tsItems) use ($stripPatterns, &$updatedCount) {
+                foreach ($tsItems as $tsItem) {
+                    $text = $tsItem->text;
+                    if (! $text) {
+                        continue;
+                    }
+
+                    // 除去パターンを適用してからnormalize
+                    $textForNormalize = ! empty($stripPatterns)
+                        ? TimestampExtractorService::applyStripPatterns($text, $stripPatterns)
+                        : $text;
+                    $newNormalized = TextNormalizer::normalize($textForNormalize);
+
+                    if ($tsItem->normalized_text !== $newNormalized) {
+                        DB::table('ts_items')
+                            ->where('id', $tsItem->id)
+                            ->update([
+                                'normalized_text' => $newNormalized,
+                                'updated_at' => now(),
+                            ]);
+                        $updatedCount++;
+                    }
+                }
+            });
+
+        return response()->json([
+            'message' => sprintf('除去パターンを再適用しました（%d件更新）', $updatedCount),
+            'updated_count' => $updatedCount,
+        ]);
     }
 
     /**

--- a/app/Models/Channel.php
+++ b/app/Models/Channel.php
@@ -28,4 +28,9 @@ class Channel extends Model
     {
         return $this->hasMany(ChannelExcludedWord::class, 'channel_id', 'channel_id');
     }
+
+    public function stripPatterns()
+    {
+        return $this->hasMany(ChannelStripPattern::class, 'channel_id', 'channel_id');
+    }
 }

--- a/app/Models/ChannelStripPattern.php
+++ b/app/Models/ChannelStripPattern.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+
+class ChannelStripPattern extends Model
+{
+    use HasUlids;
+
+    protected $fillable = [
+        'channel_id',
+        'pattern',
+    ];
+
+    public function channel()
+    {
+        return $this->belongsTo(Channel::class, 'channel_id', 'channel_id');
+    }
+}

--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -54,11 +54,14 @@ class RefreshArchiveService
 
     public function refreshArchives(Channel $channel): int
     {
+        // チャンネルの除去パターンをロード
+        $stripPatterns = $channel->stripPatterns()->pluck('pattern')->toArray();
+
         // 外部API呼び出しを全てトランザクション外で事前に実行
         // 1. archivesとts_itemsの取得および整形
         try {
             $rtn_archives = $this->youtubeService
-                ->getArchivesAndTsItems($channel->channel_id);
+                ->getArchivesAndTsItems($channel->channel_id, $stripPatterns);
         } catch (Exception $e) {
             error_log($e->getMessage());
             throw new Exception('youtubeとの接続でエラーが発生しました');
@@ -112,7 +115,7 @@ class RefreshArchiveService
             }
             try {
                 // API呼び出しのみ実行し、結果を保存
-                $comment_ts_items_map[$video_id] = $this->youtubeService->getTimeStampsFromComments($video_id);
+                $comment_ts_items_map[$video_id] = $this->youtubeService->getTimeStampsFromComments($video_id, $stripPatterns);
             } catch (Exception $e) {
                 error_log($e->getMessage());
                 throw new Exception('youtubeとの接続でエラーが発生しました');
@@ -268,8 +271,18 @@ class RefreshArchiveService
      */
     public function refreshTimeStampsFromComments(string $videoId): void
     {
+        // videoIdからチャンネルの除去パターンを取得
+        $archive = Archive::where('video_id', $videoId)->first();
+        $stripPatterns = [];
+        if ($archive) {
+            $channel = Channel::where('channel_id', $archive->channel_id)->first();
+            if ($channel) {
+                $stripPatterns = $channel->stripPatterns()->pluck('pattern')->toArray();
+            }
+        }
+
         try {
-            $ts_items = $this->youtubeService->getTimeStampsFromComments($videoId);
+            $ts_items = $this->youtubeService->getTimeStampsFromComments($videoId, $stripPatterns);
         } catch (Exception $e) {
             error_log($e->getMessage());
             throw new Exception('youtubeとの接続でエラーが発生しました');

--- a/app/Services/TimestampExtractorService.php
+++ b/app/Services/TimestampExtractorService.php
@@ -8,15 +8,32 @@ use Illuminate\Support\Str;
 class TimestampExtractorService
 {
     /**
+     * 除去パターンを適用してテキストから装飾文字を除去する
+     *
+     * @param  string  $text  元テキスト
+     * @param  array  $stripPatterns  除去パターン文字列の配列
+     * @return string 除去後のテキスト
+     */
+    public static function applyStripPatterns(string $text, array $stripPatterns): string
+    {
+        foreach ($stripPatterns as $pattern) {
+            $text = str_replace($pattern, '', $text);
+        }
+
+        return trim($text);
+    }
+
+    /**
      * テキストからタイムスタンプを抽出
      *
      * @param  string  $videoId  動画ID
      * @param  string  $type  タイプ（1: description, 2: comment）
      * @param  string  $description  抽出対象のテキスト
      * @param  string  $commentId  コメントID
+     * @param  array  $stripPatterns  除去パターン文字列の配列（チャンネル設定）
      * @return array タイムスタンプ配列
      */
-    public function extractTimestamps(string $videoId, string $type, string $description, string $commentId): array
+    public function extractTimestamps(string $videoId, string $type, string $description, string $commentId, array $stripPatterns = []): array
     {
         // 引数のバリデーション
         if (! is_string($videoId) || ! is_string($description)) {
@@ -48,6 +65,11 @@ class TimestampExtractorService
                 // 不正なUTF-8をサニタイズしてから保存
                 $sanitizedComment = TextNormalizer::sanitizeUtf8($comment);
 
+                // 除去パターンを適用してからnormalize（textは元のまま保持）
+                $textForNormalize = ! empty($stripPatterns)
+                    ? self::applyStripPatterns($sanitizedComment, $stripPatterns)
+                    : $sanitizedComment;
+
                 // 結果に追加
                 $results[] = [
                     'id' => Str::ulid(),
@@ -57,7 +79,7 @@ class TimestampExtractorService
                     'ts_text' => $timestamp,
                     'ts_num' => $this->timestampToSeconds($timestamp),
                     'text' => $sanitizedComment,
-                    'normalized_text' => TextNormalizer::normalize($sanitizedComment),
+                    'normalized_text' => TextNormalizer::normalize($textForNormalize),
                 ];
             }
         }

--- a/app/Services/YouTubeService.php
+++ b/app/Services/YouTubeService.php
@@ -44,9 +44,10 @@ class YouTubeService
      * アーカイブとタイムスタンプを取得
      *
      * @param  string  $channelId  チャンネルID
+     * @param  array  $stripPatterns  除去パターン文字列の配列（チャンネル設定）
      * @return array アーカイブ配列（タイムスタンプ付き）
      */
-    public function getArchivesAndTsItems(string $channelId): array
+    public function getArchivesAndTsItems(string $channelId, array $stripPatterns = []): array
     {
         $archives = $this->youtubeApiService->getArchives($channelId);
         $rtnArchives = [];
@@ -60,6 +61,7 @@ class YouTubeService
                 '1', // description
                 $archive['description'],
                 $archive['video_id'],
+                $stripPatterns,
             );
 
             // 歌枠またはカバー曲の場合は一旦表示にする
@@ -72,7 +74,7 @@ class YouTubeService
             // 概要欄にタイムスタンプが1件以下（過去のコピペなどで0:00:00が残っている場合がある）
             // かつ、歌枠の場合（カバー曲は0:00タイムスタンプのみで十分なためコメント取得は不要）
             if ((empty($archive['ts_items']) || count($archive['ts_items']) <= 1) && $isSingingStream) {
-                $commentTsItems = $this->getTimeStampsFromComments($archive['video_id']);
+                $commentTsItems = $this->getTimeStampsFromComments($archive['video_id'], $stripPatterns);
                 foreach ($commentTsItems as $tsItem) {
                     $archive['ts_items'][] = $tsItem;
                 }
@@ -90,9 +92,10 @@ class YouTubeService
      * コメントからタイムスタンプを取得
      *
      * @param  string  $videoId  動画ID
+     * @param  array  $stripPatterns  除去パターン文字列の配列（チャンネル設定）
      * @return array タイムスタンプ配列
      */
-    public function getTimeStampsFromComments(string $videoId): array
+    public function getTimeStampsFromComments(string $videoId, array $stripPatterns = []): array
     {
         $comments = $this->youtubeApiService->getComments($videoId);
 
@@ -103,6 +106,7 @@ class YouTubeService
                 '2', // comment
                 $comment['description'],
                 $comment['id'],
+                $stripPatterns,
             );
             foreach ($tsItems as $tsItem) {
                 $rtnTsItems[] = $tsItem;

--- a/database/migrations/2026_03_27_000001_create_channel_strip_patterns_table.php
+++ b/database/migrations/2026_03_27_000001_create_channel_strip_patterns_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('channel_strip_patterns', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->string('channel_id');
+            $table->string('pattern');
+            $table->timestamps();
+
+            $table->foreign('channel_id')
+                ->references('channel_id')
+                ->on('channels')
+                ->onDelete('cascade');
+
+            $table->unique(['channel_id', 'pattern']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('channel_strip_patterns');
+    }
+};

--- a/resources/js/manage/settings.js
+++ b/resources/js/manage/settings.js
@@ -7,6 +7,12 @@ document.addEventListener('DOMContentLoaded', function () {
     const addExcludedWordBtn = document.getElementById('addExcludedWordBtn');
     const excludedWordError = document.getElementById('excludedWordError');
     const excludedWordsList = document.getElementById('excludedWordsList');
+    const newStripPatternInput = document.getElementById('newStripPattern');
+    const addStripPatternBtn = document.getElementById('addStripPatternBtn');
+    const stripPatternError = document.getElementById('stripPatternError');
+    const stripPatternsList = document.getElementById('stripPatternsList');
+    const reapplyStripPatternsBtn = document.getElementById('reapplyStripPatternsBtn');
+    const stripPatternMessage = document.getElementById('stripPatternMessage');
     const loadPreviewBtn = document.getElementById('loadPreviewBtn');
     const reprocessBtn = document.getElementById('reprocessBtn');
     const previewMessage = document.getElementById('previewMessage');
@@ -178,6 +184,136 @@ document.addEventListener('DOMContentLoaded', function () {
             });
     }
 
+    // 除去パターン一覧の取得
+    function fetchStripPatterns() {
+        axios.get(`/api/manage/channels/${encodeURIComponent(cryptHandle)}/strip-patterns`)
+            .then(function (response) {
+                const patterns = response.data;
+                if (patterns.length === 0) {
+                    stripPatternsList.innerHTML = '<div class="text-center text-gray-500 dark:text-gray-400 py-4">除去パターンが登録されていません</div>';
+                    return;
+                }
+
+                let html = '<ul class="divide-y dark:divide-gray-700">';
+                patterns.forEach(pattern => {
+                    html += `
+                        <li class="flex items-center justify-between px-4 py-3">
+                            <span class="text-gray-800 dark:text-gray-200">${escapeHTML(pattern.pattern)}</span>
+                            <button type="button" class="delete-pattern-btn text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm" data-id="${escapeHTML(pattern.id)}">
+                                削除
+                            </button>
+                        </li>
+                    `;
+                });
+                html += '</ul>';
+                stripPatternsList.innerHTML = html;
+
+                document.querySelectorAll('.delete-pattern-btn').forEach(btn => {
+                    btn.addEventListener('click', function () {
+                        deleteStripPattern(this.dataset.id);
+                    });
+                });
+            })
+            .catch(function (error) {
+                console.error("Error fetching strip patterns:", error);
+                stripPatternsList.innerHTML = '<div class="text-center text-red-500 py-4">除去パターンの取得に失敗しました</div>';
+            });
+    }
+
+    // 除去パターンの追加
+    function addStripPattern() {
+        const pattern = newStripPatternInput.value.trim();
+        if (!pattern) {
+            showStripPatternError('除去パターンを入力してください');
+            return;
+        }
+
+        if (isProcessing) return;
+        isProcessing = true;
+        toggleButtonDisabled(addStripPatternBtn, true);
+
+        axios.post(`/api/manage/channels/${encodeURIComponent(cryptHandle)}/strip-patterns`, { pattern })
+            .then(function () {
+                newStripPatternInput.value = '';
+                hideStripPatternError();
+                fetchStripPatterns();
+            })
+            .catch(function (error) {
+                if (error.response && error.response.data && error.response.data.message) {
+                    showStripPatternError(error.response.data.message);
+                } else {
+                    showStripPatternError('エラーが発生しました');
+                }
+            })
+            .finally(function () {
+                isProcessing = false;
+                toggleButtonDisabled(addStripPatternBtn, false);
+            });
+    }
+
+    // 除去パターンの削除
+    function deleteStripPattern(patternId) {
+        if (isProcessing) return;
+        if (!confirm('この除去パターンを削除しますか？')) return;
+
+        isProcessing = true;
+
+        axios.delete(`/api/manage/channels/${encodeURIComponent(cryptHandle)}/strip-patterns/${encodeURIComponent(patternId)}`)
+            .then(function () {
+                fetchStripPatterns();
+            })
+            .catch(function (error) {
+                console.error("Error deleting strip pattern:", error);
+                alert('削除に失敗しました');
+            })
+            .finally(function () {
+                isProcessing = false;
+            });
+    }
+
+    // 除去パターンの再適用
+    function reapplyStripPatterns() {
+        if (isProcessing) return;
+        if (!confirm('既存のタイムスタンプに除去パターンを再適用しますか？\nnormalized_textが再生成されます。')) return;
+
+        isProcessing = true;
+        toggleButtonDisabled(reapplyStripPatternsBtn, true);
+
+        showStripPatternMessage('再適用中...', 'text-gray-600');
+
+        axios.post(`/api/manage/channels/${encodeURIComponent(cryptHandle)}/strip-patterns/reapply`)
+            .then(function (response) {
+                showStripPatternMessage(response.data.message, 'text-green-600');
+            })
+            .catch(function (error) {
+                console.error("Error reapplying strip patterns:", error);
+                showStripPatternMessage('再適用に失敗しました', 'text-red-500');
+            })
+            .finally(function () {
+                isProcessing = false;
+                toggleButtonDisabled(reapplyStripPatternsBtn, false);
+            });
+    }
+
+    // 除去パターンエラー表示
+    function showStripPatternError(message) {
+        stripPatternError.textContent = message;
+        stripPatternError.classList.remove('hidden');
+    }
+
+    // 除去パターンエラー非表示
+    function hideStripPatternError() {
+        stripPatternError.textContent = '';
+        stripPatternError.classList.add('hidden');
+    }
+
+    // 除去パターンメッセージ表示
+    function showStripPatternMessage(message, colorClass) {
+        stripPatternMessage.textContent = message;
+        stripPatternMessage.className = `text-sm mt-2 ${colorClass}`;
+        stripPatternMessage.classList.remove('hidden');
+    }
+
     // マッピング状態に応じたCSSクラスを返す
     function getMappingClass(status) {
         switch (status) {
@@ -225,9 +361,18 @@ document.addEventListener('DOMContentLoaded', function () {
             addExcludedWord();
         }
     });
+    addStripPatternBtn.addEventListener('click', addStripPattern);
+    newStripPatternInput.addEventListener('keypress', function (e) {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            addStripPattern();
+        }
+    });
+    reapplyStripPatternsBtn.addEventListener('click', reapplyStripPatterns);
     loadPreviewBtn.addEventListener('click', loadPreview);
     reprocessBtn.addEventListener('click', reprocessCoverSongs);
 
     // 初期化
     fetchExcludedWords();
+    fetchStripPatterns();
 });

--- a/resources/js/manage/settings.js
+++ b/resources/js/manage/settings.js
@@ -274,7 +274,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // 除去パターンの再適用
     function reapplyStripPatterns() {
         if (isProcessing) return;
-        if (!confirm('既存のタイムスタンプに除去パターンを再適用しますか？\nnormalized_textが再生成されます。')) return;
+        if (!confirm('既存のタイムスタンプに除去パターンを再適用しますか？\n照合テキストが再生成され、自動紐付けがリセットされます。')) return;
 
         isProcessing = true;
         toggleButtonDisabled(reapplyStripPatternsBtn, true);

--- a/resources/views/manage/settings.blade.php
+++ b/resources/views/manage/settings.blade.php
@@ -59,6 +59,37 @@
                 </div>
             </div>
 
+            <!-- 除去パターン管理セクション -->
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+                <h3 class="text-lg font-bold text-gray-800 dark:text-gray-200 mb-4">除去パターン管理</h3>
+                <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                    タイムスタンプテキストから除去する文字列パターンを設定します。<br>
+                    装飾絵文字や記号など、楽曲名の一部ではない文字列を登録することで、紐付けの精度が向上します。<br>
+                    例: 🎵, ♪, ▶, 【, 】
+                </p>
+
+                <!-- 除去パターン追加フォーム -->
+                <div class="flex items-center gap-2 mb-4">
+                    <x-text-input type="text" id="newStripPattern" placeholder="除去する文字列を入力" class="flex-1" />
+                    <x-primary-button id="addStripPatternBtn" type="button">追加</x-primary-button>
+                </div>
+                <div id="stripPatternError" class="text-red-500 text-sm mb-4 hidden"></div>
+
+                <!-- 除去パターン一覧 -->
+                <div id="stripPatternsList" class="border dark:border-gray-700 rounded-lg overflow-hidden">
+                    <div class="text-center text-gray-500 dark:text-gray-400 py-4">読み込み中...</div>
+                </div>
+
+                <!-- 再適用ボタン -->
+                <div class="mt-4">
+                    <x-primary-button id="reapplyStripPatternsBtn" type="button" class="bg-orange-600 hover:bg-orange-700">
+                        既存タイムスタンプに再適用
+                    </x-primary-button>
+                    <span class="text-xs text-gray-500 dark:text-gray-400 ml-2">パターン変更後に実行すると、既存のタイムスタンプのnormalized_textが更新されます</span>
+                </div>
+                <div id="stripPatternMessage" class="text-sm mt-2 hidden"></div>
+            </div>
+
             <!-- カバー曲プレビューセクション -->
             <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
                 <h3 class="text-lg font-bold text-gray-800 dark:text-gray-200 mb-4">カバー曲抽出プレビュー</h3>

--- a/resources/views/manage/settings.blade.php
+++ b/resources/views/manage/settings.blade.php
@@ -85,7 +85,7 @@
                     <x-primary-button id="reapplyStripPatternsBtn" type="button" class="bg-orange-600 hover:bg-orange-700">
                         既存タイムスタンプに再適用
                     </x-primary-button>
-                    <span class="text-xs text-gray-500 dark:text-gray-400 ml-2">パターン変更後に実行すると、既存のタイムスタンプのnormalized_textが更新されます</span>
+                    <span class="text-xs text-gray-500 dark:text-gray-400 ml-2">パターン変更後に実行すると、既存のタイムスタンプの照合テキストが再生成されます</span>
                 </div>
                 <div id="stripPatternMessage" class="text-sm mt-2 hidden"></div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -69,7 +69,9 @@ Route::middleware(['auth', 'admin'])->group(function () {
     Route::get('api/manage/channels/{id}/strip-patterns', [ManageSettingsApiController::class, 'fetchStripPatterns'])->name('manage.fetchStripPatterns');
     Route::post('api/manage/channels/{id}/strip-patterns', [ManageSettingsApiController::class, 'addStripPattern'])->name('manage.addStripPattern');
     Route::delete('api/manage/channels/{id}/strip-patterns/{patternId}', [ManageSettingsApiController::class, 'deleteStripPattern'])->name('manage.deleteStripPattern');
-    Route::post('api/manage/channels/{id}/strip-patterns/reapply', [ManageSettingsApiController::class, 'reapplyStripPatterns'])->name('manage.reapplyStripPatterns');
+    Route::post('api/manage/channels/{id}/strip-patterns/reapply', [ManageSettingsApiController::class, 'reapplyStripPatterns'])
+        ->name('manage.reapplyStripPatterns')
+        ->middleware('throttle:5,1'); // 1分間に5回まで
 
     Route::get('api/manage/channels/{id}/cover-songs/preview', [ManageSettingsApiController::class, 'previewCoverSongs'])->name('manage.previewCoverSongs');
     Route::post('api/manage/channels/{id}/cover-songs/reprocess', [ManageSettingsApiController::class, 'reprocessCoverSongs'])->name('manage.reprocessCoverSongs');

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,6 +65,12 @@ Route::middleware(['auth', 'admin'])->group(function () {
     Route::get('api/manage/channels/{id}/excluded-words', [ManageSettingsApiController::class, 'fetchExcludedWords'])->name('manage.fetchExcludedWords');
     Route::post('api/manage/channels/{id}/excluded-words', [ManageSettingsApiController::class, 'addExcludedWord'])->name('manage.addExcludedWord');
     Route::delete('api/manage/channels/{id}/excluded-words/{wordId}', [ManageSettingsApiController::class, 'deleteExcludedWord'])->name('manage.deleteExcludedWord');
+    // 除去パターン管理
+    Route::get('api/manage/channels/{id}/strip-patterns', [ManageSettingsApiController::class, 'fetchStripPatterns'])->name('manage.fetchStripPatterns');
+    Route::post('api/manage/channels/{id}/strip-patterns', [ManageSettingsApiController::class, 'addStripPattern'])->name('manage.addStripPattern');
+    Route::delete('api/manage/channels/{id}/strip-patterns/{patternId}', [ManageSettingsApiController::class, 'deleteStripPattern'])->name('manage.deleteStripPattern');
+    Route::post('api/manage/channels/{id}/strip-patterns/reapply', [ManageSettingsApiController::class, 'reapplyStripPatterns'])->name('manage.reapplyStripPatterns');
+
     Route::get('api/manage/channels/{id}/cover-songs/preview', [ManageSettingsApiController::class, 'previewCoverSongs'])->name('manage.previewCoverSongs');
     Route::post('api/manage/channels/{id}/cover-songs/reprocess', [ManageSettingsApiController::class, 'reprocessCoverSongs'])->name('manage.reprocessCoverSongs');
 

--- a/tests/Unit/Services/TimestampExtractorServiceTest.php
+++ b/tests/Unit/Services/TimestampExtractorServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Services;
 
+use App\Helpers\TextNormalizer;
 use App\Services\TimestampExtractorService;
 use Tests\TestCase;
 
@@ -119,9 +120,8 @@ class TimestampExtractorServiceTest extends TestCase
         // textは元のまま保持
         $this->assertEquals('🎵 テスト曲名 ♪', $results[0]['text']);
         $this->assertEquals('▶ アーティスト / 曲名', $results[1]['text']);
-        // normalized_textには除去パターンが適用されている
-        $this->assertStringNotContainsString('🎵', $results[0]['normalized_text']);
-        $this->assertStringNotContainsString('♪', $results[0]['normalized_text']);
-        $this->assertStringNotContainsString('▶', $results[1]['normalized_text']);
+        // normalized_textには除去パターンが適用された上でnormalizeされた値が入る
+        $this->assertEquals(TextNormalizer::normalize('テスト曲名'), $results[0]['normalized_text']);
+        $this->assertEquals(TextNormalizer::normalize('アーティスト / 曲名'), $results[1]['normalized_text']);
     }
 }

--- a/tests/Unit/Services/TimestampExtractorServiceTest.php
+++ b/tests/Unit/Services/TimestampExtractorServiceTest.php
@@ -41,4 +41,87 @@ class TimestampExtractorServiceTest extends TestCase
         $this->assertEquals('👋🏻 あいさつ', $results[0]['text']);
         $this->assertEquals('🏳️‍🌈 テスト', $results[1]['text']);
     }
+
+    /**
+     * applyStripPatterns: 基本的な除去
+     */
+    public function test_apply_strip_patterns_removes_patterns(): void
+    {
+        $text = '🎵 テスト曲名 ♪';
+        $patterns = ['🎵', '♪'];
+
+        $result = TimestampExtractorService::applyStripPatterns($text, $patterns);
+
+        $this->assertEquals('テスト曲名', $result);
+    }
+
+    /**
+     * applyStripPatterns: 空配列の場合はそのまま返す
+     */
+    public function test_apply_strip_patterns_with_empty_patterns(): void
+    {
+        $text = '🎵 テスト曲名';
+        $result = TimestampExtractorService::applyStripPatterns($text, []);
+
+        $this->assertEquals('🎵 テスト曲名', $result);
+    }
+
+    /**
+     * applyStripPatterns: 除去後に空文字になるケース
+     */
+    public function test_apply_strip_patterns_result_empty(): void
+    {
+        $text = '🎵♪';
+        $patterns = ['🎵', '♪'];
+
+        $result = TimestampExtractorService::applyStripPatterns($text, $patterns);
+
+        $this->assertEquals('', $result);
+    }
+
+    /**
+     * applyStripPatterns: 複数パターンの重複適用
+     */
+    public function test_apply_strip_patterns_multiple_occurrences(): void
+    {
+        $text = '▶ テスト ▶ 曲名 ▶';
+        $patterns = ['▶'];
+
+        $result = TimestampExtractorService::applyStripPatterns($text, $patterns);
+
+        $this->assertEquals('テスト  曲名', $result);
+    }
+
+    /**
+     * applyStripPatterns: マルチバイト文字パターン
+     */
+    public function test_apply_strip_patterns_multibyte(): void
+    {
+        $text = '【テスト曲名】';
+        $patterns = ['【', '】'];
+
+        $result = TimestampExtractorService::applyStripPatterns($text, $patterns);
+
+        $this->assertEquals('テスト曲名', $result);
+    }
+
+    /**
+     * extractTimestamps: 除去パターン付きでnormalized_textに反映される
+     */
+    public function test_extract_timestamps_with_strip_patterns(): void
+    {
+        $description = "0:00 🎵 テスト曲名 ♪\n1:30 ▶ アーティスト / 曲名";
+        $stripPatterns = ['🎵', '♪', '▶'];
+
+        $results = $this->service->extractTimestamps('test_video', '1', $description, 'dummy', $stripPatterns);
+
+        $this->assertCount(2, $results);
+        // textは元のまま保持
+        $this->assertEquals('🎵 テスト曲名 ♪', $results[0]['text']);
+        $this->assertEquals('▶ アーティスト / 曲名', $results[1]['text']);
+        // normalized_textには除去パターンが適用されている
+        $this->assertStringNotContainsString('🎵', $results[0]['normalized_text']);
+        $this->assertStringNotContainsString('♪', $results[0]['normalized_text']);
+        $this->assertStringNotContainsString('▶', $results[1]['normalized_text']);
+    }
 }


### PR DESCRIPTION
## Summary
- チャンネルごとにタイムスタンプテキストから除去する文字列パターン（装飾絵文字・記号等）を管理するCRUD機能を追加
- 除去パターンをnormalized_text生成時に適用し、楽曲マッピングの精度を向上
- 既存タイムスタンプへの一括再適用機能を追加

## 変更内容
- **DB**: `channel_strip_patterns` テーブル新設（チャンネルID + パターンのユニーク制約）
- **Model**: `ChannelStripPattern` モデル、`Channel` にリレーション追加
- **API**: 除去パターンの一覧取得・追加・削除・再適用の4エンドポイント
- **Service**: `TimestampExtractorService` に `applyStripPatterns()` 追加、`extractTimestamps()` で除去パターン適用
- **Service**: `YouTubeService`、`RefreshArchiveService` で除去パターンを受け渡し
- **Frontend**: 設定画面に除去パターン管理UIセクション追加
- **Test**: `applyStripPatterns` のユニットテスト追加

## Test plan
- [ ] マイグレーション実行確認
- [ ] 除去パターンの追加・削除・一覧表示が正常に動作すること
- [ ] 重複パターン登録時に適切なエラーが返ること
- [ ] 空白のみのパターンが登録できないこと
- [ ] 再適用で既存ts_itemsのnormalized_textが更新されること
- [ ] アーカイブリフレッシュ時に除去パターンが適用されること
- [ ] ユニットテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)