### PR TITLE
fix: 名寄せ機能のバグ修正（#515 Phase 2-3）

### DIFF
--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -658,6 +658,9 @@ class SongController extends Controller
         // この楽曲に紐づいているマッピングを削除（ログ記録含む）
         $this->songMappingService->deleteMappingsBySongId($id, $userId);
 
+        // 個別紐付け（ts_items.song_id）をクリア
+        TsItem::where('song_id', $id)->update(['song_id' => null]);
+
         // 操作ログを記録
         if ($userId) {
             NormalizationLog::log(

--- a/app/Services/SongMergeService.php
+++ b/app/Services/SongMergeService.php
@@ -131,7 +131,20 @@ class SongMergeService
         $targetSong = Song::findOrFail($targetSongId);
 
         return DB::transaction(function () use ($sourceSong, $targetSong, $userId) {
-            // マッピングを付け替え
+            // targetに既存のマッピングのnormalized_textを取得
+            $targetNormalizedTexts = TimestampSongMapping::where('song_id', $targetSong->id)
+                ->pluck('normalized_text')
+                ->toArray();
+
+            // sourceのマッピングのうち、targetと重複するものは削除（unique制約違反を回避）
+            $deletedDuplicates = 0;
+            if (! empty($targetNormalizedTexts)) {
+                $deletedDuplicates = TimestampSongMapping::where('song_id', $sourceSong->id)
+                    ->whereIn('normalized_text', $targetNormalizedTexts)
+                    ->delete();
+            }
+
+            // 残りのマッピングを付け替え
             $affectedMappings = TimestampSongMapping::where('song_id', $sourceSong->id)
                 ->update(['song_id' => $targetSong->id]);
 
@@ -152,6 +165,7 @@ class SongMergeService
                     'target_title' => $targetSong->title,
                     'target_artist' => $targetSong->artist,
                     'affected_mappings' => $affectedMappings,
+                    'deleted_duplicate_mappings' => $deletedDuplicates,
                     'affected_ts_items' => $affectedTsItems,
                 ]
             );

--- a/tests/Feature/SongMergeTest.php
+++ b/tests/Feature/SongMergeTest.php
@@ -194,4 +194,72 @@ class SongMergeTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonCount(0);
     }
+
+    public function test_merge_songs_handles_duplicate_mappings(): void
+    {
+        $targetSong = Song::factory()->create(['title' => 'Target Song', 'artist' => 'Artist']);
+        $sourceSong = Song::factory()->create(['title' => 'Source Song', 'artist' => 'Artist']);
+
+        // 同じnormalized_textのマッピングが両方に存在
+        TimestampSongMapping::factory()
+            ->withSong($targetSong)
+            ->withText('shared text')
+            ->create();
+        TimestampSongMapping::factory()
+            ->withSong($sourceSong)
+            ->withText('shared text duplicate')
+            ->create();
+
+        // sourceのみのマッピング → これはtargetに付け替えられるべき
+        TimestampSongMapping::factory()
+            ->withSong($sourceSong)
+            ->withText('source only text')
+            ->create();
+
+        // normalized_textを手動で重複させる
+        \DB::table('timestamp_song_mappings')
+            ->where('normalized_text', 'shared text duplicate')
+            ->update(['normalized_text' => 'shared text']);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/songs/merge', [
+                'source_song_id' => $sourceSong->id,
+                'target_song_id' => $targetSong->id,
+            ]);
+
+        $response->assertStatus(200);
+
+        // sourceSongが削除されていること
+        $this->assertDatabaseMissing('songs', ['id' => $sourceSong->id]);
+
+        // targetにマッピングが移行され、重複が解消されていること
+        $targetMappings = TimestampSongMapping::where('song_id', $targetSong->id)->get();
+        $this->assertEquals(2, $targetMappings->count());
+        $this->assertTrue($targetMappings->pluck('normalized_text')->contains('shared text'));
+        $this->assertTrue($targetMappings->pluck('normalized_text')->contains('source only text'));
+    }
+
+    public function test_delete_song_clears_ts_item_song_id(): void
+    {
+        $song = Song::factory()->create(['title' => 'Delete Me', 'artist' => 'Artist']);
+
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create(['channel_id' => $channel->channel_id]);
+        $tsItem = TsItem::factory()->create([
+            'video_id' => $archive->video_id,
+            'song_id' => $song->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->deleteJson("/api/songs/{$song->id}");
+
+        $response->assertStatus(200);
+
+        // songが削除されていること
+        $this->assertDatabaseMissing('songs', ['id' => $song->id]);
+
+        // ts_item.song_idがnullにクリアされていること
+        $tsItem->refresh();
+        $this->assertNull($tsItem->song_id);
+    }
 }


### PR DESCRIPTION
## Summary

- マージ時のunique制約違反を修正: targetに同じnormalized_textのマッピングが存在する場合、sourceの重複マッピングを先に削除してから付け替え
- 楽曲削除時のts_items.song_id孤立を修正: 個別紐付け（ts_items.song_id）をnullクリア
- テスト2件追加

## Test plan

- [ ] `php artisan test --filter=SongMergeTest` でテストがパスすること（#528）
- [ ] 名寄せ画面で、同じテキストのマッピングを持つ楽曲をマージしてもエラーにならないこと
- [ ] 楽曲削除後、個別紐付けされていたts_itemsのsong_idがnullになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)