### PR TITLE
feat: APIトークンを複数発行できるようにする (#579)

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
+use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 
 class ProfileController extends Controller
@@ -20,6 +21,7 @@ class ProfileController extends Controller
     {
         return view('profile.edit', [
             'user' => $request->user(),
+            'maxApiTokens' => self::MAX_API_TOKENS,
         ]);
     }
 
@@ -42,6 +44,11 @@ class ProfileController extends Controller
     }
 
     /**
+     * 1ユーザーあたりのAPIトークン発行上限
+     */
+    public const MAX_API_TOKENS = 5;
+
+    /**
      * APIトークンを発行
      */
     public function createApiToken(Request $request): RedirectResponse
@@ -50,8 +57,12 @@ class ProfileController extends Controller
             'token_name' => ['required', 'string', 'max:255'],
         ]);
 
-        // 既存トークンを全削除（1ユーザー1トークン）
-        $request->user()->tokens()->delete();
+        // 上限に達している場合は既存トークンに影響を与えずに拒否する
+        if ($request->user()->tokens()->count() >= self::MAX_API_TOKENS) {
+            throw ValidationException::withMessages([
+                'token_name' => 'APIトークンは最大'.self::MAX_API_TOKENS.'個までです。不要なトークンを失効してから発行してください。',
+            ]);
+        }
 
         $token = $request->user()->createToken($request->input('token_name'));
 
@@ -59,11 +70,18 @@ class ProfileController extends Controller
     }
 
     /**
-     * APIトークンを失効
+     * APIトークンを個別に失効
      */
-    public function destroyApiToken(Request $request): RedirectResponse
+    public function destroyApiToken(Request $request, string $token): RedirectResponse
     {
-        $request->user()->tokens()->delete();
+        // 他ユーザーのトークンを失効できないよう、必ず自分のトークンから検索する
+        $target = $request->user()->tokens()->whereKey($token)->first();
+
+        if ($target === null) {
+            abort(404);
+        }
+
+        $target->delete();
 
         return Redirect::route('profile.edit')->with('status', 'api-token-deleted');
     }

--- a/resources/views/profile/partials/api-token-form.blade.php
+++ b/resources/views/profile/partials/api-token-form.blade.php
@@ -33,30 +33,36 @@
     @endif
 
     @php
-        $currentToken = auth()->user()->tokens()->latest()->first();
+        $tokens = auth()->user()->tokens()->latest()->get();
     @endphp
 
-    @if ($currentToken)
-        {{-- 既存トークンの情報表示 --}}
-        <div class="mt-4 p-4 bg-gray-50 dark:bg-gray-700/50 rounded-md">
-            <div class="flex items-center justify-between">
-                <div>
-                    <p class="text-sm font-medium text-gray-900 dark:text-gray-100">{{ $currentToken->name }}</p>
-                    <p class="text-xs text-gray-500 dark:text-gray-400">
-                        発行日: {{ $currentToken->created_at->format('Y-m-d H:i') }}
-                        @if ($currentToken->last_used_at)
-                            / 最終使用: {{ $currentToken->last_used_at->format('Y-m-d H:i') }}
-                        @endif
-                    </p>
+    @if ($tokens->isNotEmpty())
+        {{-- 発行済みトークンの一覧 --}}
+        <div class="mt-4 space-y-2">
+            @foreach ($tokens as $token)
+                <div class="p-4 bg-gray-50 dark:bg-gray-700/50 rounded-md">
+                    <div class="flex items-center justify-between gap-4">
+                        <div class="min-w-0">
+                            <p class="text-sm font-medium text-gray-900 dark:text-gray-100 break-all">{{ $token->name }}</p>
+                            <p class="text-xs text-gray-500 dark:text-gray-400">
+                                発行日: {{ $token->created_at->format('Y-m-d H:i') }}
+                                @if ($token->last_used_at)
+                                    / 最終使用: {{ $token->last_used_at->format('Y-m-d H:i') }}
+                                @else
+                                    / 最終使用: -
+                                @endif
+                            </p>
+                        </div>
+                        <form method="post" action="{{ route('profile.api-token.destroy', $token) }}" onsubmit="return confirm('このトークンを失効しますか？')">
+                            @csrf
+                            @method('delete')
+                            <x-danger-button type="submit">
+                                失効
+                            </x-danger-button>
+                        </form>
+                    </div>
                 </div>
-                <form method="post" action="{{ route('profile.api-token.destroy') }}" onsubmit="return confirm('このトークンを失効しますか？')">
-                    @csrf
-                    @method('delete')
-                    <x-danger-button type="submit">
-                        失効
-                    </x-danger-button>
-                </form>
-            </div>
+            @endforeach
         </div>
     @endif
 
@@ -70,13 +76,11 @@
                 <x-input-error :messages="$errors->get('token_name')" class="mt-2" />
             </div>
             <x-primary-button>
-                {{ $currentToken ? '再発行' : '発行' }}
+                発行
             </x-primary-button>
         </div>
-        @if ($currentToken)
-            <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
-                再発行すると現在のトークンは失効します。
-            </p>
-        @endif
+        <p class="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            トークンは最大{{ $maxApiTokens }}個まで発行できます（現在 {{ $tokens->count() }} / {{ $maxApiTokens }}）。
+        </p>
     </form>
 </section>

