### PR TITLE
fix: 字幕取得の30分制限を修正（複数チャンク結合対応）

### DIFF
--- a/app/Http/Controllers/SubtitleApiController.php
+++ b/app/Http/Controllers/SubtitleApiController.php
@@ -55,13 +55,6 @@ class SubtitleApiController extends Controller
         }
 
         try {
-            $existing = VideoSubtitle::where('video_id', $videoId)
-                ->where('language_code', $languageCode)
-                ->where('kind', $kind)
-                ->first();
-
-            $isNew = ! $existing;
-
             $subtitle = VideoSubtitle::updateOrCreate(
                 [
                     'video_id' => $videoId,
@@ -73,6 +66,8 @@ class SubtitleApiController extends Controller
                     'segment_count' => count($subtitles),
                 ]
             );
+
+            $isNew = $subtitle->wasRecentlyCreated;
 
             // フィンガープリントを自動生成
             $fingerprintCount = $this->fingerprintService->generateFingerprintsForVideo($videoId);

--- a/app/Http/Controllers/SubtitleApiController.php
+++ b/app/Http/Controllers/SubtitleApiController.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\ManageAccessControl;
+use App\Models\Archive;
+use App\Models\SubtitleFingerprint;
+use App\Models\VideoSubtitle;
+use App\Services\SubtitleFingerprintService;
+use App\Services\SubtitleMatchingService;
+use Exception;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
+
+class SubtitleApiController extends Controller
+{
+    use ManageAccessControl;
+
+    public function __construct(
+        private SubtitleFingerprintService $fingerprintService,
+        private SubtitleMatchingService $matchingService,
+    ) {}
+
+    /**
+     * 字幕データを保存（Chrome拡張から自動送信）
+     * UPSERT: 同じvideo_id + language_code + kindなら更新
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'video_id' => ['required', 'string', 'size:11', 'regex:/^[A-Za-z0-9_-]{11}$/'],
+            'language_code' => ['required', 'string', 'regex:/^[a-zA-Z]{2,3}(-[a-zA-Z0-9]+)*$/', 'max:20'],
+            'kind' => ['present', 'string', Rule::in(['asr', ''])],
+            'subtitles' => ['required', 'array', 'min:1', 'max:10000'],
+            'subtitles.*.start' => ['required', 'numeric', 'min:0', 'max:86400'],
+            'subtitles.*.duration' => ['required', 'numeric', 'min:0', 'max:60'],
+            'subtitles.*.text' => ['required', 'string', 'max:500'],
+        ]);
+
+        $videoId = $request->input('video_id');
+        $languageCode = $request->input('language_code');
+        $kind = $request->input('kind', '');
+        $subtitles = $request->input('subtitles');
+
+        // アーカイブの存在確認とアクセス権チェック
+        $archive = Archive::where('video_id', $videoId)->first();
+        if (! $archive) {
+            return response()->json(['message' => '指定された動画はアーカイブに登録されていません'], 404);
+        }
+
+        $channel = $archive->channel;
+        if (! $channel || ! $this->canAccessChannel($channel)) {
+            return response()->json(['message' => 'このチャンネルへのアクセス権限がありません'], 403);
+        }
+
+        try {
+            $existing = VideoSubtitle::where('video_id', $videoId)
+                ->where('language_code', $languageCode)
+                ->where('kind', $kind)
+                ->first();
+
+            $isNew = ! $existing;
+
+            $subtitle = VideoSubtitle::updateOrCreate(
+                [
+                    'video_id' => $videoId,
+                    'language_code' => $languageCode,
+                    'kind' => $kind,
+                ],
+                [
+                    'subtitle_data' => $subtitles,
+                    'segment_count' => count($subtitles),
+                ]
+            );
+
+            // フィンガープリントを自動生成
+            $fingerprintCount = $this->fingerprintService->generateFingerprintsForVideo($videoId);
+
+            Log::info('字幕データ保存成功', [
+                'video_id' => $videoId,
+                'language_code' => $languageCode,
+                'kind' => $kind,
+                'segment_count' => count($subtitles),
+                'is_new' => $isNew,
+                'fingerprints_generated' => $fingerprintCount,
+            ]);
+
+            return response()->json([
+                'id' => $subtitle->id,
+                'segment_count' => $subtitle->segment_count,
+                'is_new' => $isNew,
+                'fingerprints_generated' => $fingerprintCount,
+            ]);
+        } catch (Exception $e) {
+            Log::error('字幕データ保存エラー', [
+                'video_id' => $videoId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json(['message' => '字幕データの保存に失敗しました'], 500);
+        }
+    }
+
+    /**
+     * 字幕データを取得
+     */
+    public function show(Request $request)
+    {
+        $request->validate([
+            'video_id' => ['required', 'string', 'size:11', 'regex:/^[A-Za-z0-9_-]{11}$/'],
+        ]);
+
+        $videoId = $request->input('video_id');
+
+        $archive = Archive::where('video_id', $videoId)->first();
+        if (! $archive) {
+            return response()->json(['message' => '指定された動画はアーカイブに登録されていません'], 404);
+        }
+
+        $channel = $archive->channel;
+        if (! $channel || ! $this->canAccessChannel($channel)) {
+            return response()->json(['message' => 'このチャンネルへのアクセス権限がありません'], 403);
+        }
+
+        $subtitles = VideoSubtitle::where('video_id', $videoId)->get();
+
+        return response()->json([
+            'video_id' => $videoId,
+            'subtitles' => $subtitles->map(fn (VideoSubtitle $s) => [
+                'id' => $s->id,
+                'language_code' => $s->language_code,
+                'kind' => $s->kind,
+                'segment_count' => $s->segment_count,
+                'created_at' => $s->created_at,
+                'updated_at' => $s->updated_at,
+            ]),
+        ]);
+    }
+
+    /**
+     * 楽曲候補を取得（字幕フィンガープリントベースのマッチング）
+     */
+    public function matchCandidates(string $tsItemId)
+    {
+        // ts_itemの存在確認とアクセス権チェック
+        $tsItem = \App\Models\TsItem::find($tsItemId);
+        if (! $tsItem) {
+            return response()->json(['message' => '指定されたタイムスタンプが見つかりません'], 404);
+        }
+
+        $archive = Archive::where('video_id', $tsItem->video_id)->first();
+        if (! $archive) {
+            return response()->json(['message' => '指定された動画はアーカイブに登録されていません'], 404);
+        }
+
+        $channel = $archive->channel;
+        if (! $channel || ! $this->canAccessChannel($channel)) {
+            return response()->json(['message' => 'このチャンネルへのアクセス権限がありません'], 403);
+        }
+
+        try {
+            $result = $this->matchingService->getCandidateSongs($tsItemId);
+
+            return response()->json($result);
+        } catch (Exception $e) {
+            Log::error('楽曲マッチングエラー', [
+                'ts_item_id' => $tsItemId,
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json(['message' => '楽曲マッチングに失敗しました'], 500);
+        }
+    }
+}

--- a/app/Models/SubtitleFingerprint.php
+++ b/app/Models/SubtitleFingerprint.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class SubtitleFingerprint extends Model
+{
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'video_id',
+        'ts_item_id',
+        'start_sec',
+        'duration_sec',
+        'fingerprint_text',
+        'trigrams',
+    ];
+
+    protected $casts = [
+        'trigrams' => 'array',
+        'start_sec' => 'integer',
+        'duration_sec' => 'integer',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (SubtitleFingerprint $model) {
+            if (empty($model->id)) {
+                $model->id = Str::ulid();
+            }
+        });
+    }
+
+    public function archive()
+    {
+        return $this->belongsTo(Archive::class, 'video_id', 'video_id');
+    }
+
+    public function tsItem()
+    {
+        return $this->belongsTo(TsItem::class, 'ts_item_id', 'id');
+    }
+}

--- a/app/Models/VideoSubtitle.php
+++ b/app/Models/VideoSubtitle.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class VideoSubtitle extends Model
+{
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'video_id',
+        'language_code',
+        'kind',
+        'subtitle_data',
+        'segment_count',
+    ];
+
+    protected $casts = [
+        'subtitle_data' => 'array',
+        'segment_count' => 'integer',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (VideoSubtitle $model) {
+            if (empty($model->id)) {
+                $model->id = Str::ulid();
+            }
+        });
+    }
+
+    public function archive()
+    {
+        return $this->belongsTo(Archive::class, 'video_id', 'video_id');
+    }
+}

