### PR TITLE
fix: TsItem::savingイベントでチャンネル別テキスト除去パターンを適用

### DIFF
--- a/app/Models/TsItem.php
+++ b/app/Models/TsItem.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Helpers\TextNormalizer;
+use App\Services\TimestampExtractorService;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -37,12 +38,22 @@ class TsItem extends Model
             if ($tsItem->isDirty('text') || $normalizedTextIsNull) {
                 // アクセサを経由せず生のtext値を取得して正規化
                 $rawText = $tsItem->attributes['text'] ?? null;
-                $normalized = TextNormalizer::normalize($rawText);
 
-                // 正規化結果が空の場合（例: "-"のみの場合）は元テキストを小文字化して使用
+                // チャンネルの除去パターンを適用
+                $textForNormalize = $rawText;
+                if ($rawText !== null && $tsItem->video_id) {
+                    $stripPatterns = self::getStripPatternsForVideo($tsItem->video_id);
+                    if (! empty($stripPatterns)) {
+                        $textForNormalize = TimestampExtractorService::applyStripPatterns($rawText, $stripPatterns);
+                    }
+                }
+
+                $normalized = TextNormalizer::normalize($textForNormalize);
+
+                // 正規化結果が空の場合（例: "-"のみの場合）は除去パターン適用後のテキストを小文字化して使用
                 // これにより timestamp_song_mappings との JOIN が正しく動作する
-                if ($normalized === '' && $rawText !== null && trim($rawText) !== '') {
-                    $normalized = mb_strtolower(trim($rawText), 'UTF-8');
+                if ($normalized === '' && $textForNormalize !== null && trim($textForNormalize) !== '') {
+                    $normalized = mb_strtolower(trim($textForNormalize), 'UTF-8');
                 }
 
                 // 正規化結果が現在の値と異なる場合のみ更新（無限ループ回避）
@@ -51,6 +62,37 @@ class TsItem extends Model
                 }
             }
         });
+    }
+
+    /**
+     * video_idからチャンネルの除去パターンを取得（メモリキャッシュ付き）
+     */
+    private static array $stripPatternsCache = [];
+
+    private static function getStripPatternsForVideo(string $videoId): array
+    {
+        if (array_key_exists($videoId, self::$stripPatternsCache)) {
+            return self::$stripPatternsCache[$videoId];
+        }
+
+        $archive = Archive::where('video_id', $videoId)->first();
+        if (! $archive) {
+            self::$stripPatternsCache[$videoId] = [];
+
+            return [];
+        }
+
+        $channel = Channel::where('channel_id', $archive->channel_id)->first();
+        if (! $channel) {
+            self::$stripPatternsCache[$videoId] = [];
+
+            return [];
+        }
+
+        $patterns = $channel->stripPatterns()->pluck('pattern')->toArray();
+        self::$stripPatternsCache[$videoId] = $patterns;
+
+        return $patterns;
     }
 
     public function archive()


### PR DESCRIPTION
## Summary
- `TsItem::saving`イベント内でチャンネルの除去パターンを取得・適用
- テキスト手動編集時にもnormalized_textに除去パターンが反映されるように修正
- video_id→Archive→Channel→StripPatternsのメモリキャッシュでN+1回避

Closes #505

## Test plan
- [ ] TsItemのtext手動変更時にnormalized_textに除去パターンが適用されること
- [ ] 除去パターン未設定チャンネルのTsItemが正常に保存されること
- [ ] バッチ処理（refreshArchives等）で既存の動作が維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)