### PR TITLE
feat: 除去パターンのテンプレート機能（#515 Phase 1-2）

### DIFF
--- a/config/strip_pattern_templates.php
+++ b/config/strip_pattern_templates.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+    [
+        'label' => '隅付き括弧【】の中身を除去',
+        'pattern' => '/【.*?】/u',
+        'is_regex' => true,
+    ],
+    [
+        'label' => '全角丸括弧（）の中身を除去',
+        'pattern' => '/（.*?）/u',
+        'is_regex' => true,
+    ],
+    [
+        'label' => '半角丸括弧()の中身を除去',
+        'pattern' => '/\(.*?\)/u',
+        'is_regex' => true,
+    ],
+    [
+        'label' => '音符系絵文字を除去',
+        'pattern' => '/[\x{1F3B5}\x{1F3B6}\x{1F3B4}\x{1F3B7}-\x{1F3BB}\x{266A}\x{266B}]/u',
+        'is_regex' => true,
+    ],
+    [
+        'label' => '再生ボタン系記号を除去',
+        'pattern' => '/[\x{25B6}\x{25BA}\x{23E9}\x{23EF}\x{25C0}]/u',
+        'is_regex' => true,
+    ],
+    [
+        'label' => '装飾記号（星・キラキラ等）を除去',
+        'pattern' => '/[\x{2728}\x{2B50}\x{1F31F}\x{1F4AB}\x{2764}\x{1F496}\x{1F497}\x{1F499}\x{1F49A}\x{1F49B}\x{1F49C}]/u',
+        'is_regex' => true,
+    ],
+];

--- a/resources/js/manage/settings.js
+++ b/resources/js/manage/settings.js
@@ -192,6 +192,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 const patterns = response.data;
                 if (patterns.length === 0) {
                     stripPatternsList.innerHTML = '<div class="text-center text-gray-500 dark:text-gray-400 py-4">除去パターンが登録されていません</div>';
+                    renderTemplateButtons(patterns);
                     return;
                 }
 
@@ -217,6 +218,8 @@ document.addEventListener('DOMContentLoaded', function () {
                         deleteStripPattern(this.dataset.id);
                     });
                 });
+
+                renderTemplateButtons(patterns);
             })
             .catch(function (error) {
                 console.error("Error fetching strip patterns:", error);
@@ -378,6 +381,59 @@ document.addEventListener('DOMContentLoaded', function () {
     reapplyStripPatternsBtn.addEventListener('click', reapplyStripPatterns);
     loadPreviewBtn.addEventListener('click', loadPreview);
     reprocessBtn.addEventListener('click', reprocessCoverSongs);
+
+    // テンプレートボタンの生成
+    const templates = window.stripPatternTemplates || [];
+    const templatesContainer = document.getElementById('stripPatternTemplates');
+    const templateButtonsContainer = document.getElementById('stripPatternTemplateButtons');
+
+    function renderTemplateButtons(registeredPatterns) {
+        const registeredSet = new Set(registeredPatterns.map(p => p.pattern));
+        templateButtonsContainer.innerHTML = '';
+        let visibleCount = 0;
+
+        templates.forEach(template => {
+            if (registeredSet.has(template.pattern)) return;
+            visibleCount++;
+
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'px-2 py-1 text-xs bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 rounded border border-gray-300 dark:border-gray-600 transition-colors';
+            btn.textContent = template.label;
+            btn.addEventListener('click', function () {
+                addTemplatePattern(template, btn);
+            });
+            templateButtonsContainer.appendChild(btn);
+        });
+
+        templatesContainer.classList.toggle('hidden', visibleCount === 0);
+    }
+
+    function addTemplatePattern(template, btn) {
+        if (isProcessing) return;
+        isProcessing = true;
+        toggleButtonDisabled(btn, true);
+
+        axios.post(`/api/manage/channels/${encodeURIComponent(cryptHandle)}/strip-patterns`, {
+            pattern: template.pattern,
+            is_regex: template.is_regex,
+        })
+            .then(function () {
+                hideStripPatternError();
+                fetchStripPatterns();
+            })
+            .catch(function (error) {
+                if (error.response && error.response.data && error.response.data.message) {
+                    showStripPatternError(error.response.data.message);
+                } else {
+                    showStripPatternError('エラーが発生しました');
+                }
+            })
+            .finally(function () {
+                isProcessing = false;
+                toggleButtonDisabled(btn, false);
+            });
+    }
 
     // 初期化
     fetchExcludedWords();

--- a/resources/views/manage/settings.blade.php
+++ b/resources/views/manage/settings.blade.php
@@ -80,6 +80,12 @@
                 </div>
                 <div id="stripPatternError" class="text-red-500 text-sm mb-4 hidden"></div>
 
+                <!-- テンプレートから追加 -->
+                <div id="stripPatternTemplates" class="mb-4 hidden">
+                    <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">テンプレートから追加:</p>
+                    <div id="stripPatternTemplateButtons" class="flex flex-wrap gap-2"></div>
+                </div>
+
                 <!-- 除去パターン一覧 -->
                 <div id="stripPatternsList" class="border dark:border-gray-700 rounded-lg overflow-hidden">
                     <div class="text-center text-gray-500 dark:text-gray-400 py-4">読み込み中...</div>
@@ -130,6 +136,9 @@
     </div>
 
     <x-text-input type="hidden" id="cryptHandle" value="{{ $crypt_handle }}" />
+    <script>
+        window.stripPatternTemplates = @json(config('strip_pattern_templates', []));
+    </script>
 </x-app-layout>
 
 @vite('resources/js/manage/settings.js')


### PR DESCRIPTION
## Summary

- よく使う除去パターン（括弧除去、絵文字除去等）をテンプレートとして6種類提供
- テンプレートはconfigで管理（DBテーブル不要）
- 管理画面でワンクリックでチャンネルに追加可能
- 登録済みパターンはテンプレートボタンから自動的に非表示

## Test plan

- [ ] 管理画面の除去パターンセクションにテンプレートボタンが表示されること
- [ ] テンプレートボタンをクリックするとパターンが追加されること
- [ ] 追加済みのテンプレートはボタンから非表示になること
- [ ] 全テンプレートが登録済みの場合、テンプレートセクションが非表示になること
- [ ] テンプレートを削除するとボタンが再表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)