--- a/app/Services/SubtitleFingerprintService.php
+++ b/app/Services/SubtitleFingerprintService.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\SubtitleFingerprint;
+use App\Models\TsItem;
+use App\Models\VideoSubtitle;
+
+class SubtitleFingerprintService
+{
+    /**
+     * 動画の全ts_itemsに対してフィンガープリントを生成
+     *
+     * @return int 生成件数
+     */
+    public function generateFingerprintsForVideo(string $videoId): int
+    {
+        // 手動字幕を優先（kindが空 = 手動、'asr' = 自動生成）
+        $subtitle = VideoSubtitle::where('video_id', $videoId)
+            ->orderBy('kind', 'asc')
+            ->first();
+
+        if (! $subtitle) {
+            return 0;
+        }
+
+        $tsItems = TsItem::where('video_id', $videoId)
+            ->where('is_display', '1')
+            ->whereNotNull('ts_num')
+            ->get();
+
+        $count = 0;
+        foreach ($tsItems as $tsItem) {
+            $fp = $this->generateFingerprint($tsItem, $subtitle);
+            if ($fp) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    /**
+     * 個別ts_itemのフィンガープリントを生成
+     */
+    public function generateFingerprint(TsItem $tsItem, VideoSubtitle $subtitle): ?SubtitleFingerprint
+    {
+        $segments = $subtitle->subtitle_data;
+        if (empty($segments) || $tsItem->ts_num === null) {
+            return null;
+        }
+
+        $durationSec = 30;
+        $text = $this->extractSubtitleWindow($segments, (int) $tsItem->ts_num, $durationSec);
+
+        if ($text === '') {
+            return null;
+        }
+
+        $trigrams = self::generateTrigrams($text);
+        if (empty($trigrams)) {
+            return null;
+        }
+
+        return SubtitleFingerprint::updateOrCreate(
+            ['ts_item_id' => $tsItem->id],
+            [
+                'video_id' => $tsItem->video_id,
+                'start_sec' => (int) $tsItem->ts_num,
+                'duration_sec' => $durationSec,
+                'fingerprint_text' => $text,
+                'trigrams' => $trigrams,
+            ]
+        );
+    }
+
+    /**
+     * 字幕セグメントから指定時間範囲のテキストを切り出し
+     */
+    public function extractSubtitleWindow(array $segments, int $startSec, int $durationSec = 30): string
+    {
+        $windowStart = max(0, $startSec - 1);
+        $windowEnd = $startSec + $durationSec;
+
+        $texts = [];
+        foreach ($segments as $segment) {
+            $segStart = (float) ($segment['start'] ?? 0);
+            $segEnd = $segStart + (float) ($segment['duration'] ?? 0);
+
+            // セグメントがウィンドウと重なっていれば採用
+            if ($segEnd > $windowStart && $segStart < $windowEnd) {
+                $text = $segment['text'] ?? '';
+                if ($text !== '') {
+                    $texts[] = $text;
+                }
+            }
+        }
+
+        $joined = implode('', $texts);
+
+        return self::normalizeForFingerprint($joined);
+    }
+
+    /**
+     * フィンガープリント用のテキスト正規化
+     * 句読点・記号除去、小文字化
+     */
+    public static function normalizeForFingerprint(string $text): string
+    {
+        // 小文字化
+        $text = mb_strtolower($text, 'UTF-8');
+
+        // スペース・句読点・記号を除去
+        // Unicode カテゴリ: P(句読点), S(記号), Z(区切り) を除去
+        $text = preg_replace('/[\p{P}\p{S}\p{Z}\s]+/u', '', $text);
+
+        return $text;
+    }
+
+    /**
+     * 文字レベルのトライグラム生成
+     *
+     * @return string[] ユニークなトライグラムの配列
+     */
+    public static function generateTrigrams(string $text): array
+    {
+        $chars = mb_str_split($text, 1, 'UTF-8');
+        $len = count($chars);
+
+        if ($len < 3) {
+            return [];
+        }
+
+        $trigrams = [];
+        for ($i = 0; $i <= $len - 3; $i++) {
+            $trigrams[] = $chars[$i].$chars[$i + 1].$chars[$i + 2];
+        }
+
+        return array_values(array_unique($trigrams));
+    }
+}

--- a/app/Services/SubtitleMatchingService.php
+++ b/app/Services/SubtitleMatchingService.php
@@ -1,0 +1,248 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Archive;
+use App\Models\SubtitleFingerprint;
+use App\Models\TsItem;
+use Illuminate\Support\Collection;
+
+class SubtitleMatchingService
+{
+    private const MIN_CHANNEL_CANDIDATES = 3;
+
+    /**
+     * 候補楽曲を返す（チャンネル内優先→全体フォールバック）
+     */
+    public function getCandidateSongs(string $tsItemId, float $threshold = 0.5): array
+    {
+        $fingerprint = SubtitleFingerprint::where('ts_item_id', $tsItemId)->first();
+
+        if (! $fingerprint) {
+            return [
+                'ts_item_id' => $tsItemId,
+                'has_fingerprint' => false,
+                'candidates' => [],
+            ];
+        }
+
+        // チャンネルIDを取得
+        $archive = Archive::where('video_id', $fingerprint->video_id)->first();
+        $channelId = $archive?->channel_id;
+
+        // 同一チャンネル内で検索
+        $channelCandidates = collect();
+        $channelMatchedIds = collect();
+        if ($channelId) {
+            $channelCandidates = $this->findSimilarInChannel($fingerprint, $channelId, $threshold);
+            $channelMatchedIds = $channelCandidates->pluck('fingerprint.ts_item_id');
+        }
+
+        // 候補が少なければ全チャンネルにフォールバック（チャンネル内の結果は除外）
+        $otherCandidates = collect();
+        if ($channelCandidates->count() < self::MIN_CHANNEL_CANDIDATES) {
+            $otherCandidates = $this->findSimilarOtherChannels($fingerprint, $channelMatchedIds->toArray(), $threshold);
+        }
+
+        // 結果を統合してランク付け
+        return [
+            'ts_item_id' => $tsItemId,
+            'has_fingerprint' => true,
+            'candidates' => $this->rankCandidates($channelCandidates, $otherCandidates),
+        ];
+    }
+
+    /**
+     * トライグラムJaccard類似度
+     */
+    public static function jaccardSimilarity(array $trigramsA, array $trigramsB): float
+    {
+        if (empty($trigramsA) || empty($trigramsB)) {
+            return 0.0;
+        }
+
+        $setA = array_flip($trigramsA);
+        $setB = array_flip($trigramsB);
+
+        $intersectionCount = count(array_intersect_key($setA, $setB));
+        $unionCount = count($setA) + count($setB) - $intersectionCount;
+
+        if ($unionCount === 0) {
+            return 0.0;
+        }
+
+        return $intersectionCount / $unionCount;
+    }
+
+    /**
+     * 同一チャンネル内で類似フィンガープリントを検索
+     */
+    private function findSimilarInChannel(SubtitleFingerprint $fp, string $channelId, float $threshold): Collection
+    {
+        // 同一チャンネルの動画IDを取得
+        $videoIds = Archive::where('channel_id', $channelId)
+            ->pluck('video_id')
+            ->toArray();
+
+        $others = SubtitleFingerprint::whereIn('video_id', $videoIds)
+            ->where('ts_item_id', '!=', $fp->ts_item_id)
+            ->get();
+
+        return $this->filterBySimilarity($fp, $others, $threshold, 'same_channel');
+    }
+
+    /**
+     * 他チャンネルで検索（フォールバック、チャンネル内の結果は除外）
+     */
+    private function findSimilarOtherChannels(SubtitleFingerprint $fp, array $excludeTsItemIds, float $threshold): Collection
+    {
+        $targetTrigrams = $fp->trigrams;
+        $results = collect();
+
+        $query = SubtitleFingerprint::where('ts_item_id', '!=', $fp->ts_item_id);
+        if (! empty($excludeTsItemIds)) {
+            $query->whereNotIn('ts_item_id', $excludeTsItemIds);
+        }
+
+        $query->chunkById(500, function ($chunk) use ($targetTrigrams, $threshold, &$results) {
+            foreach ($chunk as $other) {
+                $similarity = self::jaccardSimilarity($targetTrigrams, $other->trigrams);
+                if ($similarity >= $threshold) {
+                    $results->push([
+                        'fingerprint' => $other,
+                        'similarity' => round($similarity, 4),
+                        'source' => 'other_channel',
+                    ]);
+                }
+            }
+        });
+
+        return $results->sortByDesc('similarity');
+    }
+
+    /**
+     * 類似度でフィルタリング
+     */
+    private function filterBySimilarity(SubtitleFingerprint $fp, Collection $others, float $threshold, string $source): Collection
+    {
+        $targetTrigrams = $fp->trigrams;
+        $results = collect();
+
+        foreach ($others as $other) {
+            $similarity = self::jaccardSimilarity($targetTrigrams, $other->trigrams);
+            if ($similarity >= $threshold) {
+                $results->push([
+                    'fingerprint' => $other,
+                    'similarity' => round($similarity, 4),
+                    'source' => $source,
+                ]);
+            }
+        }
+
+        return $results->sortByDesc('similarity');
+    }
+
+    /**
+     * 候補をsong単位でグループ化・ランク付け
+     */
+    private function rankCandidates(Collection $channelMatches, Collection $otherMatches): array
+    {
+        // 全マッチを統合（重複はチャンネル内を優先）
+        $seenTsItemIds = [];
+        $allResults = collect();
+
+        foreach ($channelMatches as $match) {
+            $tsItemId = $match['fingerprint']->ts_item_id;
+            $seenTsItemIds[$tsItemId] = true;
+            $allResults->push($match);
+        }
+
+        foreach ($otherMatches as $match) {
+            $tsItemId = $match['fingerprint']->ts_item_id;
+            if (! isset($seenTsItemIds[$tsItemId])) {
+                $seenTsItemIds[$tsItemId] = true;
+                $allResults->push($match);
+            }
+        }
+
+        // ts_item情報をまとめて取得
+        $tsItemIds = $allResults->pluck('fingerprint.ts_item_id')->toArray();
+        $tsItems = TsItem::whereIn('id', $tsItemIds)->get()->keyBy('id');
+
+        // マッピング情報を取得（normalized_text → song）
+        $normalizedTexts = $tsItems->pluck('normalized_text')->unique()->filter()->toArray();
+        $mappings = \App\Models\TimestampSongMapping::whereIn('normalized_text', $normalizedTexts)
+            ->where('is_not_song', false)
+            ->whereNotNull('song_id')
+            ->with('song')
+            ->get()
+            ->keyBy('normalized_text');
+
+        // song_id（またはnormalized_text）でグループ化
+        $groups = [];
+        foreach ($allResults as $match) {
+            $tsItem = $tsItems->get($match['fingerprint']->ts_item_id);
+            if (! $tsItem) {
+                continue;
+            }
+
+            $normalizedText = $tsItem->normalized_text;
+            $mapping = $mappings->get($normalizedText);
+            $song = $mapping?->song;
+
+            // グループキー: song_idがあればそれ、なければnormalized_text
+            $groupKey = $song ? 'song:'.$song->id : 'text:'.$normalizedText;
+
+            if (! isset($groups[$groupKey])) {
+                $groups[$groupKey] = [
+                    'song_id' => $song?->id,
+                    'song_title' => $song?->title,
+                    'song_artist' => $song?->artist,
+                    'normalized_text' => $normalizedText,
+                    'max_similarity' => 0,
+                    'total_similarity' => 0,
+                    'matches' => [],
+                ];
+            }
+
+            $groups[$groupKey]['matches'][] = [
+                'ts_item_id' => $tsItem->id,
+                'video_id' => $match['fingerprint']->video_id,
+                'text' => $tsItem->text,
+                'similarity' => $match['similarity'],
+                'source' => $match['source'],
+            ];
+
+            $groups[$groupKey]['max_similarity'] = max(
+                $groups[$groupKey]['max_similarity'],
+                $match['similarity']
+            );
+            $groups[$groupKey]['total_similarity'] += $match['similarity'];
+        }
+
+        // ランク付け: 類似度平均 × マッチ数でスコア算出
+        $ranked = collect($groups)->map(function ($group) {
+            $matchCount = count($group['matches']);
+            $avgSimilarity = $matchCount > 0 ? $group['total_similarity'] / $matchCount : 0;
+
+            // 同一チャンネル内のマッチを優先
+            $sameChannelCount = collect($group['matches'])->where('source', 'same_channel')->count();
+
+            return [
+                'song_id' => $group['song_id'],
+                'song_title' => $group['song_title'],
+                'song_artist' => $group['song_artist'],
+                'normalized_text' => $group['normalized_text'],
+                'similarity' => round($group['max_similarity'], 4),
+                'match_count' => $matchCount,
+                'source' => $sameChannelCount > 0 ? 'same_channel' : 'other_channel',
+                'matches' => array_slice($group['matches'], 0, 10),
+            ];
+        })
+            ->sortByDesc('similarity')
+            ->values()
+            ->toArray();
+
+        return $ranked;
+    }
+}

--- a/app/Services/SubtitleMatchingService.php
+++ b/app/Services/SubtitleMatchingService.php
@@ -79,16 +79,29 @@ class SubtitleMatchingService
      */
     private function findSimilarInChannel(SubtitleFingerprint $fp, string $channelId, float $threshold): Collection
     {
-        // 同一チャンネルの動画IDを取得
         $videoIds = Archive::where('channel_id', $channelId)
             ->pluck('video_id')
             ->toArray();
 
-        $others = SubtitleFingerprint::whereIn('video_id', $videoIds)
-            ->where('ts_item_id', '!=', $fp->ts_item_id)
-            ->get();
+        $targetTrigrams = $fp->trigrams;
+        $results = collect();
 
-        return $this->filterBySimilarity($fp, $others, $threshold, 'same_channel');
+        SubtitleFingerprint::whereIn('video_id', $videoIds)
+            ->where('ts_item_id', '!=', $fp->ts_item_id)
+            ->chunkById(500, function ($chunk) use ($targetTrigrams, $threshold, &$results) {
+                foreach ($chunk as $other) {
+                    $similarity = self::jaccardSimilarity($targetTrigrams, $other->trigrams);
+                    if ($similarity >= $threshold) {
+                        $results->push([
+                            'fingerprint' => $other,
+                            'similarity' => round($similarity, 4),
+                            'source' => 'same_channel',
+                        ]);
+                    }
+                }
+            });
+
+        return $results->sortByDesc('similarity');
     }
 
     /**
@@ -116,28 +129,6 @@ class SubtitleMatchingService
                 }
             }
         });
-
-        return $results->sortByDesc('similarity');
-    }
-
-    /**
-     * 類似度でフィルタリング
-     */
-    private function filterBySimilarity(SubtitleFingerprint $fp, Collection $others, float $threshold, string $source): Collection
-    {
-        $targetTrigrams = $fp->trigrams;
-        $results = collect();
-
-        foreach ($others as $other) {
-            $similarity = self::jaccardSimilarity($targetTrigrams, $other->trigrams);
-            if ($similarity >= $threshold) {
-                $results->push([
-                    'fingerprint' => $other,
-                    'similarity' => round($similarity, 4),
-                    'source' => $source,
-                ]);
-            }
-        }
 
         return $results->sortByDesc('similarity');
     }

--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -2122,6 +2122,19 @@ function createSubtitlePanel() {
         padding: 20px;
         font-size: 12px;
       }
+      .stp-load-more {
+        text-align: center;
+        color: #aaa;
+        padding: 8px;
+        font-size: 12px;
+        cursor: pointer;
+        border-top: 1px solid #444;
+        margin-top: 4px;
+      }
+      .stp-load-more:hover {
+        color: #fff;
+        background: #444;
+      }
     </style>
     <div class="stp-header">
       <span class="stp-header-title">📝 字幕取得</span>
@@ -2416,28 +2429,56 @@ function renderSubtitleResults(subtitles) {
     return;
   }
 
-  const html = subtitles.slice(0, 500).map(sub => {
+  const CHUNK_SIZE = 500;
+  resultsEl.innerHTML = '';
+  resultsEl._subtitles = subtitles;
+  resultsEl._rendered = 0;
+
+  appendSubtitleChunk(resultsEl, CHUNK_SIZE);
+}
+
+/**
+ * 字幕アイテムを指定件数分追加描画
+ */
+function appendSubtitleChunk(resultsEl, chunkSize) {
+  const subtitles = resultsEl._subtitles;
+  const start = resultsEl._rendered;
+  const end = Math.min(start + chunkSize, subtitles.length);
+
+  const fragment = document.createDocumentFragment();
+  for (let i = start; i < end; i++) {
+    const sub = subtitles[i];
     const sec = Math.floor(sub.start);
-    const timeStr = formatSubtitleTime(sec);
-    return `
-      <div class="stp-result-item" data-time="${sec}">
-        <span class="stp-result-time">${timeStr}</span>
-        <span class="stp-result-text">${escapeHtml(sub.text)}</span>
-      </div>
-    `;
-  }).join('');
-
-  resultsEl.innerHTML = html;
-
-  // クリックでシーク
-  resultsEl.querySelectorAll('.stp-result-item').forEach(item => {
+    const item = document.createElement('div');
+    item.className = 'stp-result-item';
+    item.dataset.time = sec;
+    item.innerHTML = `<span class="stp-result-time">${formatSubtitleTime(sec)}</span><span class="stp-result-text">${escapeHtml(sub.text)}</span>`;
     item.addEventListener('click', () => {
-      const time = parseInt(item.dataset.time);
-      if (videoElement && !isNaN(time)) {
-        videoElement.currentTime = time;
+      if (videoElement && !isNaN(sec)) {
+        videoElement.currentTime = sec;
       }
     });
-  });
+    fragment.appendChild(item);
+  }
+  resultsEl._rendered = end;
+
+  // 既存の「もっと表示」ボタンがあれば削除
+  const oldBtn = resultsEl.querySelector('.stp-load-more');
+  if (oldBtn) oldBtn.remove();
+
+  resultsEl.appendChild(fragment);
+
+  // まだ残りがあれば「もっと表示」ボタンを追加
+  if (end < subtitles.length) {
+    const remaining = subtitles.length - end;
+    const btn = document.createElement('div');
+    btn.className = 'stp-load-more';
+    btn.textContent = `もっと表示（残り ${remaining} 件）`;
+    btn.addEventListener('click', () => {
+      appendSubtitleChunk(resultsEl, chunkSize);
+    });
+    resultsEl.appendChild(btn);
+  }
 }
 
 /**

--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -74,6 +74,9 @@ const CHAT_MAX_AGE_DAYS = 30; // 30日以上前のデータは削除
 let subtitlePanel = null;
 let subtitlePanelVisible = false;
 
+// 字幕サーバー送信用（重複送信防止キャッシュ）
+const subtitleSentCache = new Set();
+
 /**
  * 埋め込みUI設定を読み込む
  */
@@ -2296,6 +2299,9 @@ async function fetchSubtitleContent(videoId) {
     }
 
     renderSubtitleResults(currentSubtitles);
+
+    // サーバーに自動送信
+    sendSubtitlesToServer(videoId, selectedLang, currentSubtitles);
   } catch (error) {
     console.error('字幕取得エラー:', error);
     if (statusEl) {
@@ -2304,6 +2310,57 @@ async function fetchSubtitleContent(videoId) {
     }
   } finally {
     if (fetchBtn) fetchBtn.disabled = false;
+  }
+}
+
+/**
+ * 字幕データをYCSサーバーに自動送信
+ * 失敗時はconsole.warnのみ（字幕表示自体は影響させない）
+ */
+async function sendSubtitlesToServer(videoId, lang, subtitles) {
+  if (!videoId || !subtitles || subtitles.length === 0) return;
+
+  // 選択中のトラックからkindを判定
+  const selectEl = subtitlePanel?.querySelector('#stp-lang-select');
+  const selectedOption = selectEl?.selectedOptions?.[0];
+  const selectedLang = selectedOption?.dataset?.lang || lang;
+  const selectedTrack = currentCaptionTracks.find(t => t.languageCode === selectedLang);
+  const kind = selectedTrack?.kind === 'asr' ? 'asr' : '';
+
+  // 重複送信防止
+  const cacheKey = `${videoId}_${selectedLang}_${kind}`;
+  if (subtitleSentCache.has(cacheKey)) return;
+
+  try {
+    const response = await fetch('http://localhost:8000/api/manage/archives/subtitles/store', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      credentials: 'include',
+      body: JSON.stringify({
+        video_id: videoId,
+        language_code: selectedLang,
+        kind: kind,
+        subtitles: subtitles.map(s => ({
+          start: s.start,
+          duration: s.duration,
+          text: s.text,
+        })),
+      }),
+    });
+
+    if (response.ok) {
+      subtitleSentCache.add(cacheKey);
+      const data = await response.json();
+      console.log(`[YCS] 字幕データ送信成功: ${videoId} (${data.segment_count}セグメント, FP: ${data.fingerprints_generated}件)`);
+    } else {
+      console.warn(`[YCS] 字幕データ送信失敗: ${response.status}`);
+    }
+  } catch (error) {
+    console.warn('[YCS] 字幕データ送信エラー:', error.message);
   }
 }
 

