### PR TITLE
feat: Chrome拡張用APIトークン認証の実装

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -42,6 +42,33 @@ class ProfileController extends Controller
     }
 
     /**
+     * APIトークンを発行
+     */
+    public function createApiToken(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'token_name' => ['required', 'string', 'max:255'],
+        ]);
+
+        // 既存トークンを全削除（1ユーザー1トークン）
+        $request->user()->tokens()->delete();
+
+        $token = $request->user()->createToken($request->input('token_name'));
+
+        return Redirect::route('profile.edit')->with('new_api_token', $token->plainTextToken);
+    }
+
+    /**
+     * APIトークンを失効
+     */
+    public function destroyApiToken(Request $request): RedirectResponse
+    {
+        $request->user()->tokens()->delete();
+
+        return Redirect::route('profile.edit')->with('status', 'api-token-deleted');
+    }
+
+    /**
      * Delete the user's API key.
      */
     public function destroyApiKey(Request $request): RedirectResponse

--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -77,6 +77,10 @@ let subtitlePanelVisible = false;
 // 字幕サーバー送信用（重複送信防止キャッシュ）
 const subtitleSentCache = new Set();
 
+// YCS APIトークン（chrome.storageから読み込み）
+let ycsApiToken = null;
+let ycsServerUrl = null;
+
 /**
  * 埋め込みUI設定を読み込む
  */
