### PR TITLE
feat: 除去パターンの検出モード/プレビュー機能（#515 Phase 1-3）

### DIFF
--- a/app/Http/Controllers/ManageSettingsApiController.php
+++ b/app/Http/Controllers/ManageSettingsApiController.php
@@ -9,9 +9,11 @@ use App\Models\Archive;
 use App\Models\Channel;
 use App\Models\ChannelExcludedWord;
 use App\Models\ChannelStripPattern;
+use App\Models\Song;
 use App\Models\TimestampSongMapping;
 use App\Models\TsItem;
 use App\Services\CoverSongTitleExtractorService;
+use App\Services\TimestampExtractorService;
 use App\Services\VideoAnalyzerService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Crypt;
@@ -207,6 +209,128 @@ class ManageSettingsApiController extends Controller
         return response()->json([
             'message' => '除去パターンの再適用をバックグラウンドで開始しました。完了までしばらくお待ちください。',
         ]);
+    }
+
+    /**
+     * 除去パターンのプレビュー（検出モード）
+     * パターンを適用せず、ヒットする箇所を一覧表示する
+     */
+    public function previewStripPatterns(string $id)
+    {
+        $handle = Crypt::decryptString($id);
+        $channel = Channel::where('handle', $handle)->firstOrFail();
+
+        if (! $this->canAccessChannel($channel)) {
+            abort(403, 'このチャンネルへのアクセス権限がありません');
+        }
+
+        $stripPatterns = $channel->stripPatterns()
+            ->get(['pattern', 'is_regex'])
+            ->map(fn ($p) => ['pattern' => $p->pattern, 'is_regex' => $p->is_regex])
+            ->toArray();
+
+        if (empty($stripPatterns)) {
+            return response()->json(['ts_items' => [], 'songs' => []], 200, [], JSON_UNESCAPED_UNICODE);
+        }
+
+        $maxResults = 500;
+
+        // ts_items のプレビュー: チャンネルの表示対象ts_itemsに対してパターン適用結果を比較
+        $tsItemPreviews = [];
+        $tsItemTruncated = false;
+        TsItem::whereHas('archive', function ($q) use ($channel) {
+            $q->where('channel_id', $channel->channel_id)->where('is_display', 1);
+        })
+            ->where('is_display', 1)
+            ->chunk(200, function ($tsItems) use ($stripPatterns, &$tsItemPreviews, &$tsItemTruncated, $maxResults) {
+                if ($tsItemTruncated) {
+                    return false;
+                }
+
+                foreach ($tsItems as $tsItem) {
+                    if (count($tsItemPreviews) >= $maxResults) {
+                        $tsItemTruncated = true;
+
+                        return false;
+                    }
+
+                    $rawText = $tsItem->attributes['text'] ?? null;
+                    if (! $rawText) {
+                        continue;
+                    }
+
+                    $afterStrip = TimestampExtractorService::applyStripPatterns($rawText, $stripPatterns);
+                    $newNormalized = TextNormalizer::normalize($afterStrip);
+
+                    if ($newNormalized === '' && trim($afterStrip) !== '') {
+                        $newNormalized = mb_strtolower(trim($afterStrip), 'UTF-8');
+                    }
+
+                    $currentNormalized = $tsItem->attributes['normalized_text'] ?? '';
+
+                    // パターン適用で変化がある場合のみ返す
+                    if ($currentNormalized !== $newNormalized) {
+                        $tsItemPreviews[] = [
+                            'video_id' => $tsItem->video_id,
+                            'text' => $rawText,
+                            'current_normalized' => $currentNormalized,
+                            'new_normalized' => $newNormalized,
+                        ];
+                    }
+                }
+            });
+
+        // songs のプレビュー: チャンネルに紐づくsong（表示対象ts_items経由）のtitle/artistにパターンがヒットするか
+        $songPreviews = [];
+        $songTruncated = false;
+        $songIds = TimestampSongMapping::whereIn(
+            'normalized_text',
+            TsItem::whereHas('archive', function ($q) use ($channel) {
+                $q->where('channel_id', $channel->channel_id)->where('is_display', 1);
+            })->where('is_display', 1)->select('normalized_text')
+        )->whereNotNull('song_id')->pluck('song_id')->unique();
+
+        if ($songIds->isNotEmpty()) {
+            Song::whereIn('id', $songIds)->chunk(200, function ($songs) use ($stripPatterns, &$songPreviews, &$songTruncated, $maxResults) {
+                if ($songTruncated) {
+                    return false;
+                }
+
+                foreach ($songs as $song) {
+                    if (count($songPreviews) >= $maxResults) {
+                        $songTruncated = true;
+
+                        return false;
+                    }
+
+                    $titleAfter = $song->title
+                        ? TimestampExtractorService::applyStripPatterns($song->title, $stripPatterns)
+                        : null;
+                    $artistAfter = $song->artist
+                        ? TimestampExtractorService::applyStripPatterns($song->artist, $stripPatterns)
+                        : null;
+
+                    $titleChanged = $titleAfter !== null && $titleAfter !== $song->title;
+                    $artistChanged = $artistAfter !== null && $artistAfter !== $song->artist;
+
+                    if ($titleChanged || $artistChanged) {
+                        $songPreviews[] = [
+                            'song_id' => $song->id,
+                            'title' => $song->title,
+                            'artist' => $song->artist,
+                            'title_after' => $titleChanged ? $titleAfter : null,
+                            'artist_after' => $artistChanged ? $artistAfter : null,
+                        ];
+                    }
+                }
+            });
+        }
+
+        return response()->json([
+            'ts_items' => $tsItemPreviews,
+            'songs' => $songPreviews,
+            'truncated' => $tsItemTruncated || $songTruncated,
+        ], 200, [], JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE);
     }
 
     /**

--- a/resources/js/manage/settings.js
+++ b/resources/js/manage/settings.js
@@ -13,7 +13,16 @@ document.addEventListener('DOMContentLoaded', function () {
     const stripPatternError = document.getElementById('stripPatternError');
     const stripPatternsList = document.getElementById('stripPatternsList');
     const reapplyStripPatternsBtn = document.getElementById('reapplyStripPatternsBtn');
+    const previewStripPatternsBtn = document.getElementById('previewStripPatternsBtn');
     const stripPatternMessage = document.getElementById('stripPatternMessage');
+    const stripPatternPreview = document.getElementById('stripPatternPreview');
+    const stripPreviewTsItems = document.getElementById('stripPreviewTsItems');
+    const stripPreviewSongs = document.getElementById('stripPreviewSongs');
+    const stripPreviewNoHits = document.getElementById('stripPreviewNoHits');
+    const stripPreviewTsCount = document.getElementById('stripPreviewTsCount');
+    const stripPreviewSongCount = document.getElementById('stripPreviewSongCount');
+    const stripPreviewTsBody = document.getElementById('stripPreviewTsBody');
+    const stripPreviewSongBody = document.getElementById('stripPreviewSongBody');
     const loadPreviewBtn = document.getElementById('loadPreviewBtn');
     const reprocessBtn = document.getElementById('reprocessBtn');
     const previewMessage = document.getElementById('previewMessage');
@@ -305,6 +314,90 @@ document.addEventListener('DOMContentLoaded', function () {
             });
     }
 
+    // 除去パターンのプレビュー（検出モード）
+    function previewStripPatterns() {
+        if (isProcessing) return;
+        isProcessing = true;
+        toggleButtonDisabled(previewStripPatternsBtn, true);
+
+        showStripPatternMessage('プレビュー読み込み中...', 'text-gray-600');
+
+        axios.get(`/api/manage/channels/${encodeURIComponent(cryptHandle)}/strip-patterns/preview`)
+            .then(function (response) {
+                const data = response.data;
+                const tsItems = data.ts_items || [];
+                const songs = data.songs || [];
+                const truncated = data.truncated || false;
+
+                stripPatternPreview.classList.remove('hidden');
+
+                // ts_items プレビュー
+                if (tsItems.length > 0) {
+                    stripPreviewTsItems.classList.remove('hidden');
+                    stripPreviewTsCount.textContent = tsItems.length;
+
+                    let html = '';
+                    tsItems.forEach(item => {
+                        html += `
+                            <tr class="border-t dark:border-gray-700">
+                                <td class="px-3 py-1.5 text-gray-800 dark:text-gray-200">${escapeHTML(item.text)}</td>
+                                <td class="px-3 py-1.5 text-gray-500 dark:text-gray-400">${escapeHTML(item.current_normalized)}</td>
+                                <td class="px-3 py-1.5 text-blue-600 dark:text-blue-400 font-medium">${escapeHTML(item.new_normalized)}</td>
+                            </tr>
+                        `;
+                    });
+                    stripPreviewTsBody.innerHTML = html;
+                } else {
+                    stripPreviewTsItems.classList.add('hidden');
+                }
+
+                // songs プレビュー
+                if (songs.length > 0) {
+                    stripPreviewSongs.classList.remove('hidden');
+                    stripPreviewSongCount.textContent = songs.length;
+
+                    let html = '';
+                    songs.forEach(song => {
+                        const hitParts = [];
+                        if (song.title_after !== null) {
+                            hitParts.push(`タイトル: ${escapeHTML(song.title)} → ${escapeHTML(song.title_after)}`);
+                        }
+                        if (song.artist_after !== null) {
+                            hitParts.push(`アーティスト: ${escapeHTML(song.artist)} → ${escapeHTML(song.artist_after)}`);
+                        }
+                        html += `
+                            <tr class="border-t dark:border-gray-700">
+                                <td class="px-3 py-1.5 text-gray-800 dark:text-gray-200">${escapeHTML(song.title || '')}</td>
+                                <td class="px-3 py-1.5 text-gray-800 dark:text-gray-200">${escapeHTML(song.artist || '')}</td>
+                                <td class="px-3 py-1.5 text-orange-600 dark:text-orange-400">${hitParts.join('<br>')}</td>
+                            </tr>
+                        `;
+                    });
+                    stripPreviewSongBody.innerHTML = html;
+                } else {
+                    stripPreviewSongs.classList.add('hidden');
+                }
+
+                // ヒットなし
+                if (tsItems.length === 0 && songs.length === 0) {
+                    stripPreviewNoHits.classList.remove('hidden');
+                } else {
+                    stripPreviewNoHits.classList.add('hidden');
+                }
+
+                const truncatedMsg = truncated ? '（結果が多いため一部のみ表示）' : '';
+                showStripPatternMessage(`プレビュー完了（TS: ${tsItems.length}件、楽曲: ${songs.length}件）${truncatedMsg}`, 'text-green-600');
+            })
+            .catch(function (error) {
+                console.error("Error previewing strip patterns:", error);
+                showStripPatternMessage('プレビューの読み込みに失敗しました', 'text-red-500');
+            })
+            .finally(function () {
+                isProcessing = false;
+                toggleButtonDisabled(previewStripPatternsBtn, false);
+            });
+    }
+
     // 除去パターンエラー表示
     function showStripPatternError(message) {
         stripPatternError.textContent = message;
@@ -379,6 +472,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
     reapplyStripPatternsBtn.addEventListener('click', reapplyStripPatterns);
+    previewStripPatternsBtn.addEventListener('click', previewStripPatterns);
     loadPreviewBtn.addEventListener('click', loadPreview);
     reprocessBtn.addEventListener('click', reprocessCoverSongs);
 

--- a/resources/views/manage/settings.blade.php
+++ b/resources/views/manage/settings.blade.php
@@ -91,14 +91,60 @@
                     <div class="text-center text-gray-500 dark:text-gray-400 py-4">読み込み中...</div>
                 </div>
 
-                <!-- 再適用ボタン -->
-                <div class="mt-4">
+                <!-- プレビュー・再適用ボタン -->
+                <div class="mt-4 flex items-center gap-2 flex-wrap">
+                    <x-primary-button id="previewStripPatternsBtn" type="button">
+                        プレビュー
+                    </x-primary-button>
                     <x-primary-button id="reapplyStripPatternsBtn" type="button" class="bg-orange-600 hover:bg-orange-700">
                         既存タイムスタンプに再適用
                     </x-primary-button>
-                    <span class="text-xs text-gray-500 dark:text-gray-400 ml-2">パターン変更後に実行すると、既存のタイムスタンプの照合テキストが再生成されます</span>
+                    <span class="text-xs text-gray-500 dark:text-gray-400">パターン変更後にプレビューで確認し、問題なければ再適用してください</span>
                 </div>
                 <div id="stripPatternMessage" class="text-sm mt-2 hidden"></div>
+
+                <!-- プレビュー結果 -->
+                <div id="stripPatternPreview" class="mt-4 hidden">
+                    <h4 class="text-sm font-bold text-gray-700 dark:text-gray-300 mb-2">プレビュー結果</h4>
+
+                    <!-- ts_items プレビュー -->
+                    <div id="stripPreviewTsItems" class="mb-4 hidden">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">タイムスタンプ（<span id="stripPreviewTsCount">0</span>件変化）</p>
+                        <div class="border dark:border-gray-700 rounded-lg overflow-x-auto">
+                            <table class="w-full text-xs">
+                                <thead class="bg-gray-100 dark:bg-gray-700">
+                                    <tr>
+                                        <th class="px-3 py-1.5 text-left">元テキスト</th>
+                                        <th class="px-3 py-1.5 text-left">現在の照合テキスト</th>
+                                        <th class="px-3 py-1.5 text-left">適用後の照合テキスト</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="stripPreviewTsBody"></tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <!-- songs プレビュー -->
+                    <div id="stripPreviewSongs" class="mb-4 hidden">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-1">楽曲マスタ（<span id="stripPreviewSongCount">0</span>件ヒット）</p>
+                        <div class="border dark:border-gray-700 rounded-lg overflow-x-auto">
+                            <table class="w-full text-xs">
+                                <thead class="bg-gray-100 dark:bg-gray-700">
+                                    <tr>
+                                        <th class="px-3 py-1.5 text-left">タイトル</th>
+                                        <th class="px-3 py-1.5 text-left">アーティスト</th>
+                                        <th class="px-3 py-1.5 text-left">パターンヒット箇所</th>
+                                    </tr>
+                                </thead>
+                                <tbody id="stripPreviewSongBody"></tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div id="stripPreviewNoHits" class="text-center text-gray-500 dark:text-gray-400 py-3 text-sm hidden">
+                        パターンにヒットする箇所はありません
+                    </div>
+                </div>
             </div>
 
             <!-- カバー曲プレビューセクション -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -73,6 +73,9 @@ Route::middleware(['auth', 'admin'])->group(function () {
     Route::post('api/manage/channels/{id}/strip-patterns/reapply', [ManageSettingsApiController::class, 'reapplyStripPatterns'])
         ->name('manage.reapplyStripPatterns')
         ->middleware('throttle:5,1'); // 1分間に5回まで
+    Route::get('api/manage/channels/{id}/strip-patterns/preview', [ManageSettingsApiController::class, 'previewStripPatterns'])
+        ->name('manage.previewStripPatterns')
+        ->middleware('throttle:5,1'); // 1分間に5回まで
     // 自動紐付け（Spotify API呼び出しを含む長時間ジョブのため、レート制限は保守的に設定）
     Route::post('api/manage/channels/{id}/auto-link', [ManageSettingsApiController::class, 'autoLink'])
         ->name('manage.autoLink')

--- a/tests/Feature/ManageStripPatternPreviewTest.php
+++ b/tests/Feature/ManageStripPatternPreviewTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Archive;
+use App\Models\Channel;
+use App\Models\ChannelStripPattern;
+use App\Models\Song;
+use App\Models\TimestampSongMapping;
+use App\Models\TsItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ManageStripPatternPreviewTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Channel $channel;
+
+    private string $cryptHandle;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->channel = Channel::factory()->create(['user_id' => $this->user->id]);
+        $this->cryptHandle = Crypt::encryptString($this->channel->handle);
+    }
+
+    public function test_preview_returns_empty_when_no_patterns(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->getJson("/api/manage/channels/{$this->cryptHandle}/strip-patterns/preview");
+
+        $response->assertOk();
+        $response->assertJson(['ts_items' => [], 'songs' => []]);
+    }
+
+    public function test_preview_shows_ts_items_with_changes(): void
+    {
+        $archive = Archive::factory()->create([
+            'channel_id' => $this->channel->channel_id,
+            'is_display' => 1,
+        ]);
+
+        $tsItemId = Str::ulid();
+        TsItem::create([
+            'id' => $tsItemId,
+            'video_id' => $archive->video_id,
+            'type' => '1',
+            'ts_text' => '0:00',
+            'ts_num' => 0,
+            'text' => '🎵 テスト曲名 ♪',
+            'normalized_text' => '🎵 テスト曲名 ♪',
+            'is_display' => 1,
+            'comment_id' => $archive->video_id,
+        ]);
+
+        // normalized_textを強制的に設定（savingイベントをバイパス）
+        \DB::table('ts_items')->where('id', $tsItemId)->update([
+            'normalized_text' => '🎵 テスト曲名 ♪',
+        ]);
+
+        ChannelStripPattern::create([
+            'channel_id' => $this->channel->channel_id,
+            'pattern' => '🎵',
+            'is_regex' => false,
+        ]);
+        ChannelStripPattern::create([
+            'channel_id' => $this->channel->channel_id,
+            'pattern' => '♪',
+            'is_regex' => false,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson("/api/manage/channels/{$this->cryptHandle}/strip-patterns/preview");
+
+        $response->assertOk();
+        $tsItems = $response->json('ts_items');
+        $this->assertNotEmpty($tsItems);
+        $this->assertEquals('🎵 テスト曲名 ♪', $tsItems[0]['text']);
+    }
+
+    public function test_preview_excludes_ts_items_without_changes(): void
+    {
+        $archive = Archive::factory()->create([
+            'channel_id' => $this->channel->channel_id,
+            'is_display' => 1,
+        ]);
+
+        TsItem::create([
+            'id' => Str::ulid(),
+            'video_id' => $archive->video_id,
+            'type' => '1',
+            'ts_text' => '0:00',
+            'ts_num' => 0,
+            'text' => 'テスト曲名',
+            'is_display' => 1,
+            'comment_id' => $archive->video_id,
+        ]);
+
+        // パターンはテキストにマッチしない
+        ChannelStripPattern::create([
+            'channel_id' => $this->channel->channel_id,
+            'pattern' => '🎵',
+            'is_regex' => false,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson("/api/manage/channels/{$this->cryptHandle}/strip-patterns/preview");
+
+        $response->assertOk();
+        $this->assertEmpty($response->json('ts_items'));
+    }
+
+    public function test_preview_shows_songs_with_pattern_hits(): void
+    {
+        $archive = Archive::factory()->create([
+            'channel_id' => $this->channel->channel_id,
+            'is_display' => 1,
+        ]);
+
+        $tsItem = TsItem::create([
+            'id' => Str::ulid(),
+            'video_id' => $archive->video_id,
+            'type' => '1',
+            'ts_text' => '0:00',
+            'ts_num' => 0,
+            'text' => 'テスト曲名',
+            'is_display' => 1,
+            'comment_id' => $archive->video_id,
+        ]);
+
+        $song = Song::create([
+            'id' => Str::ulid(),
+            'title' => '【MV】テスト曲名',
+            'artist' => 'テストアーティスト',
+        ]);
+
+        TimestampSongMapping::create([
+            'id' => Str::ulid(),
+            'normalized_text' => $tsItem->normalized_text,
+            'song_id' => $song->id,
+        ]);
+
+        ChannelStripPattern::create([
+            'channel_id' => $this->channel->channel_id,
+            'pattern' => '/【.*?】/u',
+            'is_regex' => true,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson("/api/manage/channels/{$this->cryptHandle}/strip-patterns/preview");
+
+        $response->assertOk();
+        $songs = $response->json('songs');
+        $this->assertNotEmpty($songs);
+        $this->assertEquals('テスト曲名', $songs[0]['title_after']);
+    }
+
+    public function test_preview_denied_for_unauthorized_user(): void
+    {
+        $otherUser = User::factory()->create();
+
+        $response = $this->actingAs($otherUser)
+            ->getJson("/api/manage/channels/{$this->cryptHandle}/strip-patterns/preview");
+
+        $response->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary

- strip patternsを実際に適用せず、ヒットする箇所を一覧表示するプレビュー機能を追加
- `GET api/manage/channels/{id}/strip-patterns/preview` エンドポイント追加
- ts_items: 元テキスト / 現在の照合テキスト / 適用後の照合テキスト を並べて表示
- songs: title/artist へのパターンヒットを検出して表示
- 結果件数上限500件（超過時は truncated フラグで通知）
- レートリミット設定（throttle:5,1）

## Test plan

- [ ] `php artisan test --filter=ManageStripPatternPreviewTest` でテストがパスすること（#528）
- [ ] 管理画面でプレビューボタンをクリックすると、パターン適用結果が表示されること
- [ ] パターンが未登録の場合、空の結果が返ること
- [ ] パターンにヒットしない場合、「ヒットする箇所はありません」と表示されること
- [ ] 楽曲マスタにパターンがヒットする場合、songs セクションに表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)