--- a/browser-extension/page-bridge.js
+++ b/browser-extension/page-bridge.js
@@ -14,7 +14,19 @@
       const urlObj = new URL(url, location.origin);
       const lang = urlObj.searchParams.get('lang') || 'unknown';
       const videoId = urlObj.searchParams.get('v') || 'unknown';
-      timedTextCache[videoId + ':' + lang] = { text, url, timestamp: Date.now() };
+      const key = videoId + ':' + lang;
+      if (!timedTextCache[key]) {
+        timedTextCache[key] = { entries: [], lastUpdated: 0 };
+      }
+      // 同一URLのレスポンスは更新、異なるURLは追加
+      const existing = timedTextCache[key].entries.findIndex(e => e.url === url);
+      const entry = { text, url, timestamp: Date.now() };
+      if (existing >= 0) {
+        timedTextCache[key].entries[existing] = entry;
+      } else {
+        timedTextCache[key].entries.push(entry);
+      }
+      timedTextCache[key].lastUpdated = Date.now();
     } catch (e) { /* ignore */ }
   }
 
@@ -103,34 +115,58 @@
   }
 
   /**
+   * 複数チャンクのセグメントを結合し、重複を除去する
+   */
+  function mergeSegments(entriesArray) {
+    const allSegments = [];
+    for (const entry of entriesArray) {
+      try {
+        const segments = entry.text.trim().startsWith('{')
+          ? parseJson3(entry.text) : parseXml(entry.text);
+        allSegments.push(...segments);
+      } catch (e) { /* skip */ }
+    }
+    // startでソートし、重複除去（0.1秒以内は同一とみなす）
+    allSegments.sort((a, b) => a.start - b.start);
+    const unique = [];
+    for (const seg of allSegments) {
+      if (unique.length === 0 || Math.abs(seg.start - unique[unique.length - 1].start) > 0.1) {
+        unique.push(seg);
+      }
+    }
+    return unique;
+  }
+
+  /**
    * キャッシュまたはCCボタン経由でtimedtextを取得
    */
   function getTimedTextViaPlayer(videoId, lang) {
     return new Promise((resolve, reject) => {
-      // 1. キャッシュを確認（言語完全一致→前方一致→任意の言語）
+      // キャッシュを確認（言語完全一致→前方一致→任意の言語）
       function findCache() {
         const exact = timedTextCache[videoId + ':' + lang];
-        if (exact && (Date.now() - exact.timestamp) < 300000) return exact;
+        if (exact && (Date.now() - exact.lastUpdated) < 300000) return exact;
         for (const key of Object.keys(timedTextCache)) {
-          if (key.startsWith(videoId + ':') && (Date.now() - timedTextCache[key].timestamp) < 300000) {
+          if (key.startsWith(videoId + ':') && (Date.now() - timedTextCache[key].lastUpdated) < 300000) {
             return timedTextCache[key];
           }
         }
         return null;
       }
 
+      // キャッシュヒット時は全エントリを結合して返す
       const cached = findCache();
-      if (cached) {
+      if (cached && cached.entries.length > 0) {
         try {
-          const segments = cached.text.trim().startsWith('{')
-            ? parseJson3(cached.text)
-            : parseXml(cached.text);
-          resolve(segments);
-          return;
-        } catch (e) { /* パース失敗は無視 */ }
+          const segments = mergeSegments(cached.entries);
+          if (segments.length > 0) {
+            resolve(segments);
+            return;
+          }
+        } catch (e) { /* パース失敗は無視、CCボタン経由で再取得 */ }
       }
 
-      // 2. CCボタンをクリックして字幕を有効にし、インターセプトを待つ
+      // CCボタンをクリックして字幕を有効にし、インターセプトを待つ
       const ccButton = document.querySelector('.ytp-subtitles-button');
       if (!ccButton) {
         reject(new Error('字幕ボタンが見つかりません'));
@@ -139,26 +175,44 @@
 
       const wasOn = ccButton.getAttribute('aria-pressed') === 'true';
 
+      // CCクリック前に該当videoIdのキャッシュを全てクリア（lang不一致キーの混入防止）
+      for (const key of Object.keys(timedTextCache)) {
+        if (key.startsWith(videoId + ':')) delete timedTextCache[key];
+      }
+
       let resolved = false;
+      let lastEntryCount = 0;
+      let stableStartTime = 0;
+      const STABLE_WAIT_MS = 2000;
+      const TIMEOUT_MS = 15000;
+
       const checkInterval = setInterval(() => {
         const entry = findCache();
-        if (entry && (Date.now() - entry.timestamp) < 5000) {
+        if (!entry || entry.entries.length === 0) return;
+
+        const currentCount = entry.entries.length;
+        if (currentCount > lastEntryCount) {
+          // 新しいチャンクが到着した → 安定タイマーをリセット
+          lastEntryCount = currentCount;
+          stableStartTime = Date.now();
+        } else if (stableStartTime > 0 && (Date.now() - stableStartTime) >= STABLE_WAIT_MS) {
+          // 安定期間経過 → 全チャンクを結合してresolve
           clearInterval(checkInterval);
           clearTimeout(timeoutId);
           if (resolved) return;
           resolved = true;
 
-          // 元の状態に戻す
           if (!wasOn) {
             try { ccButton.click(); } catch (e) { /* ignore */ }
           }
 
           try {
-            const segments = entry.text.trim().startsWith('{')
-              ? parseJson3(entry.text)
-              : parseXml(entry.text);
+            const segments = mergeSegments(entry.entries);
             resolve(segments);
           } catch (e) {
+            if (!wasOn) {
+              try { ccButton.click(); } catch (_) { /* ignore */ }
+            }
             reject(new Error('字幕データのパースに失敗: ' + e.message));
           }
         }
@@ -173,20 +227,20 @@
           try { ccButton.click(); } catch (e) { /* ignore */ }
         }
 
-        // タイムアウト時にキャッシュにあれば使う（古くてもOK）
+        // タイムアウト時にキャッシュにあれば使う
         const lastResort = findCache();
-        if (lastResort) {
+        if (lastResort && lastResort.entries.length > 0) {
           try {
-            const segments = lastResort.text.trim().startsWith('{')
-              ? parseJson3(lastResort.text)
-              : parseXml(lastResort.text);
-            resolve(segments);
-            return;
+            const segments = mergeSegments(lastResort.entries);
+            if (segments.length > 0) {
+              resolve(segments);
+              return;
+            }
           } catch (e) { /* ignore */ }
         }
 
         reject(new Error('プレイヤー経由の字幕取得がタイムアウトしました（CCボタンクリック後にtimedtextリクエストを検出できませんでした）'));
-      }, 8000);
+      }, TIMEOUT_MS);
 
       // CCが既にONならOFF→ONでリロードを強制
       if (wasOn) {

--- a/browser-extension/page-bridge.js
+++ b/browser-extension/page-bridge.js
@@ -175,7 +175,9 @@
 
       const wasOn = ccButton.getAttribute('aria-pressed') === 'true';
 
-      // CCクリック前に該当videoIdのキャッシュを全てクリア（lang不一致キーの混入防止）
+      // CCクリック前に該当videoIdのキャッシュを全てクリア
+      // lang=unknownなどの別言語キーが残ると古いチャンクが混入するため、
+      // videoIdに紐づく全キーを削除してクリーンな状態からチャンク蓄積を開始する
       for (const key of Object.keys(timedTextCache)) {
         if (key.startsWith(videoId + ':')) delete timedTextCache[key];
       }
@@ -183,7 +185,9 @@
       let resolved = false;
       let lastEntryCount = 0;
       let stableStartTime = 0;
+      // YouTubeのチャンク分割間隔は通常1秒未満のため、2秒の無通信で全チャンク到着と判定
       const STABLE_WAIT_MS = 2000;
+      // 長時間動画ではチャンク数が多くなるため、タイムアウトを15秒に設定
       const TIMEOUT_MS = 15000;
 
       const checkInterval = setInterval(() => {

--- a/database/migrations/2026_04_06_000001_create_video_subtitles_table.php
+++ b/database/migrations/2026_04_06_000001_create_video_subtitles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('video_subtitles', function (Blueprint $table) {
+            $table->string('id', 26)->primary();
+            $table->string('video_id', 11)->index();
+            $table->string('language_code', 20);
+            $table->string('kind', 10)->default('');
+            $table->longText('subtitle_data');
+            $table->unsignedInteger('segment_count');
+            $table->timestamps();
+
+            $table->unique(['video_id', 'language_code', 'kind']);
+
+            $table->foreign('video_id')
+                ->references('video_id')
+                ->on('archives')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('video_subtitles');
+    }
+};

--- a/database/migrations/2026_04_06_000001_create_video_subtitles_table.php
+++ b/database/migrations/2026_04_06_000001_create_video_subtitles_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
             $table->string('video_id', 11)->index();
             $table->string('language_code', 20);
             $table->string('kind', 10)->default('');
-            $table->longText('subtitle_data');
+            $table->json('subtitle_data');
             $table->unsignedInteger('segment_count');
             $table->timestamps();
 

--- a/database/migrations/2026_04_06_000002_create_subtitle_fingerprints_table.php
+++ b/database/migrations/2026_04_06_000002_create_subtitle_fingerprints_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->unsignedInteger('start_sec');
             $table->unsignedSmallInteger('duration_sec')->default(30);
             $table->text('fingerprint_text');
-            $table->text('trigrams');
+            $table->json('trigrams');
             $table->timestamps();
 
             $table->foreign('video_id')

--- a/database/migrations/2026_04_06_000002_create_subtitle_fingerprints_table.php
+++ b/database/migrations/2026_04_06_000002_create_subtitle_fingerprints_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subtitle_fingerprints', function (Blueprint $table) {
+            $table->string('id', 26)->primary();
+            $table->string('video_id', 11)->index();
+            $table->string('ts_item_id', 26)->unique();
+            $table->unsignedInteger('start_sec');
+            $table->unsignedSmallInteger('duration_sec')->default(30);
+            $table->text('fingerprint_text');
+            $table->text('trigrams');
+            $table->timestamps();
+
+            $table->foreign('video_id')
+                ->references('video_id')
+                ->on('archives')
+                ->cascadeOnDelete();
+
+            $table->foreign('ts_item_id')
+                ->references('id')
+                ->on('ts_items')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subtitle_fingerprints');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ManageArchiveApiController;
 use App\Http\Controllers\ManageChannelApiController;
 use App\Http\Controllers\ManageController;
 use App\Http\Controllers\ManageSettingsApiController;
+use App\Http\Controllers\SubtitleApiController;
 use App\Http\Controllers\MarkdownController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\SongController;
@@ -83,6 +84,18 @@ Route::middleware(['auth', 'admin'])->group(function () {
     Route::get('api/manage/archives/subtitles', [ManageController::class, 'fetchSubtitles'])
         ->name('manage.fetchSubtitles')
         ->middleware('throttle:5,1'); // 1分間に5回まで
+
+    // 字幕データ保存・取得API（Chrome拡張からの自動送信用）
+    Route::post('api/manage/archives/subtitles/store', [SubtitleApiController::class, 'store'])
+        ->name('manage.storeSubtitles')
+        ->middleware('throttle:30,1'); // 1分間に30回まで
+    Route::get('api/manage/archives/subtitles/stored', [SubtitleApiController::class, 'show'])
+        ->name('manage.showStoredSubtitles');
+
+    // 字幕フィンガープリントによる楽曲マッチングAPI
+    Route::get('api/manage/subtitle-matches/{tsItemId}', [SubtitleApiController::class, 'matchCandidates'])
+        ->name('manage.subtitleMatches')
+        ->middleware('throttle:30,1'); // 1分間に30回まで
 
     // 楽曲マスタAPI
     Route::get('api/songs/timestamps', [SongController::class, 'fetchTimestamps'])->name('songs.fetchTimestamps');

--- a/tests/Feature/SubtitleApiTest.php
+++ b/tests/Feature/SubtitleApiTest.php
@@ -1,0 +1,368 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Archive;
+use App\Models\Channel;
+use App\Models\Song;
+use App\Models\SubtitleFingerprint;
+use App\Models\TimestampSongMapping;
+use App\Models\TsItem;
+use App\Models\User;
+use App\Models\VideoSubtitle;
+use App\Services\SubtitleFingerprintService;
+use App\Services\SubtitleMatchingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class SubtitleApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $superAdmin;
+
+    protected User $channelAdmin;
+
+    protected Channel $channel;
+
+    protected Archive $archive;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->superAdmin = User::factory()->create([
+            'email_verified_at' => now(),
+            'role' => User::ROLE_SUPER_ADMIN,
+        ]);
+
+        $this->channelAdmin = User::factory()->create([
+            'email_verified_at' => now(),
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $this->channel = Channel::factory()->create([
+            'user_id' => $this->channelAdmin->id,
+        ]);
+
+        $this->archive = Archive::factory()->create([
+            'channel_id' => $this->channel->channel_id,
+            'video_id' => 'dQw4w9WgXcQ',
+        ]);
+    }
+
+    // ==========================================
+    // store（字幕保存）のテスト
+    // ==========================================
+
+    public function test_store_subtitles_successfully(): void
+    {
+        $response = $this->actingAs($this->superAdmin)
+            ->postJson('/api/manage/archives/subtitles/store', [
+                'video_id' => 'dQw4w9WgXcQ',
+                'language_code' => 'ja',
+                'kind' => 'asr',
+                'subtitles' => [
+                    ['start' => 0, 'duration' => 2.5, 'text' => 'こんにちは'],
+                    ['start' => 2.5, 'duration' => 3.0, 'text' => '今日は歌枠です'],
+                ],
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('segment_count', 2)
+            ->assertJsonPath('is_new', true);
+
+        $this->assertDatabaseHas('video_subtitles', [
+            'video_id' => 'dQw4w9WgXcQ',
+            'language_code' => 'ja',
+            'kind' => 'asr',
+            'segment_count' => 2,
+        ]);
+    }
+
+    public function test_store_subtitles_upsert(): void
+    {
+        // 初回保存
+        $this->actingAs($this->superAdmin)
+            ->postJson('/api/manage/archives/subtitles/store', [
+                'video_id' => 'dQw4w9WgXcQ',
+                'language_code' => 'ja',
+                'kind' => 'asr',
+                'subtitles' => [
+                    ['start' => 0, 'duration' => 2.5, 'text' => 'テスト1'],
+                ],
+            ]);
+
+        // 同じキーで更新
+        $response = $this->actingAs($this->superAdmin)
+            ->postJson('/api/manage/archives/subtitles/store', [
+                'video_id' => 'dQw4w9WgXcQ',
+                'language_code' => 'ja',
+                'kind' => 'asr',
+                'subtitles' => [
+                    ['start' => 0, 'duration' => 2.5, 'text' => 'テスト2'],
+                    ['start' => 2.5, 'duration' => 3.0, 'text' => 'テスト3'],
+                ],
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('segment_count', 2)
+            ->assertJsonPath('is_new', false);
+
+        // レコードは1件のみ
+        $this->assertEquals(1, VideoSubtitle::where('video_id', 'dQw4w9WgXcQ')->count());
+    }
+
+    public function test_store_subtitles_requires_auth(): void
+    {
+        $response = $this->postJson('/api/manage/archives/subtitles/store', [
+            'video_id' => 'dQw4w9WgXcQ',
+            'language_code' => 'ja',
+            'kind' => '',
+            'subtitles' => [['start' => 0, 'duration' => 1, 'text' => 'test']],
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_store_subtitles_validates_video_id(): void
+    {
+        $response = $this->actingAs($this->superAdmin)
+            ->postJson('/api/manage/archives/subtitles/store', [
+                'video_id' => 'invalid',
+                'language_code' => 'ja',
+                'kind' => '',
+                'subtitles' => [['start' => 0, 'duration' => 1, 'text' => 'test']],
+            ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_store_subtitles_returns_404_for_unknown_video(): void
+    {
+        $response = $this->actingAs($this->superAdmin)
+            ->postJson('/api/manage/archives/subtitles/store', [
+                'video_id' => 'xxxxxxxxxxx',
+                'language_code' => 'ja',
+                'kind' => '',
+                'subtitles' => [['start' => 0, 'duration' => 1, 'text' => 'test']],
+            ]);
+
+        $response->assertStatus(404);
+    }
+
+    public function test_store_subtitles_denied_for_other_user(): void
+    {
+        $otherUser = User::factory()->create([
+            'email_verified_at' => now(),
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $response = $this->actingAs($otherUser)
+            ->postJson('/api/manage/archives/subtitles/store', [
+                'video_id' => 'dQw4w9WgXcQ',
+                'language_code' => 'ja',
+                'kind' => '',
+                'subtitles' => [['start' => 0, 'duration' => 1, 'text' => 'test']],
+            ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_store_subtitles_generates_fingerprints(): void
+    {
+        // ts_itemを作成
+        TsItem::factory()->create([
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_num' => 60,
+            'text' => 'テスト曲',
+            'is_display' => '1',
+        ]);
+
+        $response = $this->actingAs($this->superAdmin)
+            ->postJson('/api/manage/archives/subtitles/store', [
+                'video_id' => 'dQw4w9WgXcQ',
+                'language_code' => 'ja',
+                'kind' => 'asr',
+                'subtitles' => [
+                    ['start' => 55, 'duration' => 3, 'text' => 'さあ歌いましょう'],
+                    ['start' => 58, 'duration' => 3, 'text' => 'この曲は素敵です'],
+                    ['start' => 61, 'duration' => 3, 'text' => '歌声が響きます'],
+                    ['start' => 64, 'duration' => 3, 'text' => 'とても美しい'],
+                    ['start' => 67, 'duration' => 3, 'text' => 'メロディーですね'],
+                ],
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('fingerprints_generated', 1);
+
+        $this->assertEquals(1, SubtitleFingerprint::count());
+    }
+
+    // ==========================================
+    // show（字幕取得）のテスト
+    // ==========================================
+
+    public function test_show_stored_subtitles(): void
+    {
+        VideoSubtitle::create([
+            'id' => Str::ulid(),
+            'video_id' => 'dQw4w9WgXcQ',
+            'language_code' => 'ja',
+            'kind' => 'asr',
+            'subtitle_data' => [['start' => 0, 'duration' => 1, 'text' => 'test']],
+            'segment_count' => 1,
+        ]);
+
+        $response = $this->actingAs($this->superAdmin)
+            ->getJson('/api/manage/archives/subtitles/stored?video_id=dQw4w9WgXcQ');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('video_id', 'dQw4w9WgXcQ')
+            ->assertJsonCount(1, 'subtitles')
+            ->assertJsonPath('subtitles.0.language_code', 'ja');
+    }
+
+    public function test_show_stored_subtitles_requires_auth(): void
+    {
+        $response = $this->getJson('/api/manage/archives/subtitles/stored?video_id=dQw4w9WgXcQ');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_show_stored_subtitles_denied_for_other_user(): void
+    {
+        $otherUser = User::factory()->create([
+            'email_verified_at' => now(),
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $response = $this->actingAs($otherUser)
+            ->getJson('/api/manage/archives/subtitles/stored?video_id=dQw4w9WgXcQ');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_show_stored_subtitles_returns_404_for_unknown_video(): void
+    {
+        $response = $this->actingAs($this->superAdmin)
+            ->getJson('/api/manage/archives/subtitles/stored?video_id=xxxxxxxxxxx');
+
+        $response->assertStatus(404);
+    }
+
+    // ==========================================
+    // matchCandidates（楽曲マッチング）のテスト
+    // ==========================================
+
+    public function test_match_candidates_without_fingerprint(): void
+    {
+        $tsItem = TsItem::factory()->create([
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_num' => 60,
+            'text' => 'テスト曲',
+        ]);
+
+        $response = $this->actingAs($this->superAdmin)
+            ->getJson("/api/manage/subtitle-matches/{$tsItem->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('has_fingerprint', false)
+            ->assertJsonCount(0, 'candidates');
+    }
+
+    public function test_match_candidates_with_fingerprint(): void
+    {
+        // 対象のts_item
+        $tsItem1 = TsItem::factory()->create([
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_num' => 60,
+            'text' => 'テスト曲A',
+            'is_display' => '1',
+        ]);
+
+        // 別の動画で同じ曲を歌ったts_item（同チャンネル）
+        $archive2 = Archive::factory()->create([
+            'channel_id' => $this->channel->channel_id,
+            'video_id' => 'abcdefghijk',
+        ]);
+        $tsItem2 = TsItem::factory()->create([
+            'video_id' => 'abcdefghijk',
+            'ts_num' => 120,
+            'text' => 'テスト曲A',
+            'is_display' => '1',
+        ]);
+
+        // 楽曲マスタとマッピングを作成
+        $song = Song::factory()->create([
+            'title' => 'テスト曲A',
+            'artist' => 'テストアーティスト',
+        ]);
+        TimestampSongMapping::create([
+            'id' => Str::ulid(),
+            'normalized_text' => $tsItem2->normalized_text,
+            'song_id' => $song->id,
+            'is_not_song' => false,
+        ]);
+
+        // 類似フィンガープリントを作成
+        $trigrams = SubtitleFingerprintService::generateTrigrams('あいうえおかきくけこさしすせそ');
+
+        SubtitleFingerprint::create([
+            'id' => Str::ulid(),
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_item_id' => $tsItem1->id,
+            'start_sec' => 60,
+            'duration_sec' => 30,
+            'fingerprint_text' => 'あいうえおかきくけこさしすせそ',
+            'trigrams' => $trigrams,
+        ]);
+
+        SubtitleFingerprint::create([
+            'id' => Str::ulid(),
+            'video_id' => 'abcdefghijk',
+            'ts_item_id' => $tsItem2->id,
+            'start_sec' => 120,
+            'duration_sec' => 30,
+            'fingerprint_text' => 'あいうえおかきくけこさしすせそ',
+            'trigrams' => $trigrams,
+        ]);
+
+        $response = $this->actingAs($this->superAdmin)
+            ->getJson("/api/manage/subtitle-matches/{$tsItem1->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('has_fingerprint', true)
+            ->assertJsonPath('candidates.0.song_id', $song->id)
+            ->assertJsonPath('candidates.0.song_title', 'テスト曲A')
+            ->assertJsonPath('candidates.0.similarity', 1.0);
+    }
+
+    public function test_match_candidates_returns_404_for_unknown_ts_item(): void
+    {
+        $response = $this->actingAs($this->superAdmin)
+            ->getJson('/api/manage/subtitle-matches/00000000000000000000000000');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_match_candidates_denied_for_other_user(): void
+    {
+        $tsItem = TsItem::factory()->create([
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_num' => 60,
+            'text' => 'テスト',
+        ]);
+
+        $otherUser = User::factory()->create([
+            'email_verified_at' => now(),
+            'role' => User::ROLE_ADMIN,
+        ]);
+
+        $response = $this->actingAs($otherUser)
+            ->getJson("/api/manage/subtitle-matches/{$tsItem->id}");
+
+        $response->assertStatus(403);
+    }
+}

--- a/tests/Unit/SubtitleFingerprintServiceTest.php
+++ b/tests/Unit/SubtitleFingerprintServiceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\SubtitleFingerprintService;
+use App\Services\SubtitleMatchingService;
+use PHPUnit\Framework\TestCase;
+
+class SubtitleFingerprintServiceTest extends TestCase
+{
+    // ==========================================
+    // トライグラム生成のテスト
+    // ==========================================
+
+    public function test_generate_trigrams_basic(): void
+    {
+        $trigrams = SubtitleFingerprintService::generateTrigrams('abcdef');
+
+        $this->assertEquals(['abc', 'bcd', 'cde', 'def'], $trigrams);
+    }
+
+    public function test_generate_trigrams_japanese(): void
+    {
+        $trigrams = SubtitleFingerprintService::generateTrigrams('あいうえお');
+
+        $this->assertEquals(['あいう', 'いうえ', 'うえお'], $trigrams);
+    }
+
+    public function test_generate_trigrams_short_text(): void
+    {
+        $this->assertEquals([], SubtitleFingerprintService::generateTrigrams('ab'));
+        $this->assertEquals([], SubtitleFingerprintService::generateTrigrams(''));
+        $this->assertEquals(['abc'], SubtitleFingerprintService::generateTrigrams('abc'));
+    }
+
+    public function test_generate_trigrams_removes_duplicates(): void
+    {
+        // 'aaa' → ['aaa'] (重複するトライグラムはユニーク化)
+        $trigrams = SubtitleFingerprintService::generateTrigrams('aaaa');
+
+        $this->assertEquals(['aaa'], $trigrams);
+    }
+
+    // ==========================================
+    // テキスト正規化のテスト
+    // ==========================================
+
+    public function test_normalize_for_fingerprint(): void
+    {
+        $result = SubtitleFingerprintService::normalizeForFingerprint('Hello, World! こんにちは。');
+
+        $this->assertEquals('helloworldこんにちは', $result);
+    }
+
+    public function test_normalize_removes_punctuation_and_symbols(): void
+    {
+        $result = SubtitleFingerprintService::normalizeForFingerprint('テスト！？「」（）…♪');
+
+        $this->assertEquals('テスト', $result);
+    }
+
+    public function test_normalize_removes_spaces(): void
+    {
+        $result = SubtitleFingerprintService::normalizeForFingerprint('a b　c　d');
+
+        $this->assertEquals('abcd', $result);
+    }
+
+    // ==========================================
+    // 字幕ウィンドウ抽出のテスト
+    // ==========================================
+
+    public function test_extract_subtitle_window(): void
+    {
+        $service = new SubtitleFingerprintService;
+
+        $segments = [
+            ['start' => 0, 'duration' => 3, 'text' => '最初のセグメント'],
+            ['start' => 55, 'duration' => 3, 'text' => '対象前'],
+            ['start' => 58, 'duration' => 3, 'text' => '対象開始'],
+            ['start' => 61, 'duration' => 3, 'text' => '対象中'],
+            ['start' => 85, 'duration' => 3, 'text' => '対象後'],
+            ['start' => 100, 'duration' => 3, 'text' => '範囲外'],
+        ];
+
+        // ts_num=60, 窓=59-90秒
+        $result = $service->extractSubtitleWindow($segments, 60, 30);
+
+        // 55+3=58 > 59 → 含まれない（58 < 59）
+        // 58+3=61 > 59 → 含まれる
+        // 61+3=64 > 59 → 含まれる
+        // 85+3=88 < 90 → 含まれる
+        // 100+3=103 > 59 but 100 >= 90 → 含まれない
+        $this->assertStringContainsString('対象開始', $result);
+        $this->assertStringContainsString('対象中', $result);
+        $this->assertStringContainsString('対象後', $result);
+        $this->assertStringNotContainsString('最初', $result);
+        $this->assertStringNotContainsString('範囲外', $result);
+    }
+
+    public function test_extract_subtitle_window_boundary(): void
+    {
+        $service = new SubtitleFingerprintService;
+
+        $segments = [
+            ['start' => 59, 'duration' => 2, 'text' => 'ちょうど境界'],
+            ['start' => 90, 'duration' => 2, 'text' => '終了境界'],
+        ];
+
+        // ts_num=60, 窓=59-90秒
+        $result = $service->extractSubtitleWindow($segments, 60, 30);
+
+        $this->assertStringContainsString('ちょうど境界', $result);
+        // 90 >= 90 → 含まれない
+        $this->assertStringNotContainsString('終了境界', $result);
+    }
+
+    public function test_extract_subtitle_window_empty(): void
+    {
+        $service = new SubtitleFingerprintService;
+
+        $result = $service->extractSubtitleWindow([], 60, 30);
+
+        $this->assertEquals('', $result);
+    }
+
+    // ==========================================
+    // Jaccard類似度のテスト
+    // ==========================================
+
+    public function test_jaccard_similarity_identical(): void
+    {
+        $trigrams = ['abc', 'bcd', 'cde'];
+
+        $result = SubtitleMatchingService::jaccardSimilarity($trigrams, $trigrams);
+
+        $this->assertEquals(1.0, $result);
+    }
+
+    public function test_jaccard_similarity_disjoint(): void
+    {
+        $a = ['abc', 'bcd', 'cde'];
+        $b = ['xyz', 'yza', 'zab'];
+
+        $result = SubtitleMatchingService::jaccardSimilarity($a, $b);
+
+        $this->assertEquals(0.0, $result);
+    }
+
+    public function test_jaccard_similarity_partial(): void
+    {
+        $a = ['abc', 'bcd', 'cde', 'def'];
+        $b = ['abc', 'bcd', 'xyz', 'yza'];
+
+        // intersection = 2 (abc, bcd), union = 6
+        $result = SubtitleMatchingService::jaccardSimilarity($a, $b);
+
+        $this->assertEqualsWithDelta(2.0 / 6.0, $result, 0.0001);
+    }
+
+    public function test_jaccard_similarity_empty(): void
+    {
+        $this->assertEquals(0.0, SubtitleMatchingService::jaccardSimilarity([], ['abc']));
+        $this->assertEquals(0.0, SubtitleMatchingService::jaccardSimilarity(['abc'], []));
+        $this->assertEquals(0.0, SubtitleMatchingService::jaccardSimilarity([], []));
+    }
+}


### PR DESCRIPTION
## Summary
- YouTubeプレイヤーのチャンク分割字幕レスポンスを複数蓄積・結合する方式に変更
- キャッシュ構造を配列ベースに変更し、安定待機ロジック（2秒間新規なし→確定）を導入
- `mergeSegments`関数で複数チャンクのセグメントをstart順にソート・重複除去

## 変更内容
### `browser-extension/page-bridge.js`
- **`cacheTimedText`**: 単一エントリ上書き → 配列で複数レスポンス蓄積（同一URLは更新、異なるURLは追加）
- **`mergeSegments`（新規）**: 複数チャンクのセグメントを結合し、start時刻でソート・重複除去（0.1秒閾値）
- **`getTimedTextViaPlayer`**: 
  - CCクリック前にvideoId全言語キーのキャッシュをクリア
  - 安定待機期間（2秒間新規チャンクなし）で全チャンク到着を確認
  - タイムアウトを8秒→15秒に延長
- **`findCache`**: `lastUpdated`プロパティで鮮度判定、キャッシュヒット時も全エントリを結合

## Test plan
- [ ] 30分以上の動画（歌枠アーカイブ等）で字幕取得し、動画終盤までセグメントが含まれることを確認
- [ ] 短い動画（30分以下）でも従来通り動作することを確認
- [ ] CCボタンの状態が取得後に元に戻ることを確認
- [ ] キャッシュヒット時（2回目の取得）も正常に全セグメントが返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)