### PR TITLE
feat: ガチャ（ランダム再生）で検索・絞り込み条件を考慮する (#574)

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Helpers\CharacterCategorizer;
 use App\Helpers\TextNormalizer;
 use App\Helpers\ValidationHelper;
 use App\Models\Channel;
@@ -153,16 +154,11 @@ class ChannelController extends Controller
     {
         $channel = Channel::where('handle', $id)->firstOrFail();
 
-        $allowedIndexes = [
-            'ABCDE', 'FGHIJ', 'KLMNO', 'PQRST', 'UVWXYZ',
-            '0-9', 'あ', 'か', 'さ', 'た', 'な', 'は', 'ま', 'や', 'ら', 'わ', 'その他',
-        ];
-
         $validated = $request->validate([
             'per_page' => 'integer|min:1|max:100',
             'page' => 'integer|min:1',
             'search' => 'string|max:255',
-            'index' => ['nullable', 'string', Rule::in($allowedIndexes)],
+            'index' => ['nullable', 'string', Rule::in(CharacterCategorizer::getAllCategories())],
         ]);
 
         $result = $this->timestampService->getTimestampsWithMapping(
@@ -183,11 +179,23 @@ class ChannelController extends Controller
     {
         $channel = Channel::where('handle', $id)->firstOrFail();
 
+        // 一覧と同じ絞り込み条件を受け取り、条件に合致する中からランダムに選ぶ
+        $validated = $request->validate([
+            'search' => 'nullable|string|max:255',
+            'index' => ['nullable', 'string', Rule::in(CharacterCategorizer::getAllCategories())],
+        ]);
+
         $excludeVideoId = $request->query('exclude_video_id');
         if ($excludeVideoId !== null && ! preg_match('/^[A-Za-z0-9_-]{11}$/', $excludeVideoId)) {
             $excludeVideoId = null;
         }
-        $result = $this->timestampService->getRandomTimestamp($channel, 50, $excludeVideoId);
+        $result = $this->timestampService->getRandomTimestamp(
+            $channel,
+            50,
+            $excludeVideoId,
+            $validated['search'] ?? '',
+            $validated['index'] ?? ''
+        );
 
         if (! $result) {
             return response()->json([

--- a/app/Services/TimestampService.php
+++ b/app/Services/TimestampService.php
@@ -67,20 +67,8 @@ class TimestampService
                 ->orWhere('timestamp_song_mappings.is_not_song', false);
         });
 
-        // 検索条件（スペース区切りでAND検索、正規化して類似文字を吸収）
-        if ($search) {
-            $keywords = QueryHelper::splitSearchKeywords($search);
-            foreach ($keywords as $keyword) {
-                $normalizedKeyword = TextNormalizer::normalize($keyword);
-                $escaped = QueryHelper::escapeLikeString($normalizedKeyword);
-                $query->where('ts_items.normalized_text', 'like', "%{$escaped}%");
-            }
-        }
-
-        // 頭文字インデックスでフィルタリング
-        if ($index) {
-            $this->applyIndexFilter($query, $index);
-        }
+        // 検索・頭文字インデックスで絞り込み
+        $this->applyFilters($query, $search, $index);
 
         // 楽曲名順でソート（楽曲名がなければタイムスタンプテキストを使用）
         $query->orderByRaw('COALESCE(songs.title, ts_items.text) ASC');
@@ -128,6 +116,32 @@ class TimestampService
             'total' => $paginated->total(),
             'available_indexes' => $availableIndexes,
         ];
+    }
+
+    /**
+     * 検索・頭文字インデックスの絞り込み条件を適用
+     *
+     * 一覧・ガチャ（ランダム取得）・ページ位置計算で同じ条件を使うため共通化している。
+     *
+     * @param  string  $search  検索キーワード（スペース区切りでAND検索）
+     * @param  string  $index  頭文字インデックス（カテゴリ名）
+     */
+    private function applyFilters(Builder $query, string $search, string $index): void
+    {
+        // 検索条件（スペース区切りでAND検索、正規化して類似文字を吸収）
+        if ($search) {
+            $keywords = QueryHelper::splitSearchKeywords($search);
+            foreach ($keywords as $keyword) {
+                $normalizedKeyword = TextNormalizer::normalize($keyword);
+                $escaped = QueryHelper::escapeLikeString($normalizedKeyword);
+                $query->where('ts_items.normalized_text', 'like', "%{$escaped}%");
+            }
+        }
+
+        // 頭文字インデックスでフィルタリング
+        if ($index) {
+            $this->applyIndexFilter($query, $index);
+        }
     }
 
     /**
@@ -267,10 +281,17 @@ class TimestampService
      * チャンネルのタイムスタンプからランダムに1件取得
      *
      * @param  int  $perPage  1ページあたりの件数（ページ番号計算用）
+     * @param  string  $search  検索キーワード（一覧と同じ条件で絞り込む）
+     * @param  string  $index  頭文字インデックス（一覧と同じ条件で絞り込む）
      * @return array|null タイムスタンプデータ（見つからない場合はnull）
      */
-    public function getRandomTimestamp(Channel $channel, int $perPage = 50, ?string $excludeVideoId = null): ?array
-    {
+    public function getRandomTimestamp(
+        Channel $channel,
+        int $perPage = 50,
+        ?string $excludeVideoId = null,
+        string $search = '',
+        string $index = ''
+    ): ?array {
         // ベースクエリ: ts_itemsとtimestamp_song_mappings、songsをLEFT JOIN
         $query = TsItem::with(['archive'])
             ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
@@ -301,6 +322,9 @@ class TimestampService
                 ->orWhere('timestamp_song_mappings.is_not_song', false);
         });
 
+        // 一覧と同じ検索・頭文字インデックスの条件で絞り込む
+        $this->applyFilters($query, $search, $index);
+
         // 直前のアーカイブを除外してランダムに1件取得（同じアーカイブの連続再生を防止）
         $item = null;
         if ($excludeVideoId) {
@@ -327,8 +351,9 @@ class TimestampService
         }
 
         // 選ばれたアイテムのソート順での位置を計算（ページ番号算出用）
+        // 一覧側も同じ絞り込みが効いているため、同条件でカウントしないとページがずれる
         $sortKey = $item->song_title ?? $item->text;
-        $position = $this->calculateItemPosition($channel, $sortKey, $item->id);
+        $position = $this->calculateItemPosition($channel, $sortKey, $item->id, $search, $index);
         $page = (int) ceil($position / $perPage);
 
         // 同じ動画内の次のタイムスタンプを取得（自動再抽選用）
@@ -479,10 +504,15 @@ class TimestampService
     /**
      * アイテムのソート順での位置を計算
      */
-    private function calculateItemPosition(Channel $channel, string $sortKey, string $itemId): int
-    {
+    private function calculateItemPosition(
+        Channel $channel,
+        string $sortKey,
+        string $itemId,
+        string $search = '',
+        string $index = ''
+    ): int {
         // ソートキーより前にあるアイテム数をカウント
-        $countBefore = TsItem::query()
+        $countBeforeQuery = TsItem::query()
             ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
             ->leftJoin('songs', 'timestamp_song_mappings.song_id', '=', 'songs.id')
             ->whereHas('archive', function ($q) use ($channel) {
@@ -497,11 +527,12 @@ class TimestampService
                 $q->whereNull('timestamp_song_mappings.id')
                     ->orWhere('timestamp_song_mappings.is_not_song', false);
             })
-            ->whereRaw('COALESCE(songs.title, ts_items.text) < ?', [$sortKey])
-            ->count();
+            ->whereRaw('COALESCE(songs.title, ts_items.text) < ?', [$sortKey]);
+        $this->applyFilters($countBeforeQuery, $search, $index);
+        $countBefore = $countBeforeQuery->count();
 
         // 同じソートキーを持つアイテムの中での位置も考慮
-        $countSameKey = TsItem::query()
+        $countSameKeyQuery = TsItem::query()
             ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
             ->leftJoin('songs', 'timestamp_song_mappings.song_id', '=', 'songs.id')
             ->whereHas('archive', function ($q) use ($channel) {
@@ -517,8 +548,9 @@ class TimestampService
                     ->orWhere('timestamp_song_mappings.is_not_song', false);
             })
             ->whereRaw('COALESCE(songs.title, ts_items.text) = ?', [$sortKey])
-            ->where('ts_items.id', '<', $itemId)
-            ->count();
+            ->where('ts_items.id', '<', $itemId);
+        $this->applyFilters($countSameKeyQuery, $search, $index);
+        $countSameKey = $countSameKeyQuery->count();
 
         return $countBefore + $countSameKey + 1;
     }

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -911,7 +911,11 @@ function registerArchiveListComponent() {
                         this.isPlaybackTransitioning = true;
 
                         const excludeVideoId = this.selectedTimestamp?.video_id || null;
-                        const timestamp = await ChannelApiService.fetchRandomTimestamp(this.channel.handle, excludeVideoId);
+                        // 一覧の検索・頭文字フィルタと同じ条件で抽選する
+                        const timestamp = await ChannelApiService.fetchRandomTimestamp(this.channel.handle, excludeVideoId, {
+                            search: this.searchQuery,
+                            index: this.selectedIndex,
+                        });
 
                         if (excludeVideoId && timestamp.video_id === excludeVideoId) {
                             console.warn('同じアーカイブが再選択されました', { excludeVideoId, selectedVideoId: timestamp.video_id });
@@ -919,6 +923,8 @@ function registerArchiveListComponent() {
 
                         logUserAction('playRandomTimestamp', {
                             excludeVideoId: excludeVideoId,
+                            search: this.searchQuery,
+                            index: this.selectedIndex,
                             timestampId: timestamp.id,
                             videoId: timestamp.video_id,
                             tsNum: timestamp.ts_num,

--- a/resources/js/channels/services/ChannelApiService.js
+++ b/resources/js/channels/services/ChannelApiService.js
@@ -67,11 +67,27 @@ export class ChannelApiService {
     /**
      * ランダムなタイムスタンプを1件取得
      * @param {string} channelHandle - チャンネルハンドル
+     * @param {string|null} excludeVideoId - 直前のアーカイブID（連続再生防止用）
+     * @param {{search?: string, index?: string}} filters - 一覧と同じ絞り込み条件
      * @returns {Promise<Object>} ランダムなタイムスタンプデータ
      */
-    static async fetchRandomTimestamp(channelHandle, excludeVideoId = null) {
-        const params = excludeVideoId ? `?exclude_video_id=${encodeURIComponent(excludeVideoId)}` : '';
-        const response = await fetch(`/api/channels/${channelHandle}/timestamps/random${params}`);
+    static async fetchRandomTimestamp(channelHandle, excludeVideoId = null, { search = '', index = '' } = {}) {
+        const params = new URLSearchParams();
+
+        if (excludeVideoId) {
+            params.set('exclude_video_id', excludeVideoId);
+        }
+
+        if (search) {
+            params.set('search', search);
+        }
+
+        if (index) {
+            params.set('index', index);
+        }
+
+        const queryString = params.toString();
+        const response = await fetch(`/api/channels/${channelHandle}/timestamps/random${queryString ? `?${queryString}` : ''}`);
         if (!response.ok) {
             if (response.status === 404) {
                 throw new Error('タイムスタンプが見つかりませんでした');

--- a/tests/Feature/ChannelRandomTimestampTest.php
+++ b/tests/Feature/ChannelRandomTimestampTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Archive;
+use App\Models\Channel;
+use App\Models\TsItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * ガチャ（ランダム再生）APIが一覧と同じ絞り込み条件を考慮することを検証する
+ */
+class ChannelRandomTimestampTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Channel $channel;
+
+    private Archive $archive;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+
+        $this->channel = Channel::create([
+            'handle' => 'test-channel',
+            'channel_id' => 'UC123456789',
+            'title' => 'Test Channel',
+            'thumbnail' => 'https://example.com/thumb.jpg',
+            'user_id' => $user->id,
+        ]);
+
+        $this->archive = Archive::create([
+            'id' => 'video123',
+            'channel_id' => 'UC123456789',
+            'video_id' => 'video123',
+            'title' => 'Test Archive',
+            'thumbnail' => 'https://example.com/video.jpg',
+            'is_public' => true,
+            'is_display' => true,
+            'published_at' => now(),
+            'comments_updated_at' => now(),
+        ]);
+    }
+
+    private function createTsItem(string $text, int $tsNum): TsItem
+    {
+        return TsItem::factory()->create([
+            'video_id' => $this->archive->video_id,
+            'text' => $text,
+            'ts_text' => gmdate('H:i:s', $tsNum),
+            'ts_num' => $tsNum,
+            'is_display' => 1,
+        ]);
+    }
+
+    public function test_random_endpoint_respects_search_query(): void
+    {
+        $this->createTsItem('夜に駆ける', 0);
+        $this->createTsItem('アイドル', 180);
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps/random?search=夜に駆ける');
+
+        $response->assertOk()
+            ->assertJsonPath('text', '夜に駆ける');
+    }
+
+    public function test_random_endpoint_respects_index_filter(): void
+    {
+        $this->createTsItem('あいうえお', 0);
+        $this->createTsItem('かきくけこ', 180);
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps/random?index='.urlencode('か'));
+
+        $response->assertOk()
+            ->assertJsonPath('text', 'かきくけこ');
+    }
+
+    public function test_random_endpoint_returns_404_when_filter_matches_nothing(): void
+    {
+        $this->createTsItem('夜に駆ける', 0);
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps/random?search=存在しない曲名');
+
+        $response->assertNotFound();
+    }
+
+    public function test_random_endpoint_rejects_invalid_index(): void
+    {
+        $this->createTsItem('夜に駆ける', 0);
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps/random?index=invalid');
+
+        $response->assertStatus(422);
+    }
+
+    public function test_random_endpoint_without_filters_returns_any_item(): void
+    {
+        $this->createTsItem('夜に駆ける', 0);
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps/random');
+
+        $response->assertOk()
+            ->assertJsonPath('text', '夜に駆ける');
+    }
+}

--- a/tests/Unit/Services/TimestampServiceRandomTest.php
+++ b/tests/Unit/Services/TimestampServiceRandomTest.php
@@ -137,6 +137,104 @@ class TimestampServiceRandomTest extends TestCase
         $this->assertNull($result);
     }
 
+    public function test_get_random_timestamp_respects_search_filter(): void
+    {
+        $this->createTsItem(['text' => '夜に駆ける', 'ts_text' => '0:00', 'ts_num' => 0]);
+        $this->createTsItem(['text' => 'アイドル', 'ts_text' => '3:00', 'ts_num' => 180]);
+        $this->createTsItem(['text' => '怪物', 'ts_text' => '6:00', 'ts_num' => 360]);
+
+        // 何度引いても検索条件に合致する1件しか返らない
+        for ($i = 0; $i < 10; $i++) {
+            $result = $this->service->getRandomTimestamp($this->channel, 50, null, '夜に駆ける');
+
+            $this->assertNotNull($result);
+            $this->assertEquals('夜に駆ける', $result['text']);
+        }
+    }
+
+    public function test_get_random_timestamp_returns_null_when_search_matches_nothing(): void
+    {
+        $this->createTsItem(['text' => '夜に駆ける', 'ts_text' => '0:00', 'ts_num' => 0]);
+
+        $result = $this->service->getRandomTimestamp($this->channel, 50, null, '存在しない曲名');
+
+        $this->assertNull($result);
+    }
+
+    public function test_get_random_timestamp_search_filter_survives_exclude_fallback(): void
+    {
+        // 除外対象のアーカイブにしか該当曲がない場合、フォールバックしても
+        // 検索条件を外して別の曲を返してはいけない
+        $this->createTsItem(['text' => '夜に駆ける', 'ts_text' => '0:00', 'ts_num' => 0]);
+
+        $archive2 = Archive::factory()->create([
+            'channel_id' => $this->channel->channel_id,
+            'is_display' => 1,
+        ]);
+        TsItem::factory()->create([
+            'video_id' => $archive2->video_id,
+            'text' => '別アーカイブの別曲',
+            'ts_text' => '2:00',
+            'ts_num' => 120,
+            'is_display' => 1,
+        ]);
+
+        $result = $this->service->getRandomTimestamp(
+            $this->channel,
+            50,
+            $this->archive->video_id,
+            '夜に駆ける'
+        );
+
+        $this->assertNotNull($result);
+        $this->assertEquals('夜に駆ける', $result['text']);
+    }
+
+    public function test_get_random_timestamp_respects_index_filter(): void
+    {
+        $this->createTsItem(['text' => 'あいうえお', 'ts_text' => '0:00', 'ts_num' => 0]);
+        $this->createTsItem(['text' => 'かきくけこ', 'ts_text' => '3:00', 'ts_num' => 180]);
+
+        for ($i = 0; $i < 10; $i++) {
+            $result = $this->service->getRandomTimestamp($this->channel, 50, null, '', 'か');
+
+            $this->assertNotNull($result);
+            $this->assertEquals('かきくけこ', $result['text']);
+        }
+    }
+
+    public function test_get_random_timestamp_page_matches_filtered_list(): void
+    {
+        // 絞り込みで除外される曲。ソート順で対象曲より前に来るため、
+        // ページ計算に混ざると返却される page がずれる
+        foreach (['0除外1', '0除外2', '0除外3', '0除外4'] as $index => $text) {
+            $this->createTsItem([
+                'text' => $text,
+                'ts_text' => "{$index}:00",
+                'ts_num' => $index * 60,
+            ]);
+        }
+        foreach (['A対象1', 'A対象2', 'A対象3'] as $index => $text) {
+            $this->createTsItem([
+                'text' => $text,
+                'ts_text' => '1'.$index.':00',
+                'ts_num' => 600 + $index * 60,
+            ]);
+        }
+
+        $result = $this->service->getRandomTimestamp($this->channel, 2, null, 'A対象');
+
+        $this->assertNotNull($result);
+        $this->assertStringStartsWith('A対象', $result['text']);
+
+        // 絞り込み後は3件しかないため、2ページを超えることはない
+        $this->assertLessThanOrEqual(2, $result['page']);
+
+        // 返却された page を同じ条件の一覧に渡すと、その曲が含まれている
+        $list = $this->service->getTimestampsWithMapping($this->channel, 2, $result['page'], 'A対象');
+        $this->assertContains($result['text'], array_column($list['data'], 'text'));
+    }
+
     public function test_get_next_timestamp_in_archive_returns_next(): void
     {
         $this->createTsItem(['text' => '1曲目', 'ts_text' => '0:00', 'ts_num' => 0]);


### PR DESCRIPTION
## 概要

ガチャ（ランダム再生）が検索クエリ・頭文字フィルタを無視してチャンネル内の全タイムスタンプから抽選していた問題を修正しました。絞り込んだ状態でガチャを引くと、その条件に合致する中から抽選されます。

Closes #574

## 変更内容

### `app/Services/TimestampService.php`
- `applyFilters(Builder, string $search, string $index)` を追加し、一覧・ガチャ・ページ位置計算で同じ絞り込みロジックを共有（条件のドリフト防止）
- `getRandomTimestamp()` に `$search` / `$index` を追加
- `calculateItemPosition()` にも同条件を適用

### `app/Http/Controllers/ChannelController.php`
- ランダム取得APIで `search` / `index` をバリデーション（一覧と同じルール）
- 頭文字カテゴリの許可リストをベタ書き配列から `CharacterCategorizer::getAllCategories()` に統一

### フロントエンド
- `ChannelApiService.fetchRandomTimestamp()` の第3引数に `{ search, index }` を追加
- `playRandomTimestamp()` が現在の `searchQuery` / `selectedIndex` を送信。`logUserAction` にも記録

## 実装上のポイント

**`calculateItemPosition()` にも絞り込みを効かせる必要がある**
レスポンスの `page` は「ガチャで当たった曲が一覧の何ページ目か」で、フロントはこれを使ってページを切り替えます。ここに絞り込みを適用しないと絞り込み前の順位で計算され、切り替え先のページにその曲が存在しません。

**除外フォールバック時も絞り込みは維持される**
`exclude_video_id` で結果が0件になった場合のフォールバックは絞り込み済みクエリに対して行われるため、条件外の曲が返ることはありません（テストで検証）。

**絞り込み結果が0件の場合**
従来どおり404を返し、フロントは「タイムスタンプが見つかりませんでした」を表示します。

## テスト

`tests/Unit/Services/TimestampServiceRandomTest.php` に5件追加:
- 検索条件を尊重する / 検索が0件なら null
- 除外フォールバック時も検索条件が維持される
- 頭文字フィルタを尊重する
- 返却された `page` が絞り込み後の一覧と一致する

`tests/Feature/ChannelRandomTimestampTest.php`（新規）に5件:
- API が `search` / `index` を反映する
- 合致0件で404 / 不正な `index` で422 / 条件なしでも従来どおり動作

> `page` 一致のテストは、`calculateItemPosition()` の絞り込みを外すと実際に落ちることを確認済みです。

## 確認

- `php artisan test` → **562 passed (1788 assertions)**
- `./vendor/bin/pint --test` → **PASS (232 files)**
- `npm run build` → 成功

## スコープ外

Issue に記載の「検索対象（曲名/タイトル/すべて）の切り替え」は現時点で未実装の機能のため、本PRでは対象外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)