@@ -2327,11 +2331,33 @@ async function fetchSubtitleContent(videoId) {
 }
 
 /**
+ * YCS API設定をchrome.storageから読み込み
+ */
+async function loadYcsApiSettings() {
+  try {
+    const result = await chrome.storage.local.get(['ycsApiToken', 'ycsServerUrl']);
+    ycsApiToken = result.ycsApiToken || null;
+    ycsServerUrl = result.ycsServerUrl || 'http://localhost:8000';
+  } catch (error) {
+    console.warn('[YCS] API設定読み込みエラー:', error);
+  }
+}
+
+/**
  * 字幕データをYCSサーバーに自動送信
  * 失敗時はconsole.warnのみ（字幕表示自体は影響させない）
  */
 async function sendSubtitlesToServer(videoId, lang, subtitles) {
   if (!videoId || !subtitles || subtitles.length === 0) return;
+
+  // API設定が未読み込みなら読み込む
+  if (!ycsApiToken) {
+    await loadYcsApiSettings();
+  }
+  if (!ycsApiToken) {
+    console.warn('[YCS] APIトークンが未設定です。プロフィール画面でトークンを発行し、拡張の設定に登録してください。');
+    return;
+  }
 
   // 選択中のトラックからkindを判定
   const selectEl = subtitlePanel?.querySelector('#stp-lang-select');
@@ -2345,14 +2371,13 @@ async function sendSubtitlesToServer(videoId, lang, subtitles) {
   if (subtitleSentCache.has(cacheKey)) return;
 
   try {
-    const response = await fetch('http://localhost:8000/api/manage/archives/subtitles/store', {
+    const response = await fetch(`${ycsServerUrl}/api/manage/archives/subtitles/store`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
+        'Authorization': `Bearer ${ycsApiToken}`,
       },
-      credentials: 'include',
       body: JSON.stringify({
         video_id: videoId,
         language_code: selectedLang,

--- a/browser-extension/popup.html
+++ b/browser-extension/popup.html
@@ -258,6 +258,23 @@
       </div>
     </div>
 
+    <!-- YCS API設定 -->
+    <div class="section-title">YCS API設定</div>
+    <div style="font-size: 12px; color: #666; margin-bottom: 8px;">字幕データの自動送信に使用します</div>
+    <div style="margin-bottom: 6px;">
+      <div style="display: flex; align-items: center; gap: 4px;">
+        <input type="text" id="ycs-server-url" placeholder="http://localhost:8000" style="flex: 1; font-size: 11px; padding: 4px 6px; border: 1px solid #ddd; border-radius: 4px;">
+      </div>
+      <div style="font-size: 10px; color: #888; margin-top: 2px;">サーバーURL</div>
+    </div>
+    <div style="margin-bottom: 6px;">
+      <div style="display: flex; align-items: center; gap: 4px;">
+        <input type="password" id="ycs-api-token" placeholder="トークンを入力..." style="flex: 1; font-size: 11px; padding: 4px 6px; border: 1px solid #ddd; border-radius: 4px; font-family: monospace;">
+        <button id="save-ycs-settings" style="font-size: 11px; padding: 4px 8px; background: #667eea; color: #fff; border: none; border-radius: 4px; cursor: pointer; white-space: nowrap;">保存</button>
+      </div>
+      <div id="ycs-settings-status" style="font-size: 10px; color: #888; margin-top: 2px;">APIトークン</div>
+    </div>
+
     <!-- スキャンボタン（YouTube動画ページ用） -->
     <div id="scan-section" style="display: none; margin-top: 12px;">
       <button id="scan-btn" class="btn-scan">スキャン開始</button>

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -10,6 +10,8 @@ const STORAGE_KEY_CHAT_DELAY_ENABLED = 'chatDelayEnabled';
 const STORAGE_KEY_CHAT_DELAY_SECONDS = 'chatDelaySeconds';
 const STORAGE_KEY_TOXICITY_CHECK = 'toxicityCheckEnabled';
 const STORAGE_KEY_CLAUDE_API_KEY = 'claudeApiKey';
+const STORAGE_KEY_YCS_SERVER_URL = 'ycsServerUrl';
+const STORAGE_KEY_YCS_API_TOKEN = 'ycsApiToken';
 
 // DOM要素
 const elements = {
@@ -30,7 +32,11 @@ const elements = {
   clearAllBtn: document.getElementById('clear-all-btn'),
   scanSection: document.getElementById('scan-section'),
   scanBtn: document.getElementById('scan-btn'),
-  scanStatus: document.getElementById('scan-status')
+  scanStatus: document.getElementById('scan-status'),
+  ycsServerUrl: document.getElementById('ycs-server-url'),
+  ycsApiToken: document.getElementById('ycs-api-token'),
+  saveYcsSettings: document.getElementById('save-ycs-settings'),
+  ycsSettingsStatus: document.getElementById('ycs-settings-status')
 };
 
 let isScanning = false;
@@ -57,7 +63,9 @@ async function init() {
     STORAGE_KEY_CHAT_DELAY_ENABLED,
     STORAGE_KEY_CHAT_DELAY_SECONDS,
     STORAGE_KEY_TOXICITY_CHECK,
-    STORAGE_KEY_CLAUDE_API_KEY
+    STORAGE_KEY_CLAUDE_API_KEY,
+    STORAGE_KEY_YCS_SERVER_URL,
+    STORAGE_KEY_YCS_API_TOKEN
   ]);
   const showUI = result[STORAGE_KEY_EMBEDDED_UI] !== false; // デフォルトはtrue
   const hideGoogleAI = result[STORAGE_KEY_HIDE_GOOGLE_AI] !== false; // デフォルトはtrue
@@ -80,6 +88,14 @@ async function init() {
     elements.apiKeyStatus.style.color = '#2e7d32';
   }
 
+  // YCS API設定を読み込み
+  elements.ycsServerUrl.value = result[STORAGE_KEY_YCS_SERVER_URL] || 'http://localhost:8000';
+  if (result[STORAGE_KEY_YCS_API_TOKEN]) {
+    elements.ycsApiToken.placeholder = '設定済み';
+    elements.ycsSettingsStatus.textContent = 'APIトークン設定済み';
+    elements.ycsSettingsStatus.style.color = '#2e7d32';
+  }
+
   // イベントリスナーを設定
   elements.showEmbeddedUI.addEventListener('change', toggleEmbeddedUI);
   elements.hideGoogleAI.addEventListener('change', toggleHideGoogleAI);
@@ -87,6 +103,7 @@ async function init() {
   elements.chatDelaySeconds.addEventListener('input', changeChatDelaySeconds);
   elements.toxicityCheckEnabled.addEventListener('change', toggleToxicityCheck);
   elements.saveApiKey.addEventListener('click', saveClaudeApiKey);
+  elements.saveYcsSettings.addEventListener('click', saveYcsSettings);
   elements.helpLink.addEventListener('click', showHelp);
   elements.clearAllBtn.addEventListener('click', clearAllScannedData);
 
@@ -193,6 +210,29 @@ async function saveClaudeApiKey() {
   elements.claudeApiKey.placeholder = '設定済み';
   elements.apiKeyStatus.textContent = 'APIキーを保存しました';
   elements.apiKeyStatus.style.color = '#2e7d32';
+}
+
+/**
+ * YCS API設定を保存
+ */
+async function saveYcsSettings() {
+  const serverUrl = elements.ycsServerUrl.value.trim() || 'http://localhost:8000';
+  const apiToken = elements.ycsApiToken.value.trim();
+
+  const settings = { [STORAGE_KEY_YCS_SERVER_URL]: serverUrl };
+  if (apiToken) {
+    settings[STORAGE_KEY_YCS_API_TOKEN] = apiToken;
+  }
+
+  await chrome.storage.local.set(settings);
+  elements.ycsServerUrl.value = serverUrl;
+
+  if (apiToken) {
+    elements.ycsApiToken.value = '';
+    elements.ycsApiToken.placeholder = '設定済み';
+  }
+  elements.ycsSettingsStatus.textContent = '設定を保存しました';
+  elements.ycsSettingsStatus.style.color = '#2e7d32';
 }
 
 /**

--- a/config/cors.php
+++ b/config/cors.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'paths' => ['api/*', 'sanctum/csrf-cookie'],
+    'paths' => ['api/*', 'api/manage/*', 'sanctum/csrf-cookie'],
 
     'allowed_methods' => ['*'],
 

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -15,6 +15,12 @@
 
             <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow sm:rounded-lg">
                 <div class="max-w-xl">
+                    @include('profile.partials.api-token-form')
+                </div>
+            </div>
+
+            <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow sm:rounded-lg">
+                <div class="max-w-xl">
                     @include('profile.partials.google-account-info')
                 </div>
             </div>

--- a/resources/views/profile/partials/api-token-form.blade.php
+++ b/resources/views/profile/partials/api-token-form.blade.php
@@ -1,0 +1,82 @@
+<section>
+    <header>
+        <h2 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+            APIトークン
+        </h2>
+
+        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+            Chrome拡張や外部ツールからYCSのAPIにアクセスするためのトークンです。
+        </p>
+    </header>
+
+    {{-- 新しいトークンが発行された場合の表示 --}}
+    @if (session('new_api_token'))
+        <div class="mt-4 p-4 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-700 rounded-md">
+            <p class="text-sm font-medium text-green-800 dark:text-green-200">
+                トークンが発行されました。この値はもう一度表示できないのでコピーしてください。
+            </p>
+            <div class="mt-2 flex items-center gap-2">
+                <code id="api-token-value" class="block flex-1 p-2 bg-white dark:bg-gray-900 border border-green-300 dark:border-green-600 rounded text-sm font-mono text-gray-900 dark:text-gray-100 break-all">{{ session('new_api_token') }}</code>
+                <button type="button" onclick="navigator.clipboard.writeText(document.getElementById('api-token-value').textContent).then(() => this.textContent = 'Copied!')" class="px-3 py-2 text-sm bg-green-600 text-white rounded hover:bg-green-700">
+                    Copy
+                </button>
+            </div>
+        </div>
+    @endif
+
+    @if (session('status') === 'api-token-deleted')
+        <div class="mt-4 p-3 bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-700 rounded-md">
+            <p class="text-sm text-yellow-800 dark:text-yellow-200">
+                APIトークンを失効しました。
+            </p>
+        </div>
+    @endif
+
+    @php
+        $currentToken = auth()->user()->tokens()->latest()->first();
+    @endphp
+
+    @if ($currentToken)
+        {{-- 既存トークンの情報表示 --}}
+        <div class="mt-4 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-md">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ $currentToken->name }}</p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                        発行日: {{ $currentToken->created_at->format('Y-m-d H:i') }}
+                        @if ($currentToken->last_used_at)
+                            / 最終使用: {{ $currentToken->last_used_at->format('Y-m-d H:i') }}
+                        @endif
+                    </p>
+                </div>
+                <form method="post" action="{{ route('profile.api-token.destroy') }}" onsubmit="return confirm('このトークンを失効しますか？')">
+                    @csrf
+                    @method('delete')
+                    <x-danger-button type="submit">
+                        失効
+                    </x-danger-button>
+                </form>
+            </div>
+        </div>
+    @endif
+
+    {{-- トークン発行フォーム --}}
+    <form method="post" action="{{ route('profile.api-token.create') }}" class="mt-4">
+        @csrf
+        <div class="flex items-end gap-4">
+            <div class="flex-1">
+                <x-input-label for="token_name" value="トークン名" />
+                <x-text-input id="token_name" name="token_name" type="text" class="mt-1 block w-full" placeholder="例: Chrome拡張" required />
+                <x-input-error :messages="$errors->get('token_name')" class="mt-2" />
+            </div>
+            <x-primary-button>
+                {{ $currentToken ? '再発行' : '発行' }}
+            </x-primary-button>
+        </div>
+        @if ($currentToken)
+            <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                再発行すると現在のトークンは失効します。
+            </p>
+        @endif
+    </form>
+</section>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\SubtitleApiController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -16,4 +17,10 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
+});
+
+// Chrome拡張用API（Sanctumトークン認証）
+Route::middleware(['auth:sanctum', 'admin'])->group(function () {
+    Route::post('manage/archives/subtitles/store', [SubtitleApiController::class, 'store'])
+        ->middleware('throttle:30,1');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -151,6 +151,8 @@ Route::middleware(['auth', 'super_admin'])->group(function () {
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
+    Route::post('/profile/api-token', [ProfileController::class, 'createApiToken'])->name('profile.api-token.create');
+    Route::delete('/profile/api-token', [ProfileController::class, 'destroyApiToken'])->name('profile.api-token.destroy');
     Route::delete('/profile/api-key', [ProfileController::class, 'destroyApiKey'])->name('profile.api-key.destroy');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });


### PR DESCRIPTION
## Summary
- Laravel SanctumベースのAPIトークン発行/失効をプロフィール画面に追加
- Chrome拡張のポップアップにYCS API設定（サーバーURL・トークン）UIを追加
- 字幕自動送信をBearerトークン認証に変更（localhostハードコードを解消）
- routes/api.phpにSanctumトークン認証付き字幕保存エンドポイントを追加

Closes #504

## Test plan
- [ ] プロフィール画面でトークンを発行できること
- [ ] 発行されたトークンが1回だけ表示されること
- [ ] トークンを失効できること
- [ ] 再発行時に旧トークンが無効化されること
- [ ] Chrome拡張のポップアップでサーバーURL・トークンを設定できること
- [ ] 設定済みトークンで字幕データの自動送信が成功すること
- [ ] トークン未設定時は送信がスキップされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)