### PR TITLE
feat: ガチャシェアにハッシュタグ追加

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -1026,7 +1026,7 @@ function registerArchiveListComponent() {
                     const siteUrl = window.location.origin + '/channels/' + encodeURIComponent(data.channelHandle)
                         + '?play=' + encodeURIComponent(data.videoId) + '&t=' + (data.tsNum || 0);
                     const dateText = date ? data.channelTitle + 'が' + date + 'に歌った' : data.channelTitle + 'が歌った';
-                    const text = '🎵 ' + dateText + data.songTitle + '！\n\n歌枠履歴er:D で探す👇';
+                    const text = '🎵 ' + dateText + data.songTitle + '！\n\n#歌枠履歴er:D で探す👇';
                     return 'https://twitter.com/intent/tweet?text=' + encodeURIComponent(text) + '&url=' + encodeURIComponent(siteUrl);
                 },
                 getGachaShareText() {


### PR DESCRIPTION
## Summary
- ガチャ結果シェアのツイートテキストに `#歌枠履歴er:D` を追加

## Test plan
- [ ] ガチャ実行後のシェアポップアップで「シェア」ボタンを押し、ツイートテキストに `#歌枠履歴er` タグが含まれること

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)