### PR TITLE
feat: strip patternsの正規表現対応（#515 Phase 1-1）

### DIFF
--- a/app/Http/Controllers/ManageSettingsApiController.php
+++ b/app/Http/Controllers/ManageSettingsApiController.php
@@ -138,12 +138,24 @@ class ManageSettingsApiController extends Controller
 
         $validated = $request->validate([
             'pattern' => ['required', 'string', 'max:255', 'regex:/\S/'],
+            'is_regex' => ['sometimes', 'boolean'],
         ]);
+
+        $isRegex = $validated['is_regex'] ?? false;
+
+        // 正規表現パターンの場合、コンパイルチェック
+        if ($isRegex) {
+            $testResult = @preg_match($validated['pattern'], '');
+            if ($testResult === false) {
+                return response()->json(['message' => '無効な正規表現パターンです'], 422);
+            }
+        }
 
         try {
             $pattern = ChannelStripPattern::create([
                 'channel_id' => $channel->channel_id,
                 'pattern' => $validated['pattern'],
+                'is_regex' => $isRegex,
             ]);
         } catch (\Illuminate\Database\UniqueConstraintViolationException $e) {
             return response()->json(['message' => '既に登録されています'], 422);
@@ -185,7 +197,10 @@ class ManageSettingsApiController extends Controller
             abort(403, 'このチャンネルへのアクセス権限がありません');
         }
 
-        $stripPatterns = $channel->stripPatterns()->pluck('pattern')->toArray();
+        $stripPatterns = $channel->stripPatterns()
+            ->get(['pattern', 'is_regex'])
+            ->map(fn ($p) => ['pattern' => $p->pattern, 'is_regex' => $p->is_regex])
+            ->toArray();
 
         \App\Jobs\ReapplyStripPatternsJob::dispatch($channel, $stripPatterns);
 

--- a/app/Models/ChannelStripPattern.php
+++ b/app/Models/ChannelStripPattern.php
@@ -12,6 +12,11 @@ class ChannelStripPattern extends Model
     protected $fillable = [
         'channel_id',
         'pattern',
+        'is_regex',
+    ];
+
+    protected $casts = [
+        'is_regex' => 'boolean',
     ];
 
     public function channel()

--- a/app/Models/TsItem.php
+++ b/app/Models/TsItem.php
@@ -89,7 +89,10 @@ class TsItem extends Model
             return [];
         }
 
-        $patterns = $channel->stripPatterns()->pluck('pattern')->toArray();
+        $patterns = $channel->stripPatterns()
+            ->get(['pattern', 'is_regex'])
+            ->map(fn ($p) => ['pattern' => $p->pattern, 'is_regex' => $p->is_regex])
+            ->toArray();
         self::$stripPatternsCache[$videoId] = $patterns;
 
         return $patterns;