--- a/routes/web.php
+++ b/routes/web.php
@@ -159,7 +159,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::post('/profile/api-token', [ProfileController::class, 'createApiToken'])->name('profile.api-token.create');
-    Route::delete('/profile/api-token', [ProfileController::class, 'destroyApiToken'])->name('profile.api-token.destroy');
+    Route::delete('/profile/api-token/{token}', [ProfileController::class, 'destroyApiToken'])->name('profile.api-token.destroy');
     Route::delete('/profile/api-key', [ProfileController::class, 'destroyApiKey'])->name('profile.api-key.destroy');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Http\Controllers\ProfileController;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -58,6 +59,90 @@ class ProfileTest extends TestCase
             ->assertRedirect('/profile');
 
         $this->assertNull($user->refresh()->api_key);
+    }
+
+    public function test_api_token_can_be_created(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->post('/profile/api-token', ['token_name' => 'Chrome拡張']);
+
+        $response
+            ->assertSessionHasNoErrors()
+            ->assertRedirect('/profile')
+            ->assertSessionHas('new_api_token');
+
+        $this->assertSame(1, $user->tokens()->count());
+    }
+
+    public function test_creating_api_token_does_not_revoke_existing_tokens(): void
+    {
+        $user = User::factory()->create();
+        $first = $user->createToken('1つ目')->accessToken;
+
+        $this
+            ->actingAs($user)
+            ->post('/profile/api-token', ['token_name' => '2つ目'])
+            ->assertSessionHasNoErrors();
+
+        $this->assertSame(2, $user->tokens()->count());
+        $this->assertNotNull($user->tokens()->whereKey($first->id)->first());
+    }
+
+    public function test_api_token_cannot_exceed_the_limit(): void
+    {
+        $user = User::factory()->create();
+
+        for ($i = 1; $i <= ProfileController::MAX_API_TOKENS; $i++) {
+            $user->createToken("token{$i}");
+        }
+
+        $response = $this
+            ->actingAs($user)
+            ->from('/profile')
+            ->post('/profile/api-token', ['token_name' => '上限超過']);
+
+        $response
+            ->assertSessionHasErrors('token_name')
+            ->assertRedirect('/profile');
+
+        // 既存トークンは影響を受けない
+        $this->assertSame(ProfileController::MAX_API_TOKENS, $user->tokens()->count());
+    }
+
+    public function test_api_token_can_be_revoked_individually(): void
+    {
+        $user = User::factory()->create();
+        $keep = $user->createToken('残す')->accessToken;
+        $revoke = $user->createToken('消す')->accessToken;
+
+        $response = $this
+            ->actingAs($user)
+            ->delete('/profile/api-token/'.$revoke->id);
+
+        $response
+            ->assertSessionHasNoErrors()
+            ->assertRedirect('/profile');
+
+        $this->assertNull($user->tokens()->whereKey($revoke->id)->first());
+        $this->assertNotNull($user->tokens()->whereKey($keep->id)->first());
+    }
+
+    public function test_user_cannot_revoke_another_users_api_token(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $otherToken = $other->createToken('他人のトークン')->accessToken;
+
+        $response = $this
+            ->actingAs($user)
+            ->delete('/profile/api-token/'.$otherToken->id);
+
+        $response->assertNotFound();
+
+        $this->assertNotNull($other->tokens()->whereKey($otherToken->id)->first());
     }
 
     public function test_user_can_delete_their_account(): void


### PR DESCRIPTION
## 概要

1ユーザー1トークンだった APIトークンを、最大5個まで発行・個別失効できるようにしました。

Closes #579

## 変更内容

### `app/Http/Controllers/ProfileController.php`
- `MAX_API_TOKENS = 5` を追加
- `createApiToken()`: 既存トークンの `tokens()->delete()` を除去。上限到達時は `ValidationException` で `token_name` にエラーを返す（既存トークンは無影響）
- `destroyApiToken()`: 引数に `{token}` を受け取り、`$request->user()->tokens()->whereKey()` から検索。見つからなければ 404。他ユーザーのトークンは構造上失効できない
- `edit()`: ビューに `maxApiTokens` を渡す

### `routes/web.php`
- `DELETE /profile/api-token` → `DELETE /profile/api-token/{token}`

### `resources/views/profile/partials/api-token-form.blade.php`
- 最新1件のみ → 発行済みトークンを全件表示（トークン名 / 発行日 / 最終使用日時）
- 各トークンに個別の失効ボタン
- ボタン文言を「発行」に統一、「再発行すると現在のトークンは失効します」を削除し、残り枠の表示（`現在 n / 5`）に置換

## テスト

`tests/Feature/ProfileTest.php` に5件追加:

- `test_api_token_can_be_created`
- `test_creating_api_token_does_not_revoke_existing_tokens`
- `test_api_token_cannot_exceed_the_limit`（既存トークンが減らないことも検証）
- `test_api_token_can_be_revoked_individually`（他のトークンが残ることも検証）
- `test_user_cannot_revoke_another_users_api_token`（404 かつ対象トークンが残存）

## 確認

- `php artisan test` → **557 passed (1752 assertions)**
- `./vendor/bin/pint --test` → **PASS (231 files)**

> 補足: このマシンの Ubuntu 20.04 では ondrej PPA の focal 向けインデックスが空になっており apt で PHP 8.2 を導入できないため、`php:8.2-cli` ベースの Docker コンテナ内でテスト・Pint を実行しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)