### PR TITLE
feat: Songレコードのバッチ信頼度判定（#515 Phase 2-1）

### DIFF
--- a/app/Console/Commands/ReviewSongStatus.php
+++ b/app/Console/Commands/ReviewSongStatus.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Song;
+use App\Services\TimestampExtractorService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class ReviewSongStatus extends Command
+{
+    protected $signature = 'songs:review-status
+        {--chunk=200 : チャンクサイズ}
+        {--dry-run : 実際の更新を行わず、判定結果のみ表示}';
+
+    protected $description = '全Songレコードの信頼度を判定し、review_status (safe/needs_review) を設定（装飾検出にstrip_pattern_templatesを使用）';
+
+    public function handle(): int
+    {
+        $chunkSize = (int) $this->option('chunk');
+        $dryRun = $this->option('dry-run');
+
+        $decorationPatterns = collect(config('strip_pattern_templates', []))
+            ->map(fn ($t) => ['pattern' => $t['pattern'], 'is_regex' => $t['is_regex']])
+            ->toArray();
+
+        $stats = [Song::REVIEW_STATUS_SAFE => 0, Song::REVIEW_STATUS_NEEDS_REVIEW => 0, 'total' => 0];
+
+        Song::with('mappings')->chunk($chunkSize, function ($songs) use ($decorationPatterns, $dryRun, &$stats) {
+            $safeIds = [];
+            $needsReviewIds = [];
+
+            foreach ($songs as $song) {
+                $stats['total']++;
+                $status = $this->evaluateSong($song, $decorationPatterns);
+                $stats[$status]++;
+
+                if ($status === Song::REVIEW_STATUS_SAFE) {
+                    $safeIds[] = $song->id;
+                } else {
+                    $needsReviewIds[] = $song->id;
+                }
+
+                if ($this->getOutput()->isVerbose()) {
+                    $this->line("[{$status}] {$song->title} / {$song->artist}");
+                }
+            }
+
+            if (! $dryRun) {
+                if (! empty($safeIds)) {
+                    DB::table('songs')->whereIn('id', $safeIds)
+                        ->update(['review_status' => Song::REVIEW_STATUS_SAFE, 'updated_at' => now()]);
+                }
+                if (! empty($needsReviewIds)) {
+                    DB::table('songs')->whereIn('id', $needsReviewIds)
+                        ->update(['review_status' => Song::REVIEW_STATUS_NEEDS_REVIEW, 'updated_at' => now()]);
+                }
+            }
+        });
+
+        $safe = $stats[Song::REVIEW_STATUS_SAFE];
+        $needsReview = $stats[Song::REVIEW_STATUS_NEEDS_REVIEW];
+        $this->info("判定完了: 合計 {$stats['total']}件 (safe: {$safe}, needs_review: {$needsReview})");
+
+        if ($dryRun) {
+            $this->warn('--dry-run: 実際の更新は行われていません');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function evaluateSong(Song $song, array $decorationPatterns): string
+    {
+        // 1. 装飾検出: title/artist にテンプレートパターンがヒットするか
+        if ($this->hasDecoration($song, $decorationPatterns)) {
+            return Song::REVIEW_STATUS_NEEDS_REVIEW;
+        }
+
+        // 2. 一致チェック: マッピングが存在し、normalized_text にtitle/artistが含まれるか
+        $mappedTexts = $song->mappings->pluck('normalized_text')->toArray();
+
+        if (empty($mappedTexts)) {
+            return Song::REVIEW_STATUS_NEEDS_REVIEW;
+        }
+
+        $normalizedTitle = $song->normalized_title ?? '';
+        $normalizedArtist = $song->normalized_artist ?? '';
+
+        foreach ($mappedTexts as $text) {
+            if ($normalizedTitle !== '' && str_contains($text, $normalizedTitle)) {
+                return Song::REVIEW_STATUS_SAFE;
+            }
+            if ($normalizedArtist !== '' && str_contains($text, $normalizedArtist)) {
+                return Song::REVIEW_STATUS_SAFE;
+            }
+        }
+
+        return Song::REVIEW_STATUS_NEEDS_REVIEW;
+    }
+
+    private function hasDecoration(Song $song, array $decorationPatterns): bool
+    {
+        if (empty($decorationPatterns)) {
+            return false;
+        }
+
+        if ($song->title) {
+            $after = TimestampExtractorService::applyStripPatterns($song->title, $decorationPatterns);
+            if ($after !== $song->title) {
+                return true;
+            }
+        }
+
+        if ($song->artist) {
+            $after = TimestampExtractorService::applyStripPatterns($song->artist, $decorationPatterns);
+            if ($after !== $song->artist) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -24,9 +24,14 @@ class Song extends Model
         'duration_ms',
         'normalized_title',
         'normalized_artist',
+        'review_status',
         'created_by',
         'updated_by',
     ];
+
+    public const REVIEW_STATUS_SAFE = 'safe';
+
+    public const REVIEW_STATUS_NEEDS_REVIEW = 'needs_review';
 
     protected $casts = [
         'spotify_data' => 'array',

--- a/database/migrations/2026_04_17_000001_add_review_status_to_songs_table.php
+++ b/database/migrations/2026_04_17_000001_add_review_status_to_songs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->string('review_status', 20)->nullable()->after('normalized_artist');
+            $table->index('review_status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('songs', function (Blueprint $table) {
+            $table->dropIndex(['review_status']);
+            $table->dropColumn('review_status');
+        });
+    }
+};

--- a/tests/Unit/Commands/ReviewSongStatusTest.php
+++ b/tests/Unit/Commands/ReviewSongStatusTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Unit\Commands;
+
+use App\Models\Song;
+use App\Models\TimestampSongMapping;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ReviewSongStatusTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_safe_when_normalized_title_matches_mapped_text(): void
+    {
+        $song = Song::factory()->withoutSpotify()->create([
+            'title' => 'テスト曲名',
+            'artist' => 'テストアーティスト',
+        ]);
+
+        TimestampSongMapping::create([
+            'id' => Str::ulid(),
+            'normalized_text' => $song->normalized_title,
+            'song_id' => $song->id,
+        ]);
+
+        $this->artisan('songs:review-status')->assertSuccessful();
+
+        $song->refresh();
+        $this->assertEquals('safe', $song->review_status);
+    }
+
+    public function test_needs_review_when_no_mappings(): void
+    {
+        $song = Song::factory()->withoutSpotify()->create([
+            'title' => '孤立した曲',
+            'artist' => 'アーティスト',
+        ]);
+
+        $this->artisan('songs:review-status')->assertSuccessful();
+
+        $song->refresh();
+        $this->assertEquals('needs_review', $song->review_status);
+    }
+
+    public function test_needs_review_when_title_does_not_match(): void
+    {
+        $song = Song::factory()->withoutSpotify()->create([
+            'title' => 'Song Title in English',
+            'artist' => 'English Artist',
+        ]);
+
+        TimestampSongMapping::create([
+            'id' => Str::ulid(),
+            'normalized_text' => '全く違うテキスト',
+            'song_id' => $song->id,
+        ]);
+
+        $this->artisan('songs:review-status')->assertSuccessful();
+
+        $song->refresh();
+        $this->assertEquals('needs_review', $song->review_status);
+    }
+
+    public function test_needs_review_when_decoration_detected(): void
+    {
+        config(['strip_pattern_templates' => [
+            ['label' => 'test', 'pattern' => '/【.*?】/u', 'is_regex' => true],
+        ]]);
+
+        $song = Song::factory()->withoutSpotify()->create([
+            'title' => '【MV】テスト曲名',
+            'artist' => 'テストアーティスト',
+        ]);
+
+        TimestampSongMapping::create([
+            'id' => Str::ulid(),
+            'normalized_text' => $song->normalized_title,
+            'song_id' => $song->id,
+        ]);
+
+        $this->artisan('songs:review-status')->assertSuccessful();
+
+        $song->refresh();
+        // 装飾検出が先に評価されるため needs_review
+        $this->assertEquals('needs_review', $song->review_status);
+    }
+
+    public function test_dry_run_does_not_update(): void
+    {
+        $song = Song::factory()->withoutSpotify()->create([
+            'title' => 'テスト曲名',
+            'artist' => 'テストアーティスト',
+        ]);
+
+        $this->artisan('songs:review-status', ['--dry-run' => true])->assertSuccessful();
+
+        $song->refresh();
+        $this->assertNull($song->review_status);
+    }
+}


### PR DESCRIPTION
## Summary

- `songs` テーブルに `review_status` カラム（safe/needs_review）を追加
- `songs:review-status` Artisanコマンドで全Songの信頼度をバッチ判定
  - 装飾検出: strip_pattern_templatesのパターンがtitle/artistにヒット → needs_review
  - 一致チェック: normalized_title/artistがマッピング先のnormalized_textに含まれるか → safe/needs_review
  - マッピング未存在 → needs_review
- Eager Loading + バルク更新でパフォーマンス最適化
- `--dry-run` / `--chunk` / `-v` オプション対応

## Test plan

- [ ] `php artisan test --filter=ReviewSongStatusTest` でテストがパスすること（#528）
- [ ] `php artisan songs:review-status --dry-run` で判定結果が表示されること
- [ ] `php artisan songs:review-status` で songs.review_status が更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)