### PR TITLE
fix: 字幕取得の並行呼び出し時にCCボタンが複数回トグルされる問題を修正

### DIFF
--- a/browser-extension/page-bridge.js
+++ b/browser-extension/page-bridge.js
@@ -137,11 +137,22 @@
     return unique;
   }
 
+  // 進行中の字幕取得Promiseを保持（並行呼び出し防止）
+  const pendingTimedTextRequests = {};
+
   /**
    * キャッシュまたはCCボタン経由でtimedtextを取得
+   * 同一videoId:langで既に取得中の場合は同じPromiseを返す
    */
   function getTimedTextViaPlayer(videoId, lang) {
-    return new Promise((resolve, reject) => {
+    const requestKey = videoId + ':' + lang;
+
+    // 既に取得中なら同じPromiseを返す（CCボタンの多重トグルを防止）
+    if (pendingTimedTextRequests[requestKey]) {
+      return pendingTimedTextRequests[requestKey];
+    }
+
+    const promise = new Promise((resolve, reject) => {
       // キャッシュを確認（言語完全一致→前方一致→任意の言語）
       function findCache() {
         const exact = timedTextCache[videoId + ':' + lang];
@@ -253,7 +264,12 @@
       } else {
         ccButton.click(); // ON
       }
+    }).finally(() => {
+      delete pendingTimedTextRequests[requestKey];
     });
+
+    pendingTimedTextRequests[requestKey] = promise;
+    return promise;
   }
 
   window.addEventListener('message', function (event) {


### PR DESCRIPTION
## Summary
- `getTimedTextViaPlayer`に進行中Promiseのキャッシュを導入
- 同一`videoId:lang`で既に取得中の場合は同じPromiseを返す
- CCボタンの多重トグルと複数`checkInterval`の競合を防止
- Promise完了時に自動でキャッシュをクリア

Closes #503

## Test plan
- [ ] 字幕取得ボタンを連打してもCCボタンが1回だけトグルされること
- [ ] 通常の字幕取得が正常に動作すること
- [ ] 取得完了後に再度取得できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)