### PR TITLE
fix: refreshTimeStampsFromCommentsの削除・挿入をトランザクションで包む

### DIFF
--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -296,12 +296,14 @@ class RefreshArchiveService
         }
         unset($ts_item);
 
-        TsItem::where('video_id', $videoId)
-            ->where('type', '2')
-            ->delete();
-        if ($ts_items) {
-            DB::table('ts_items')->insert($ts_items);
-        }
+        DB::transaction(function () use ($videoId, $ts_items) {
+            TsItem::where('video_id', $videoId)
+                ->where('type', '2')
+                ->delete();
+            if ($ts_items) {
+                DB::table('ts_items')->insert($ts_items);
+            }
+        });
     }
 
     public function getOldestUpdatedChannel(): Channel


### PR DESCRIPTION
## Summary
- コメント由来ts_itemsの削除・挿入を`DB::transaction()`で包み原子性を保証
- insertが失敗した場合にデータ消失するリスクを解消

Closes #500

## Test plan
- [ ] コメント取得処理が正常に動作すること
- [ ] insert失敗時に削除もロールバックされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)