### PR TITLE
fix: SPA遷移時にタイムスタンプエディタの状態をリセットする

### DIFF
--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -45,7 +45,7 @@ let selectedMarkerId = null;
 let nextMarkerId = 1;
 const MARKER_SNAP_THRESHOLD_SEC = 3; // マーカー選択の判定距離（秒）
 const MARKER_SNAP_THRESHOLD_PX = 8; // マーカー選択の判定距離（ピクセル）。長時間動画では秒基準が1px未満になるため併用
-let seekedListenerTarget = null; // seekedリスナー登録済みのvideo要素（重複登録防止）
+let videoListenerTarget = null; // イベント登録済みのvideo要素（SPA遷移での重複登録防止）
 
 // タイムスタンプエディタ: Undo/Redo履歴（変更前スナップショットのスタック）
 let tsHistoryUndo = [];
@@ -4302,16 +4302,19 @@ function startTimeSync() {
     clearInterval(timeUpdateInterval);
   }
 
-  // 動画のメタデータ読み込み時に長さを取得
-  videoElement.addEventListener('loadedmetadata', () => {
-    updateVideoDuration();
-  });
+  // video要素へのイベント登録
+  // YouTubeのSPA遷移では同じvideo要素が使い回されるため、startTimeSyncが
+  // 再実行されても同一要素へ重複登録しないようにする（リスナーの積み上がり防止）
+  if (videoListenerTarget !== videoElement) {
+    videoListenerTarget = videoElement;
 
-  // 停止中のシークでも赤い再生位置ラインを追従させる
-  // （通常の更新は再生中のみのインターバル処理のため、シーク完了時にも更新する）
-  // SPA遷移でstartTimeSyncが再実行されても同一要素へ重複登録しない
-  if (seekedListenerTarget !== videoElement) {
-    seekedListenerTarget = videoElement;
+    // 動画のメタデータ読み込み時に長さを取得
+    videoElement.addEventListener('loadedmetadata', () => {
+      updateVideoDuration();
+    });
+
+    // 停止中のシークでも赤い再生位置ラインを追従させる
+    // （通常の更新は再生中のみのインターバル処理のため、シーク完了時にも更新する）
     videoElement.addEventListener('seeked', () => {
       if (isGraphVisible) {
         updateTimeMarker();
@@ -6347,6 +6350,9 @@ function loadMarkersFromStorage() {
   if (!videoId) return;
   const key = `tsMarkers_${videoId}`;
   chrome.storage.local.get(key, (result) => {
+    // 読み込み中に別の動画へ遷移していた場合は破棄する（別動画のマーカーを適用しない）
+    if (getVideoId() !== videoId) return;
+
     const saved = result[key];
     if (saved && saved.markers) {
       tsMarkers = saved.markers;
@@ -6361,6 +6367,28 @@ function loadMarkersFromStorage() {
       drawVolumeGraph();
     }
   });
+}
+
+/**
+ * 動画切替時にタイムスタンプエディタの状態を初期化し、新しい動画の保存データを読み込む
+ *
+ * YouTubeのSPA遷移では content script が再読み込みされないため、これを呼ばないと
+ * 前の動画のマーカーが残ったままになり、編集すると saveMarkersToStorage() が
+ * 「新しい動画のキー」に「前の動画のマーカー」を保存してデータが混ざる
+ */
+function resetTimestampEditorForVideoChange() {
+  closeLyricsPastePopup();
+  tsMarkers = [];
+  selectedMarkerId = null;
+  nextMarkerId = 1;
+  tsHistoryUndo = [];
+  tsHistoryRedo = [];
+  lastHistoryTag = null;
+  updateUndoRedoButtons();
+  updateTimestampList();
+  drawVolumeGraph();
+  // 新しい動画に保存済みマーカーがあれば読み込む（なければ空のまま）
+  loadMarkersFromStorage();
 }
 
 /**
@@ -6457,6 +6485,8 @@ function observePageChanges() {
 
       initWatchPageUI();
       loadVolumeData();
+      // 前のwatchページのマーカーが残らないようリセットして読み込み直す
+      resetTimestampEditorForVideoChange();
     } else if (nowWatchPage && currentVideoId !== lastVideoId) {
       // watchページ → 別の動画のwatchページへの遷移
       lastVideoId = currentVideoId;
@@ -6489,6 +6519,8 @@ function observePageChanges() {
 
       // 保存済みデータを読み込み
       loadVolumeData();
+      // 前の動画のマーカー・Undo履歴が残らないようリセットして読み込み直す
+      resetTimestampEditorForVideoChange();
 
       // 自動スキャンモードの場合は継続
       if (isAutoScanMode && !autoScanStopRequested) {


### PR DESCRIPTION
## 概要

Issue #575 のうち、SPA遷移に関する2件（データ混在のおそれがある不具合とリスナーリーク）に対応します。

## 修正内容

### 1. SPA遷移でマーカーが前の動画から引き継がれる問題（データ混在）

- 原因: `loadMarkersFromStorage()` の呼び出しが `setupVolumeGraphEvents()` 内の1箇所のみで、`createVolumeGraph()` のシングルトンガードによりページ読み込み時に1回だけ実行される。YouTubeのSPA内部遷移（関連動画クリック・再生リスト自動送り・自動スキャンなど）を処理する `handleNavigation()` では `tsMarkers` に一切触れていなかった
- 影響: 動画Bに移動しても動画Aのマーカーが残り、その状態で編集すると `saveMarkersToStorage()` が **動画Bのキー（`tsMarkers_${videoId}`）に動画A由来のマーカーを保存**してしまう
- 対応: `resetTimestampEditorForVideoChange()` を新設し、`handleNavigation()` の「非watch→watch」「watch→別動画」の両分岐で呼び出す。マーカー・選択状態・ID採番・Undo/Redo履歴・ペースト変換ポップアップをクリアしたうえで、新しい動画の保存済みマーカーを読み込み直す
- あわせて `loadMarkersFromStorage()` の非同期コールバックで動画IDを再確認し、読み込み中にさらに遷移していた場合は結果を破棄するようにした（別動画のマーカーが適用されるのを防ぐ）

### 2. `loadedmetadata` リスナーの重複登録（リーク）

- 原因: SPA遷移では同じ `<video>` 要素が使い回されるため、遷移ごとに `startTimeSync()` がリスナーを追加していた
- 対応: 既に `seeked` で使っていた方式を一般化し、`videoListenerTarget` で登録済みのvideo要素を記憶して `loadedmetadata` / `seeked` を1回だけ登録する

## 動作確認

- `node --check` による構文チェックのみ実施
- 実機での確認（関連動画クリックでの動画切替後にマーカー一覧が新しい動画の内容になること、前の動画のマーカーが残らないこと、Undo履歴が引き継がれないこと）をお願いします

Refs #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)