### PR TITLE
fix: マーカー全削除時に確認ダイアログを追加

### DIFF
--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -4101,6 +4101,8 @@ function setupVolumeGraphEvents() {
   if (tsClearBtn) {
     tsClearBtn.addEventListener('click', (e) => {
       e.stopPropagation();
+      if (tsMarkers.length === 0) return;
+      if (!confirm(`${tsMarkers.length}件のマーカーをすべて削除しますか？`)) return;
       tsMarkers = [];
       selectedMarkerId = null;
       updateTimestampList();


### PR DESCRIPTION
## Summary
- クリアボタン押下時に `confirm()` で確認を挟むよう変更
- マーカーが0件の場合は何もしない

## Test plan
- [ ] クリアボタン押下で確認ダイアログが表示されること
- [ ] キャンセル時にマーカーが削除されないこと
- [ ] OK時にすべてのマーカーが削除されること
- [ ] マーカーが0件の場合はダイアログが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)