### PR TITLE
feat: 正規化画面にreview_statusフィルタ追加（#515 Phase 2-2）

### DIFF
--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -295,11 +295,18 @@ class SongController extends Controller
         // バリデーション
         $validated = $request->validate([
             'search' => 'nullable|string|max:255',
+            'review_status' => 'nullable|string|in:safe,needs_review',
         ]);
 
         $search = $validated['search'] ?? '';
+        $reviewStatus = $validated['review_status'] ?? null;
 
         $query = Song::query();
+
+        // review_statusフィルタ
+        if ($reviewStatus !== null) {
+            $query->where('review_status', $reviewStatus);
+        }
 
         // 検索条件（スペース区切りでAND検索）
         // 各キーワードがtitleまたはartistのいずれかに含まれる

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -25,6 +25,7 @@ class TimestampNormalization {
         this.currentSongFilter = null; // 楽曲による絞り込み（楽曲オブジェクト）
         this.operationHistory = []; // 操作履歴
         this.maxHistoryItems = 20; // 最大履歴保持数
+        this.songReviewStatus = null; // 楽曲マスタのreview_statusフィルタ
 
         this.init();
     }
@@ -105,6 +106,21 @@ class TimestampNormalization {
         document.getElementById('clearSongsSearchBtn').addEventListener('click', () => {
             document.getElementById('songsSearch').value = '';
             this.loadSongs('');
+        });
+
+        // 楽曲マスタ review_status フィルタ
+        document.querySelectorAll('.song-review-filter').forEach(btn => {
+            btn.addEventListener('click', () => {
+                this.songReviewStatus = btn.dataset.reviewStatus || null;
+                // ボタンのアクティブ状態を更新
+                document.querySelectorAll('.song-review-filter').forEach(b => {
+                    b.classList.remove('bg-blue-100', 'dark:bg-blue-900', 'text-blue-700', 'dark:text-blue-300');
+                    b.classList.add('text-gray-600', 'dark:text-gray-400', 'hover:bg-gray-100', 'dark:hover:bg-gray-700');
+                });
+                btn.classList.add('bg-blue-100', 'dark:bg-blue-900', 'text-blue-700', 'dark:text-blue-300');
+                btn.classList.remove('text-gray-600', 'dark:text-gray-400', 'hover:bg-gray-100', 'dark:hover:bg-gray-700');
+                this.loadSongs(document.getElementById('songsSearch').value);
+            });
         });
 
         // タブ切り替え
@@ -792,7 +808,7 @@ class TimestampNormalization {
 
     async loadSongs(search = '') {
         try {
-            const response = await songApiService.fetchSongs(search);
+            const response = await songApiService.fetchSongs(search, this.songReviewStatus);
 
             if (response.data) {
                 this.displaySongs(response.data, response.total);

--- a/resources/js/songs/services/SongApiService.js
+++ b/resources/js/songs/services/SongApiService.js
@@ -7,12 +7,15 @@ export class SongApiService {
     /**
      * 楽曲マスタ一覧を取得
      * @param {string} search - 検索クエリ
+     * @param {string|null} reviewStatus - review_statusフィルタ (safe/needs_review/null)
      * @returns {Promise<Object>} 楽曲一覧データ
      */
-    async fetchSongs(search = '') {
-        const response = await axios.get('/api/songs', {
-            params: { search }
-        });
+    async fetchSongs(search = '', reviewStatus = null) {
+        const params = { search };
+        if (reviewStatus) {
+            params.review_status = reviewStatus;
+        }
+        const response = await axios.get('/api/songs', { params });
         return response.data;
     }
 

--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -196,7 +196,7 @@
 
                         <!-- 楽曲マスタ一覧 -->
                         <div id="songsList" class="tab-content hidden">
-                            <div class="flex gap-2 mb-3">
+                            <div class="flex gap-2 mb-2">
                                 <input type="text" id="songsSearch" placeholder="楽曲名やアーティスト名で検索..." class="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
                                 <button id="clearSongsSearchBtn" class="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600">
                                     クリア
@@ -204,6 +204,11 @@
                                 <div id="songsCount" class="text-sm text-gray-600 dark:text-gray-400 flex items-center">
                                     <!-- JavaScriptで動的に更新 -->
                                 </div>
+                            </div>
+                            <div class="flex gap-1 mb-3">
+                                <button type="button" data-review-status="" class="song-review-filter px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300">全て</button>
+                                <button type="button" data-review-status="needs_review" class="song-review-filter px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700">要確認</button>
+                                <button type="button" data-review-status="safe" class="song-review-filter px-2 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700">安全</button>
                             </div>
                             <div id="songsResults" class="space-y-2 max-h-64 overflow-y-auto">
                                 <!-- 楽曲マスタリストがここに表示される -->

--- a/tests/Feature/SongControllerTest.php
+++ b/tests/Feature/SongControllerTest.php
@@ -412,6 +412,56 @@ class SongControllerTest extends TestCase
     }
 
     /**
+     * 楽曲マスタ一覧取得のテスト（review_statusフィルタ: needs_review）
+     */
+    public function test_fetch_songs_filter_by_needs_review(): void
+    {
+        Song::factory()->create(['title' => 'Safe Song', 'artist' => 'A', 'review_status' => 'safe']);
+        Song::factory()->create(['title' => 'Review Song', 'artist' => 'B', 'review_status' => 'needs_review']);
+        Song::factory()->create(['title' => 'No Status', 'artist' => 'C', 'review_status' => null]);
+
+        $response = $this->actingAs($this->user)->getJson(route('songs.fetchSongs', ['review_status' => 'needs_review']));
+
+        $response->assertOk();
+        $this->assertEquals(1, $response->json('total'));
+        $this->assertEquals('Review Song', $response->json('data.0.title'));
+    }
+
+    /**
+     * 楽曲マスタ一覧取得のテスト（review_statusフィルタ: safe）
+     */
+    public function test_fetch_songs_filter_by_safe(): void
+    {
+        Song::factory()->create(['title' => 'Safe Song', 'artist' => 'A', 'review_status' => 'safe']);
+        Song::factory()->create(['title' => 'Review Song', 'artist' => 'B', 'review_status' => 'needs_review']);
+
+        $response = $this->actingAs($this->user)->getJson(route('songs.fetchSongs', ['review_status' => 'safe']));
+
+        $response->assertOk();
+        $this->assertEquals(1, $response->json('total'));
+        $this->assertEquals('Safe Song', $response->json('data.0.title'));
+    }
+
+    /**
+     * 楽曲マスタ一覧取得のテスト（review_statusフィルタとsearch併用）
+     */
+    public function test_fetch_songs_filter_with_search(): void
+    {
+        Song::factory()->create(['title' => 'Good Song', 'artist' => 'A', 'review_status' => 'needs_review']);
+        Song::factory()->create(['title' => 'Bad Song', 'artist' => 'A', 'review_status' => 'needs_review']);
+        Song::factory()->create(['title' => 'Good Song', 'artist' => 'B', 'review_status' => 'safe']);
+
+        $response = $this->actingAs($this->user)->getJson(route('songs.fetchSongs', [
+            'review_status' => 'needs_review',
+            'search' => 'Good',
+        ]));
+
+        $response->assertOk();
+        $this->assertEquals(1, $response->json('total'));
+        $this->assertEquals('Good Song', $response->json('data.0.title'));
+    }
+
+    /**
      * 楽曲マスタ登録のテスト（新規作成）
      */
     public function test_store_song_creates_new(): void


### PR DESCRIPTION
## Summary

- 楽曲マスタタブに review_status フィルタボタン（全て / 要確認 / 安全）を追加
- `fetchSongs` APIに `review_status` パラメータ対応（バリデーション: safe/needs_review）
- Phase 2-1 のバッチ判定結果で楽曲を絞り込めるように
- Feature テスト3件追加（needs_review/safe/search併用）

## Test plan

- [ ] `php artisan test --filter=SongControllerTest` でテストがパスすること（#528）
- [ ] 正規化画面の楽曲マスタタブにフィルタボタンが表示されること
- [ ] 「要確認」ボタンで needs_review の楽曲のみ表示されること
- [ ] 「安全」ボタンで safe の楽曲のみ表示されること
- [ ] フィルタとテキスト検索が併用できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)