### PR TITLE
fix: 波形データ保存のエラーハンドリングと容量管理

### DIFF
--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -2528,21 +2528,73 @@ function getVideoId() {
 }
 
 /**
+ * ストレージの容量を確認し、上限に近い場合は古いデータを削除
+ * @returns {Promise<void>}
+ */
+async function ensureStorageCapacity() {
+  const STORAGE_LIMIT = 10 * 1024 * 1024; // 10MB
+  const THRESHOLD = 0.8; // 80%で削除開始
+
+  return new Promise((resolve) => {
+    chrome.storage.local.getBytesInUse(null, (bytesInUse) => {
+      if (bytesInUse < STORAGE_LIMIT * THRESHOLD) {
+        resolve();
+        return;
+      }
+
+      console.warn(`ストレージ使用量が上限の${Math.round(bytesInUse / STORAGE_LIMIT * 100)}%に達しています。古いデータを削除します。`);
+
+      chrome.storage.local.get(null, (allData) => {
+        const volumeEntries = [];
+        for (const key in allData) {
+          if (key.startsWith('volumeData_') && allData[key]?.savedAt) {
+            volumeEntries.push({ key, savedAt: allData[key].savedAt });
+          }
+        }
+
+        // 古い順にソート
+        volumeEntries.sort((a, b) => a.savedAt - b.savedAt);
+
+        // 古いものから1/4を削除
+        const deleteCount = Math.max(1, Math.floor(volumeEntries.length / 4));
+        const keysToDelete = volumeEntries.slice(0, deleteCount).map(e => e.key);
+
+        if (keysToDelete.length > 0) {
+          chrome.storage.local.remove(keysToDelete, () => {
+            console.log(`ストレージ容量確保のため${keysToDelete.length}件の古い波形データを削除しました`);
+            resolve();
+          });
+        } else {
+          resolve();
+        }
+      });
+    });
+  });
+}
+
+/**
  * 音量データをストレージに保存
  */
-function saveVolumeData() {
+async function saveVolumeData() {
   const videoId = getVideoId();
   if (!videoId || volumeData.length === 0) return;
+
+  // 容量チェック・古いデータの自動削除
+  await ensureStorageCapacity();
 
   const storageKey = `volumeData_${videoId}`;
   const dataToSave = {
     data: volumeData,
     duration: videoDuration,
-    timestamps: detectedTimestamps, // タイムスタンプも保存
+    timestamps: detectedTimestamps,
     savedAt: Date.now()
   };
 
   chrome.storage.local.set({ [storageKey]: dataToSave }, () => {
+    if (chrome.runtime.lastError) {
+      console.error(`音量データの保存に失敗しました: ${chrome.runtime.lastError.message}`);
+      return;
+    }
     console.log(`音量データを保存しました: ${videoId} (${volumeData.length}サンプル, ${detectedTimestamps.length}候補)`);
   });
 }

--- a/browser-extension/popup.html
+++ b/browser-extension/popup.html
@@ -282,7 +282,7 @@
     </div>
 
     <!-- スキャン済み一覧 -->
-    <div class="section-title">スキャン済み一覧</div>
+    <div class="section-title">スキャン済み一覧 <span id="storage-usage" style="font-weight: normal; color: #999; font-size: 11px;"></span></div>
     <div id="scanned-list" class="scanned-list">
       <div class="empty-message">読み込み中...</div>
     </div>

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -295,6 +295,15 @@ async function getScannedVideosList() {
 async function loadScannedList() {
   const videos = await getScannedVideosList();
 
+  // ストレージ使用量を表示
+  chrome.storage.local.getBytesInUse(null, (bytes) => {
+    const usageEl = document.getElementById('storage-usage');
+    if (usageEl) {
+      const mb = (bytes / 1024 / 1024).toFixed(1);
+      usageEl.textContent = `(${mb} MB / 10 MB)`;
+    }
+  });
+
   if (videos.length === 0) {
     elements.scannedList.innerHTML = '<div class="empty-message">スキャン済みの動画はありません</div>';
     elements.clearAllBtn.style.display = 'none';


### PR DESCRIPTION
## Summary
- 波形データ保存時に `chrome.runtime.lastError` をチェックし、失敗時にログ出力
- ストレージ使用量が80%超の場合、古い波形データを自動削除してから保存
- ポップアップのスキャン済み一覧にストレージ使用量（MB）を表示

## Test plan
- [ ] 波形データの保存が正常に動作すること
- [ ] ポップアップのスキャン済み一覧にストレージ使用量が表示されること

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)