### PR TITLE
fix: 正規表現パターン登録時のReDoS安全性検証を追加（#529）

### DIFF
--- a/app/Http/Controllers/ManageSettingsApiController.php
+++ b/app/Http/Controllers/ManageSettingsApiController.php
@@ -145,11 +145,21 @@ class ManageSettingsApiController extends Controller
 
         $isRegex = $validated['is_regex'] ?? false;
 
-        // 正規表現パターンの場合、コンパイルチェック
+        // 正規表現パターンの場合、コンパイルチェック + ReDoS安全性検証
         if ($isRegex) {
             $testResult = @preg_match($validated['pattern'], '');
             if ($testResult === false) {
                 return response()->json(['message' => '無効な正規表現パターンです'], 422);
+            }
+
+            // ReDoS対策: テスト文字列で実行時間を検証
+            $testString = str_repeat('aあ', 500);
+            $startTime = microtime(true);
+            @preg_replace($validated['pattern'], '', $testString);
+            $elapsed = microtime(true) - $startTime;
+
+            if ($elapsed > 1.0) {
+                return response()->json(['message' => '正規表現パターンの実行に時間がかかりすぎます。パターンを簡素化してください'], 422);
             }
         }
 


### PR DESCRIPTION
## Summary

- 正規表現パターン登録時に、テスト文字列（1000文字）で `preg_replace` を実行し、1秒を超える場合は登録を拒否
- 壊滅的バックトラッキング（ReDoS）を引き起こすパターンの登録を防止
- PHP の `pcre.backtrack_limit` による暗黙的な保護に加え、明示的な時間ベースの検証を追加

Closes #529

## Test plan

- [ ] 通常の正規表現パターン（例: `/【.*?】/u`）は問題なく登録できること
- [ ] 無効な正規表現はエラーメッセージが表示されること
- [ ] `php artisan test --filter=ManageStripPatternApiTest` でテストがパスすること（#528）

🤖 Generated with [Claude Code](https://claude.com/claude-code)