--- a/app/Services/RefreshArchiveService.php
+++ b/app/Services/RefreshArchiveService.php
@@ -55,7 +55,10 @@ class RefreshArchiveService
     public function refreshArchives(Channel $channel): int
     {
         // チャンネルの除去パターンをロード
-        $stripPatterns = $channel->stripPatterns()->pluck('pattern')->toArray();
+        $stripPatterns = $channel->stripPatterns()
+            ->get(['pattern', 'is_regex'])
+            ->map(fn ($p) => ['pattern' => $p->pattern, 'is_regex' => $p->is_regex])
+            ->toArray();
 
         // 外部API呼び出しを全てトランザクション外で事前に実行
         // 1. archivesとts_itemsの取得および整形

--- a/app/Services/TimestampExtractorService.php
+++ b/app/Services/TimestampExtractorService.php
@@ -11,13 +11,28 @@ class TimestampExtractorService
      * 除去パターンを適用してテキストから装飾文字を除去する
      *
      * @param  string  $text  元テキスト
-     * @param  array  $stripPatterns  除去パターン文字列の配列
+     * @param  array  $stripPatterns  除去パターンの配列。各要素は ['pattern' => string, 'is_regex' => bool] または文字列
      * @return string 除去後のテキスト
      */
     public static function applyStripPatterns(string $text, array $stripPatterns): string
     {
-        foreach ($stripPatterns as $pattern) {
-            $text = str_replace($pattern, '', $text);
+        foreach ($stripPatterns as $item) {
+            if (is_array($item)) {
+                $pattern = $item['pattern'];
+                $isRegex = $item['is_regex'] ?? false;
+            } else {
+                $pattern = $item;
+                $isRegex = false;
+            }
+
+            if ($isRegex) {
+                $result = @preg_replace($pattern, '', $text);
+                if ($result !== null) {
+                    $text = $result;
+                }
+            } else {
+                $text = str_replace($pattern, '', $text);
+            }
         }
 
         return trim($text);
@@ -30,7 +45,7 @@ class TimestampExtractorService
      * @param  string  $type  タイプ（1: description, 2: comment）
      * @param  string  $description  抽出対象のテキスト
      * @param  string  $commentId  コメントID
-     * @param  array  $stripPatterns  除去パターン文字列の配列（チャンネル設定）
+     * @param  array  $stripPatterns  除去パターンの配列。各要素は ['pattern' => string, 'is_regex' => bool] または文字列
      * @return array タイムスタンプ配列
      */
     public function extractTimestamps(string $videoId, string $type, string $description, string $commentId, array $stripPatterns = []): array

--- a/app/Services/YouTubeService.php
+++ b/app/Services/YouTubeService.php
@@ -44,7 +44,7 @@ class YouTubeService
      * アーカイブとタイムスタンプを取得
      *
      * @param  string  $channelId  チャンネルID
-     * @param  array  $stripPatterns  除去パターン文字列の配列（チャンネル設定）
+     * @param  array  $stripPatterns  除去パターンの配列。各要素は ['pattern' => string, 'is_regex' => bool] または文字列
      * @return array アーカイブ配列（タイムスタンプ付き）
      */
     public function getArchivesAndTsItems(string $channelId, array $stripPatterns = []): array
@@ -92,7 +92,7 @@ class YouTubeService
      * コメントからタイムスタンプを取得
      *
      * @param  string  $videoId  動画ID
-     * @param  array  $stripPatterns  除去パターン文字列の配列（チャンネル設定）
+     * @param  array  $stripPatterns  除去パターンの配列。各要素は ['pattern' => string, 'is_regex' => bool] または文字列
      * @return array タイムスタンプ配列
      */
     public function getTimeStampsFromComments(string $videoId, array $stripPatterns = []): array

--- a/database/migrations/2026_04_16_000001_add_is_regex_to_channel_strip_patterns_table.php
+++ b/database/migrations/2026_04_16_000001_add_is_regex_to_channel_strip_patterns_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('channel_strip_patterns', function (Blueprint $table) {
+            $table->boolean('is_regex')->default(false)->after('pattern');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('channel_strip_patterns', function (Blueprint $table) {
+            $table->dropColumn('is_regex');
+        });
+    }
+};

--- a/resources/js/manage/settings.js
+++ b/resources/js/manage/settings.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const excludedWordError = document.getElementById('excludedWordError');
     const excludedWordsList = document.getElementById('excludedWordsList');
     const newStripPatternInput = document.getElementById('newStripPattern');
+    const newStripPatternIsRegex = document.getElementById('newStripPatternIsRegex');
     const addStripPatternBtn = document.getElementById('addStripPatternBtn');
     const stripPatternError = document.getElementById('stripPatternError');
     const stripPatternsList = document.getElementById('stripPatternsList');
@@ -196,9 +197,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
                 let html = '<ul class="divide-y dark:divide-gray-700">';
                 patterns.forEach(pattern => {
+                    const regexBadge = pattern.is_regex
+                        ? '<span class="ml-2 px-1.5 py-0.5 text-xs bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300 rounded">正規表現</span>'
+                        : '';
                     html += `
                         <li class="flex items-center justify-between px-4 py-3">
-                            <span class="text-gray-800 dark:text-gray-200">${escapeHTML(pattern.pattern)}</span>
+                            <span class="text-gray-800 dark:text-gray-200">${escapeHTML(pattern.pattern)}${regexBadge}</span>
                             <button type="button" class="delete-pattern-btn text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 text-sm" data-id="${escapeHTML(pattern.id)}">
                                 削除
                             </button>
@@ -232,9 +236,12 @@ document.addEventListener('DOMContentLoaded', function () {
         isProcessing = true;
         toggleButtonDisabled(addStripPatternBtn, true);
 
-        axios.post(`/api/manage/channels/${encodeURIComponent(cryptHandle)}/strip-patterns`, { pattern })
+        const isRegex = newStripPatternIsRegex.checked;
+
+        axios.post(`/api/manage/channels/${encodeURIComponent(cryptHandle)}/strip-patterns`, { pattern, is_regex: isRegex })
             .then(function () {
                 newStripPatternInput.value = '';
+                newStripPatternIsRegex.checked = false;
                 hideStripPatternError();
                 fetchStripPatterns();
             })

--- a/resources/views/manage/settings.blade.php
+++ b/resources/views/manage/settings.blade.php
@@ -72,6 +72,10 @@
                 <!-- 除去パターン追加フォーム -->
                 <div class="flex items-center gap-2 mb-4">
                     <x-text-input type="text" id="newStripPattern" placeholder="除去する文字列を入力" class="flex-1" />
+                    <label class="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap cursor-pointer">
+                        <input type="checkbox" id="newStripPatternIsRegex" class="rounded border-gray-300 dark:border-gray-600 dark:bg-gray-700">
+                        正規表現
+                    </label>
                     <x-primary-button id="addStripPatternBtn" type="button">追加</x-primary-button>
                 </div>
                 <div id="stripPatternError" class="text-red-500 text-sm mb-4 hidden"></div>

--- a/tests/Feature/ManageStripPatternApiTest.php
+++ b/tests/Feature/ManageStripPatternApiTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Channel;
+use App\Models\ChannelStripPattern;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Crypt;
+use Tests\TestCase;
+
+class ManageStripPatternApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Channel $channel;
+
+    private string $cryptHandle;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $this->cryptHandle = Crypt::encryptString($this->channel->handle);
+    }
+
+    public function test_add_string_pattern(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->postJson("/api/manage/channels/{$this->cryptHandle}/strip-patterns", [
+                'pattern' => '🎵',
+            ]);
+
+        $response->assertCreated();
+        $response->assertJsonFragment(['pattern' => '🎵', 'is_regex' => false]);
+
+        $this->assertDatabaseHas('channel_strip_patterns', [
+            'channel_id' => $this->channel->channel_id,
+            'pattern' => '🎵',
+            'is_regex' => false,
+        ]);
+    }
+
+    public function test_add_regex_pattern(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->postJson("/api/manage/channels/{$this->cryptHandle}/strip-patterns", [
+                'pattern' => '/【.*?】/u',
+                'is_regex' => true,
+            ]);
+
+        $response->assertCreated();
+        $response->assertJsonFragment(['pattern' => '/【.*?】/u', 'is_regex' => true]);
+
+        $this->assertDatabaseHas('channel_strip_patterns', [
+            'channel_id' => $this->channel->channel_id,
+            'pattern' => '/【.*?】/u',
+            'is_regex' => true,
+        ]);
+    }
+
+    public function test_add_invalid_regex_returns_422(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->postJson("/api/manage/channels/{$this->cryptHandle}/strip-patterns", [
+                'pattern' => '/[invalid/',
+                'is_regex' => true,
+            ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonFragment(['message' => '無効な正規表現パターンです']);
+
+        $this->assertDatabaseMissing('channel_strip_patterns', [
+            'channel_id' => $this->channel->channel_id,
+            'pattern' => '/[invalid/',
+        ]);
+    }
+
+    public function test_fetch_patterns_includes_is_regex(): void
+    {
+        ChannelStripPattern::create([
+            'channel_id' => $this->channel->channel_id,
+            'pattern' => '🎵',
+            'is_regex' => false,
+        ]);
+        ChannelStripPattern::create([
+            'channel_id' => $this->channel->channel_id,
+            'pattern' => '/【.*?】/u',
+            'is_regex' => true,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson("/api/manage/channels/{$this->cryptHandle}/strip-patterns");
+
+        $response->assertOk();
+        $patterns = $response->json();
+        $this->assertCount(2, $patterns);
+
+        // is_regex フラグが含まれていることを確認
+        $regexPattern = collect($patterns)->firstWhere('is_regex', true);
+        $stringPattern = collect($patterns)->firstWhere('is_regex', false);
+        $this->assertNotNull($regexPattern);
+        $this->assertNotNull($stringPattern);
+        $this->assertEquals('/【.*?】/u', $regexPattern['pattern']);
+        $this->assertEquals('🎵', $stringPattern['pattern']);
+    }
+
+    public function test_add_pattern_without_is_regex_defaults_to_false(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->postJson("/api/manage/channels/{$this->cryptHandle}/strip-patterns", [
+                'pattern' => '♪',
+            ]);
+
+        $response->assertCreated();
+        $response->assertJsonFragment(['is_regex' => false]);
+    }
+}

--- a/tests/Unit/Services/TimestampExtractorServiceTest.php
+++ b/tests/Unit/Services/TimestampExtractorServiceTest.php
@@ -124,4 +124,105 @@ class TimestampExtractorServiceTest extends TestCase
         $this->assertEquals(TextNormalizer::normalize('テスト曲名'), $results[0]['normalized_text']);
         $this->assertEquals(TextNormalizer::normalize('アーティスト / 曲名'), $results[1]['normalized_text']);
     }
+
+    /**
+     * applyStripPatterns: 正規表現パターンで除去
+     */
+    public function test_apply_strip_patterns_with_regex(): void
+    {
+        $text = '【MV】テスト曲名（full ver.）';
+        $patterns = [
+            ['pattern' => '/【.*?】/u', 'is_regex' => true],
+            ['pattern' => '/（.*?）/u', 'is_regex' => true],
+        ];
+
+        $result = TimestampExtractorService::applyStripPatterns($text, $patterns);
+
+        $this->assertEquals('テスト曲名', $result);
+    }
+
+    /**
+     * applyStripPatterns: 正規表現と文字列パターンの混在
+     */
+    public function test_apply_strip_patterns_mixed_regex_and_string(): void
+    {
+        $text = '🎵 【リクエスト】テスト曲名 ♪';
+        $patterns = [
+            ['pattern' => '🎵', 'is_regex' => false],
+            ['pattern' => '/【.*?】/u', 'is_regex' => true],
+            '♪',  // 文字列としても後方互換
+        ];
+
+        $result = TimestampExtractorService::applyStripPatterns($text, $patterns);
+
+        $this->assertEquals('テスト曲名', $result);
+    }
+
+    /**
+     * applyStripPatterns: 構造化配列形式（is_regex=false）
+     */
+    public function test_apply_strip_patterns_with_structured_array_non_regex(): void
+    {
+        $text = '🎵 テスト曲名 ♪';
+        $patterns = [
+            ['pattern' => '🎵', 'is_regex' => false],
+            ['pattern' => '♪', 'is_regex' => false],
+        ];
+
+        $result = TimestampExtractorService::applyStripPatterns($text, $patterns);
+
+        $this->assertEquals('テスト曲名', $result);
+    }
+
+    /**
+     * applyStripPatterns: 無効な正規表現はスキップされる
+     */
+    public function test_apply_strip_patterns_invalid_regex_is_skipped(): void
+    {
+        $text = 'テスト曲名';
+        $patterns = [
+            ['pattern' => '/[invalid/', 'is_regex' => true],
+        ];
+
+        $result = TimestampExtractorService::applyStripPatterns($text, $patterns);
+
+        $this->assertEquals('テスト曲名', $result);
+    }
+
+    /**
+     * applyStripPatterns: 絵文字を正規表現で除去
+     */
+    public function test_apply_strip_patterns_regex_removes_emoji_range(): void
+    {
+        $text = '🎵🎶 テスト曲名 ✨';
+        $patterns = [
+            ['pattern' => '/[\x{1F3B5}\x{1F3B6}\x{2728}]/u', 'is_regex' => true],
+        ];
+
+        $result = TimestampExtractorService::applyStripPatterns($text, $patterns);
+
+        $this->assertEquals('テスト曲名', $result);
+    }
+
+    /**
+     * extractTimestamps: 正規表現パターン付きでnormalized_textに反映される
+     */
+    public function test_extract_timestamps_with_regex_strip_patterns(): void
+    {
+        $description = "0:00 【MV】テスト曲名\n1:30 （リクエスト）アーティスト / 曲名";
+        $stripPatterns = [
+            ['pattern' => '/【.*?】/u', 'is_regex' => true],
+            ['pattern' => '/（.*?）/u', 'is_regex' => true],
+        ];
+
+        $results = $this->service->extractTimestamps('test_video', '1', $description, 'dummy', $stripPatterns);
+
+        $this->assertCount(2, $results);
+        // textは元のまま保持
+        $this->assertEquals('【MV】テスト曲名', $results[0]['text']);
+        $this->assertEquals('（リクエスト）アーティスト / 曲名', $results[1]['text']);
+        // normalized_textには正規表現パターンが適用された上でnormalizeされた値が入る
+        $this->assertEquals(TextNormalizer::normalize('テスト曲名'), $results[0]['normalized_text']);
+        $this->assertEquals(TextNormalizer::normalize('アーティスト / 曲名'), $results[1]['normalized_text']);
+    }
 }


### PR DESCRIPTION
## Summary

- `channel_strip_patterns` テーブルに `is_regex` カラム（boolean, default false）を追加
- `applyStripPatterns()` で正規表現パターン（`preg_replace`）と文字列パターン（`str_replace`）の両方に対応
- 正規表現パターン登録時にコンパイルチェックを実施し、無効パターンを拒否
- 管理画面に正規表現チェックボックスとバッジ表示を追加
- Unit/Feature テストを追加

Closes #515 の Phase 1-1 部分

## Test plan

- [ ] `php artisan test --filter=TimestampExtractorServiceTest` で正規表現関連テストがパスすること（#528）
- [ ] `php artisan test --filter=ManageStripPatternApiTest` でAPIテストがパスすること（#528）
- [ ] 管理画面で文字列パターンの追加・削除が従来通り動作すること
- [ ] 管理画面で正規表現パターン（例: `/【.*?】/u`）を追加でき、正規表現バッジが表示されること
- [ ] 無効な正規表現（例: `/[invalid/`）を登録するとエラーメッセージが表示されること
- [ ] 既存のstrip patternsの動作に影響がないこと（後方互換性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)