### PR TITLE
feat: 波形サンプリングを等間隔（2秒）に変更

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -15,7 +15,9 @@ let currentTabId = null;
 let volumeGraphData = [];
 let videoDuration = 0;
 let isScanning = false;
-const GRAPH_RESOLUTION = 500; // グラフのデータポイント数
+const SAMPLING_INTERVAL_SEC = 2; // サンプリング間隔（秒）
+const LEGACY_GRAPH_RESOLUTION = 500; // 旧形式との互換用
+let currentGraphResolution = LEGACY_GRAPH_RESOLUTION;
 let lastVolumeUpdateTime = 0; // 最後にUI更新した時刻
 
 // デフォルト設定
@@ -111,7 +113,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     case 'VOLUME_DATA_FROM_OFFSCREEN':
       // Offscreen Documentからの音量データ
       console.log('音量データ受信(raw)', { index: message.index, volume: message.volume });
-      if (message.index >= 0 && message.index < GRAPH_RESOLUTION) {
+      if (message.index >= 0 && message.index < currentGraphResolution) {
         const oldValue = volumeGraphData[message.index] || 0;
         if (message.volume > oldValue) {
           volumeGraphData[message.index] = message.volume;
@@ -232,7 +234,7 @@ async function startCapture(tabId) {
       type: 'START_AUDIO_PROCESSING',
       streamId: streamId,
       config: CONFIG,
-      graphResolution: GRAPH_RESOLUTION
+      graphResolution: currentGraphResolution
     });
 
     console.log('START_AUDIO_PROCESSING応答:', response);
@@ -302,11 +304,11 @@ async function sendVolumeDataToContent() {
     if (tab?.id) {
       // スパース配列を埋める
       const filledData = [];
-      for (let i = 0; i < GRAPH_RESOLUTION; i++) {
+      for (let i = 0; i < currentGraphResolution; i++) {
         filledData[i] = volumeGraphData[i] || 0;
       }
 
-      const progress = (filledData.filter(v => v > 0).length / GRAPH_RESOLUTION) * 100;
+      const progress = (filledData.filter(v => v > 0).length / currentGraphResolution) * 100;
 
       // デバッグ: 送信データを確認（毎回出力）
       console.log('音量データ送信', {
@@ -361,6 +363,9 @@ async function startScan() {
       return { success: false, error: 'NO_VIDEO_DURATION' };
     }
 
+    // 動画の長さに応じてグラフ解像度を計算
+    currentGraphResolution = Math.ceil(videoDuration / SAMPLING_INTERVAL_SEC);
+
     // キャプチャを開始（既存のキャプチャは停止してから再開始）
     if (isCapturing) {
       await stopCapture();
@@ -381,7 +386,7 @@ async function startScan() {
     if (scanStatus.hasData && scanStatus.data) {
       volumeGraphData = [...scanStatus.data];
       // 配列の長さが足りなければ埋める
-      while (volumeGraphData.length < GRAPH_RESOLUTION) {
+      while (volumeGraphData.length < currentGraphResolution) {
         volumeGraphData.push(0);
       }
       // デバッグ: データの状態を確認
@@ -395,16 +400,16 @@ async function startScan() {
         last10: volumeGraphData.slice(-10)
       });
     } else {
-      volumeGraphData = new Array(GRAPH_RESOLUTION).fill(0);
+      volumeGraphData = new Array(currentGraphResolution).fill(0);
       console.log('新規スキャン開始');
     }
 
     // Offscreen Documentにスキャン開始を通知
-    console.log('START_VOLUME_SCAN送信中...', { duration: videoDuration, graphResolution: GRAPH_RESOLUTION });
+    console.log('START_VOLUME_SCAN送信中...', { duration: videoDuration, graphResolution: currentGraphResolution });
     chrome.runtime.sendMessage({
       type: 'START_VOLUME_SCAN',
       duration: videoDuration,
-      graphResolution: GRAPH_RESOLUTION
+      graphResolution: currentGraphResolution
     }).then(res => {
       console.log('START_VOLUME_SCAN応答:', res);
     }).catch(err => {

--- a/browser-extension/content-ycs.js
+++ b/browser-extension/content-ycs.js
@@ -4,7 +4,7 @@
  * ycs管理画面でスキャン済みアーカイブを表示するための機能を提供
  */
 
-const GRAPH_RESOLUTION = 500;
+// 旧形式互換: 解像度はデータの長さから取得
 
 /**
  * スキャン済みvideoIdリストを取得してページに通知
@@ -24,7 +24,7 @@ async function notifyScannedVideoIds() {
         }
 
         const filledCount = data.data.filter(v => v > 0).length;
-        const progress = Math.round((filledCount / GRAPH_RESOLUTION) * 100);
+        const progress = Math.round((filledCount / data.data.length) * 100);
 
         scannedIds.push({
           videoId,

--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -41,7 +41,18 @@ let gainNode = null; // 音量制御用
 let mediaElementSource = null;
 let isScanning = false;
 let scanInterval = null;
-const GRAPH_RESOLUTION = 500; // グラフのデータポイント数
+const SAMPLING_INTERVAL_SEC = 2; // サンプリング間隔（秒）
+const LEGACY_GRAPH_RESOLUTION = 500; // 旧形式との互換用
+
+/**
+ * 動画の長さに応じたグラフ解像度を計算
+ * @param {number} duration - 動画の長さ（秒）
+ * @returns {number} データポイント数
+ */
+function calcGraphResolution(duration) {
+  if (!duration || duration <= 0) return LEGACY_GRAPH_RESOLUTION;
+  return Math.ceil(duration / SAMPLING_INTERVAL_SEC);
+}
 let originalPlaybackRate = 1;
 let audioInitialized = false; // 音声解析が初期化済みか
 
@@ -768,7 +779,7 @@ async function getVideoScanStatus(videoId) {
 
   const data = result[key].data;
   const filledCount = data.filter(v => v > 0).length;
-  const progress = Math.round((filledCount / GRAPH_RESOLUTION) * 100);
+  const progress = Math.round((filledCount / data.length) * 100);
 
   if (progress >= 95) {
     return { status: 'completed', progress: 100 };
@@ -907,7 +918,7 @@ async function loadScannedVideosList() {
         if (!data || !data.data) continue;
 
         const filledCount = data.data.filter(v => v > 0).length;
-        const progress = Math.round((filledCount / GRAPH_RESOLUTION) * 100);
+        const progress = Math.round((filledCount / data.data.length) * 100);
 
         videos.push({
           videoId,
@@ -2584,6 +2595,8 @@ async function saveVolumeData() {
 
   const storageKey = `volumeData_${videoId}`;
   const dataToSave = {
+    version: 2, // v2: 等間隔サンプリング（v1/未指定: 固定500ポイント）
+    samplingInterval: SAMPLING_INTERVAL_SEC,
     data: volumeData,
     duration: videoDuration,
     timestamps: detectedTimestamps,
@@ -2894,7 +2907,7 @@ function getScanStatus() {
 
       const data = saved.data;
       const duration = saved.duration || 0;
-      const GRAPH_RESOLUTION = 500;
+      const resolution = data.length;
 
       // 進捗を計算（データがある部分の割合）
       let lastFilledIndex = -1;
@@ -2906,7 +2919,7 @@ function getScanStatus() {
       }
 
       const progress = lastFilledIndex >= 0
-        ? ((lastFilledIndex + 1) / GRAPH_RESOLUTION) * 100
+        ? ((lastFilledIndex + 1) / resolution) * 100
         : 0;
 
       // 95%以上なら完了とみなす
@@ -2914,7 +2927,7 @@ function getScanStatus() {
 
       // 再開時刻を計算
       const resumeTime = duration > 0 && lastFilledIndex >= 0
-        ? (lastFilledIndex / GRAPH_RESOLUTION) * duration
+        ? (lastFilledIndex / resolution) * duration
         : 0;
 
       resolve({
@@ -3058,7 +3071,9 @@ function handleStorageChange(changes, areaName) {
       // 進捗表示を更新
       const progress = volumeGraphContainer?.querySelector('#vdg-progress');
       if (progress && videoDuration > 0) {
-        const coverage = (volumeData.length / GRAPH_RESOLUTION) * 100;
+        const coverage = volumeData.length > 0
+          ? (volumeData.filter(v => v > 0).length / volumeData.length) * 100
+          : 0;
         progress.textContent = `${Math.round(coverage)}%`;
       }
     }
@@ -4108,7 +4123,8 @@ async function startDirectScan() {
   }
 
   isScanning = true;
-  volumeData = new Array(GRAPH_RESOLUTION).fill(0);
+  const resolution = calcGraphResolution(videoDuration);
+  volumeData = new Array(resolution).fill(0);
 
   // 現在の状態を保存
   originalPlaybackRate = videoElement.playbackRate;
@@ -4153,16 +4169,17 @@ async function startDirectScan() {
     const normalizedVolume = Math.min(1, rms * 5);
 
     // データポイントのインデックスを計算
-    const index = Math.floor((videoElement.currentTime / videoDuration) * GRAPH_RESOLUTION);
+    const currentResolution = volumeData.length;
+    const index = Math.floor((videoElement.currentTime / videoDuration) * currentResolution);
 
-    if (index >= 0 && index < GRAPH_RESOLUTION) {
+    if (index >= 0 && index < currentResolution) {
       if (normalizedVolume > volumeData[index]) {
         volumeData[index] = normalizedVolume;
       }
     }
 
     // 進捗を更新
-    const progress = (volumeData.filter(v => v > 0).length / GRAPH_RESOLUTION) * 100;
+    const progress = (volumeData.filter(v => v > 0).length / currentResolution) * 100;
     updateProgress(progress);
     drawVolumeGraph();
 


### PR DESCRIPTION
## Summary
- 固定500ポイントから動画の長さに応じた等間隔サンプリング（2秒間隔）に変更
- 30分の動画: 900ポイント、2時間: 3600ポイント（従来はすべて500ポイント）
- 保存データにversion/samplingIntervalフィールドを追加し、旧データとの互換性を維持
- content.js, background.js, content-ycs.jsの全GRAPH_RESOLUTION参照を更新

## Test plan
- [ ] 新規スキャンで波形データが正しく記録されること
- [ ] グラフ描画が正常に動作すること
- [ ] 旧形式（500ポイント固定）のスキャン済みデータが正常に表示されること
- [ ] ポップアップのスキャン済み一覧の進捗表示が正しいこと
- [ ] ycs管理画面連携の進捗表示が正しいこと

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)