### PR TITLE
feat: 曲名入力の状態遷移を整える（Enter/Escで入力終了、↑↓でカーソル移動）

### DIFF
--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -4801,7 +4801,7 @@ function createVolumeGraph() {
       </div>
       <div class="vdg-ts-footer">
         <div class="vdg-ts-help">
-          クリック: マーカー追加(付近は選択/ドラッグで移動) | Enter: 曲名入力/入力終了 | Del: 削除 | Esc: 入力終了・選択解除 | ←→: 1秒移動(2度押し5秒) | ↑↓: マーカー移動 | Space: 再生/停止 | J/L: 再生を10秒戻す/進める | Ctrl+Z/Y: 操作を戻す/やり直す | Ctrl+ホイール: 拡大/縮小
+          クリック: マーカー追加(付近は選択/ドラッグで移動) | Enter: 曲名入力/入力終了 | Del: 削除 | Esc: 入力終了・選択解除 | ←→: 1秒移動(2度押し5秒) | ↑↓: マーカー移動(入力中は行頭/行末へ) | Space: 再生/停止 | J/L: 再生を10秒戻す/進める | Ctrl+Z/Y: 操作を戻す/やり直す | Ctrl+ホイール: 拡大/縮小
         </div>
         <label class="vdg-ts-format-toggle">
           <input type="checkbox" id="vdg-ts-zeropad">
@@ -5331,6 +5331,18 @@ function setupVolumeGraphEvents() {
       return;
     }
 
+    // 曲名入力中の↑↓はカーソルを文字列の先頭/末尾へ移動する
+    // （入力状態を抜けるのはEnter/Escの役割。IME変換中は上のガードで候補選択が優先される）
+    if (isTextInput && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      // ポップアップが開いていれば閉じる（キー操作では挿入しないのがポップアップ側の挙動と同じ）
+      closeLyricsPastePopup();
+      const pos = e.key === 'ArrowUp' ? 0 : e.target.value.length;
+      e.target.setSelectionRange(pos, pos);
+      return;
+    }
+
     // マーカー未選択なら何もしない
     if (selectedMarkerId === null) return;
 
@@ -5343,10 +5355,7 @@ function setupVolumeGraphEvents() {
     } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
       e.preventDefault();
       e.stopImmediatePropagation();
-      // 曲名入力中の場合は入力状態を抜けてから移動する
-      // （一覧の再構築による暗黙のフォーカス喪失に頼らず明示的に外す）
-      blurMarkerTextInput();
-      // 上下キーで前後のマーカーに移動
+      // 上下キーで前後のマーカーに移動（入力中は上の分岐でカーソル移動として扱われる）
       const currentIndex = tsMarkers.findIndex(m => m.id === selectedMarkerId);
       if (currentIndex < 0) return;
       const nextIndex = e.key === 'ArrowUp'

--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -5291,6 +5291,9 @@ function setupVolumeGraphEvents() {
     const isTextInput = e.target.classList.contains('vdg-ts-text-input');
     // テキスト入力中は基本的にスキップ（入力を妨げない）
     if (isTextInput && !['Delete', 'ArrowUp', 'ArrowDown', 'Enter', 'Escape'].includes(e.key)) return;
+    // IME変換中は確定(Enter)・取消(Esc)・候補選択(↑↓)をIME側の処理に委ねる
+    // （奪うと変換中の文字が失われる。keyCode 229は変換開始時のフォールバック判定）
+    if (isTextInput && (e.isComposing || e.keyCode === 229)) return;
     // 検索ボックスやコメント欄など、エディタ以外の編集可能要素への入力は妨げない
     if (!isTextInput && isEditableTarget(e.target)) return;
     // 設定メニューやボタン等、YouTube本体のUI部品にフォーカスがある間は本体の操作を優先
@@ -5319,9 +5322,12 @@ function setupVolumeGraphEvents() {
     // （入力内容は1文字ごとに保存済みなので、確定/取消の区別はせず単に抜ける。
     //   編集前に戻したい場合はCtrl+Zを使う）
     if (isTextInput && (e.key === 'Enter' || e.key === 'Escape')) {
+      // ペースト変換ポップアップが開いている間は、ポップアップ側のキー処理を優先する
+      // （Esc=元テキストのまま挿入。閉じてから改めて押せば入力状態を抜けられる）
+      if (lyricsPastePopup) return;
       e.preventDefault();
       e.stopImmediatePropagation();
-      e.target.blur();
+      blurMarkerTextInput();
       return;
     }
 
@@ -6061,6 +6067,9 @@ function updateUndoRedoButtons() {
  * （mousedownのpreventDefaultで自動のフォーカス移動が起きないケース用）
  */
 function blurMarkerTextInput() {
+  // キーボード操作で入力を抜ける場合はポップアップのmousedown経由の後始末が働かないため、
+  // ここで明示的に閉じる（開いたまま残るとリスナーが生き続け、後続のクリックで誤挿入される）
+  closeLyricsPastePopup();
   const active = document.activeElement;
   if (active instanceof HTMLElement && active.classList.contains('vdg-ts-text-input')) {
     active.blur();

--- a/browser-extension/content.js
+++ b/browser-extension/content.js
@@ -4801,7 +4801,7 @@ function createVolumeGraph() {
       </div>
       <div class="vdg-ts-footer">
         <div class="vdg-ts-help">
-          クリック: マーカー追加(付近は選択/ドラッグで移動) | Enter: 曲名入力 | Del: 削除 | Esc: 選択解除 | ←→: 1秒移動(2度押し5秒) | ↑↓: マーカー移動 | Space: 再生/停止 | J/L: 再生を10秒戻す/進める | Ctrl+Z/Y: 操作を戻す/やり直す | Ctrl+ホイール: 拡大/縮小
+          クリック: マーカー追加(付近は選択/ドラッグで移動) | Enter: 曲名入力/入力終了 | Del: 削除 | Esc: 入力終了・選択解除 | ←→: 1秒移動(2度押し5秒) | ↑↓: マーカー移動 | Space: 再生/停止 | J/L: 再生を10秒戻す/進める | Ctrl+Z/Y: 操作を戻す/やり直す | Ctrl+ホイール: 拡大/縮小
         </div>
         <label class="vdg-ts-format-toggle">
           <input type="checkbox" id="vdg-ts-zeropad">
@@ -5290,7 +5290,7 @@ function setupVolumeGraphEvents() {
   document.addEventListener('keydown', (e) => {
     const isTextInput = e.target.classList.contains('vdg-ts-text-input');
     // テキスト入力中は基本的にスキップ（入力を妨げない）
-    if (isTextInput && !['Delete', 'ArrowUp', 'ArrowDown'].includes(e.key)) return;
+    if (isTextInput && !['Delete', 'ArrowUp', 'ArrowDown', 'Enter', 'Escape'].includes(e.key)) return;
     // 検索ボックスやコメント欄など、エディタ以外の編集可能要素への入力は妨げない
     if (!isTextInput && isEditableTarget(e.target)) return;
     // 設定メニューやボタン等、YouTube本体のUI部品にフォーカスがある間は本体の操作を優先
@@ -5315,6 +5315,16 @@ function setupVolumeGraphEvents() {
       return;
     }
 
+    // 曲名入力中のEnter/Escは入力状態を終了して選択状態に戻す
+    // （入力内容は1文字ごとに保存済みなので、確定/取消の区別はせず単に抜ける。
+    //   編集前に戻したい場合はCtrl+Zを使う）
+    if (isTextInput && (e.key === 'Enter' || e.key === 'Escape')) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      e.target.blur();
+      return;
+    }
+
     // マーカー未選択なら何もしない
     if (selectedMarkerId === null) return;
 
@@ -5327,6 +5337,9 @@ function setupVolumeGraphEvents() {
     } else if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
       e.preventDefault();
       e.stopImmediatePropagation();
+      // 曲名入力中の場合は入力状態を抜けてから移動する
+      // （一覧の再構築による暗黙のフォーカス喪失に頼らず明示的に外す）
+      blurMarkerTextInput();
       // 上下キーで前後のマーカーに移動
       const currentIndex = tsMarkers.findIndex(m => m.id === selectedMarkerId);
       if (currentIndex < 0) return;


### PR DESCRIPTION
## 概要

Issue #575 の残り1件（曲名入力中の↑↓でフォーカスが失われる問題）に対応し、あわせて曲名入力の状態遷移を整理します。

## 修正内容

### 1. 入力中のEnter/Escで入力状態を終了
- 曲名入力中にEnterまたはEscを押すと入力欄を `blur()` し、マーカーの選択状態に戻る
- Escは二段階の挙動: **入力中** = 入力終了、**選択中** = 選択解除（従来どおり）
- 入力内容は `input` イベントで1文字ごとに保存されるため確定/取消の区別はしない（編集前に戻す場合は Ctrl+Z）

### 2. 入力中の↑↓はカーソルを行頭/行末へ移動
- 入力状態を抜ける手段がEnter/Escで揃ったため、入力中の↑↓は「前後のマーカーへ移動（＝入力から抜ける）」ではなく、単一行入力欄の標準的な挙動である**カーソルの先頭/末尾への移動**に変更
- 非入力状態の↑↓は従来どおりマーカー移動
- これにより、Issue #575 の「入力中の↑↓で一覧が再構築されフォーカスが失われる」問題も解消

### 3. IME（日本語入力）対応
- `e.isComposing` / `keyCode === 229` を判定し、変換中のEnter（確定）・Esc（取消）・↑↓（候補選択）を奪わずIME側の処理に委ねる
- 奪うと変換中の文字が失われるため必須の対応（既存の↑↓の扱いにも潜在していた問題）

### 4. ペースト変換ポップアップとの整合
- 入力中のEnter/Escはポップアップが開いている間はポップアップ側のキー処理を優先（閉じてから改めて押せば入力を抜けられる二段階）
- `blurMarkerTextInput()` でポップアップを閉じる。キーボード起点で入力を抜ける経路では `mousedown` 経由の後始末が働かず、リスナーが残って後続のクリックで誤挿入される問題があった

### 5. ヘルプ表記の更新
- 「Enter: 曲名入力/入力終了」「Esc: 入力終了・選択解除」「↑↓: マーカー移動(入力中は行頭/行末へ)」

## 動作確認

- `node --check` による構文チェックのみ実施
- 実機での確認をお願いします:
  - 日本語入力の変換中にEnterで確定・Escで変換取消・↑↓で候補選択ができること
  - 変換確定後のEnterで入力を抜けられ、選択状態が維持されること
  - 入力中の↑↓でカーソルが行頭/行末へ移動すること
  - Escの二段階動作（入力終了→選択解除）

Refs #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)