### PR TITLE
fix: 字幕フィンガープリントの窓を60秒に拡大し縮退マッチを防止

### DIFF
--- a/app/Console/Commands/GenerateSubtitleFingerprints.php
+++ b/app/Console/Commands/GenerateSubtitleFingerprints.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\VideoSubtitle;
+use App\Services\SubtitleFingerprintService;
+use Illuminate\Console\Command;
+
+class GenerateSubtitleFingerprints extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'subtitle-fingerprints:generate
+                            {--video= : 対象のvideo_id（省略時は字幕が保存されている全動画）}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = '保存済み字幕からフィンガープリントを生成する（既存分は現行の窓の長さで作り直す）';
+
+    public function __construct(private SubtitleFingerprintService $fingerprintService)
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $videoId = $this->option('video');
+
+        $videoIds = VideoSubtitle::query()
+            ->when($videoId, fn ($query) => $query->where('video_id', $videoId))
+            ->distinct()
+            ->orderBy('video_id')
+            ->pluck('video_id');
+
+        if ($videoIds->isEmpty()) {
+            $this->info('対象の字幕データがありません。');
+
+            return self::SUCCESS;
+        }
+
+        $this->info('対象動画: '.$videoIds->count().'件');
+        $this->line('窓の長さ: '.SubtitleFingerprintService::WINDOW_DURATION_SEC.'秒 / '
+            .'最小トライグラム数: '.SubtitleFingerprintService::MIN_TRIGRAM_COUNT);
+
+        $bar = $this->output->createProgressBar($videoIds->count());
+        $bar->start();
+
+        $generated = 0;
+        foreach ($videoIds as $id) {
+            $generated += $this->fingerprintService->generateFingerprintsForVideo($id);
+            $bar->advance();
+        }
+
+        $bar->finish();
+        $this->newLine(2);
+        $this->info("フィンガープリント生成: {$generated}件");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/SubtitleFingerprintService.php
+++ b/app/Services/SubtitleFingerprintService.php
@@ -9,7 +9,36 @@ use App\Models\VideoSubtitle;
 class SubtitleFingerprintService
 {
     /**
-     * 動画の全ts_itemsに対してフィンガープリントを生成
+     * フィンガープリントの窓の長さ（秒）
+     *
+     * 歌い出し直後は前奏で歌声がなく、自動字幕が [音楽] だけになる区間が続く。
+     * 30秒では前奏の長い楽曲で歌詞をまったく拾えないため60秒を採る。
+     *
+     * この値を変更した場合、既存のフィンガープリントは窓の長さが異なるため
+     * 照合対象から外れる（SubtitleMatchingService が duration_sec の一致を要求する）。
+     * 変更時は subtitle-fingerprints:generate で全件を再生成すること。
+     */
+    public const WINDOW_DURATION_SEC = 60;
+
+    /**
+     * 窓の開始を歌い出しの何秒手前から取るか
+     */
+    public const WINDOW_LEAD_SEC = 1;
+
+    /**
+     * フィンガープリントとして採用する最小トライグラム数
+     *
+     * トライグラムが少ないテキストはJaccard類似度が不安定になる。
+     * 特に効果音アノテーションだけが並ぶ区間は種類数が数個まで縮退し、
+     * 内容の異なる区間どうしが類似度1.0で一致してしまう。
+     */
+    public const MIN_TRIGRAM_COUNT = 20;
+
+    /**
+     * 動画の全ts_itemsに対してフィンガープリントを生成する。
+     *
+     * 生成対象から外れた既存のフィンガープリントは削除するため、
+     * 呼び出し後はこの動画のフィンガープリントが現行条件のものだけになる。
      *
      * @return int 生成件数
      */
@@ -29,15 +58,22 @@ class SubtitleFingerprintService
             ->whereNotNull('ts_num')
             ->get();
 
-        $count = 0;
+        $generatedTsItemIds = [];
         foreach ($tsItems as $tsItem) {
             $fp = $this->generateFingerprint($tsItem, $subtitle);
             if ($fp) {
-                $count++;
+                $generatedTsItemIds[] = $tsItem->id;
             }
         }
 
-        return $count;
+        // 今回の条件で生成されなかったフィンガープリントを削除する。
+        // 窓の長さの変更・ts_itemの非表示化・字幕の差し替えで古い行が残ると、
+        // 現行条件の行と混在して照合結果が歪むため。
+        SubtitleFingerprint::where('video_id', $videoId)
+            ->whereNotIn('ts_item_id', $generatedTsItemIds)
+            ->delete();
+
+        return count($generatedTsItemIds);
     }
 
     /**
@@ -50,7 +86,7 @@ class SubtitleFingerprintService
             return null;
         }
 
-        $durationSec = 30;
+        $durationSec = self::WINDOW_DURATION_SEC;
         $text = $this->extractSubtitleWindow($segments, (int) $tsItem->ts_num, $durationSec);
 
         if ($text === '') {
@@ -58,7 +94,7 @@ class SubtitleFingerprintService
         }
 
         $trigrams = self::generateTrigrams($text);
-        if (empty($trigrams)) {
+        if (count($trigrams) < self::MIN_TRIGRAM_COUNT) {
             return null;
         }
 
@@ -77,9 +113,11 @@ class SubtitleFingerprintService
     /**
      * 字幕セグメントから指定時間範囲のテキストを切り出し
      */
-    public function extractSubtitleWindow(array $segments, int $startSec, int $durationSec = 30): string
+    public function extractSubtitleWindow(array $segments, int $startSec, ?int $durationSec = null): string
     {
-        $windowStart = max(0, $startSec - 1);
+        $durationSec ??= self::WINDOW_DURATION_SEC;
+
+        $windowStart = max(0, $startSec - self::WINDOW_LEAD_SEC);
         $windowEnd = $startSec + $durationSec;
 
         $texts = [];
@@ -103,10 +141,16 @@ class SubtitleFingerprintService
 
     /**
      * フィンガープリント用のテキスト正規化
-     * 句読点・記号除去、小文字化
+     * 効果音アノテーション除去、句読点・記号除去、小文字化
      */
     public static function normalizeForFingerprint(string $text): string
     {
+        // 自動字幕の効果音アノテーション（[音楽] [拍手] [Music] など）を角括弧ごと除去する。
+        // 記号除去だけでは角括弧が外れて「音楽」が本文として残り、前奏や間奏の窓が
+        // 「音楽」の繰り返しだけになって、内容の異なる楽曲どうしが一致してしまう。
+        // 歌詞側の誤除去を避けるため、括弧内の長さに上限を設ける。
+        $text = preg_replace('/[\[［][^\[\]［］]{0,20}[\]］]/u', '', $text);
+
         // 小文字化
         $text = mb_strtolower($text, 'UTF-8');
 

--- a/app/Services/SubtitleMatchingService.php
+++ b/app/Services/SubtitleMatchingService.php
@@ -76,6 +76,10 @@ class SubtitleMatchingService
 
     /**
      * 同一チャンネル内で類似フィンガープリントを検索
+     *
+     * 窓の長さ（duration_sec）が異なるものは比較しない。短い窓のトライグラム集合は
+     * 長い窓のほぼ部分集合になるため、同一楽曲でもJaccard類似度が構造的に低く出て
+     * しきい値を下回る。窓の長さを変更した直後の混在状態で静かに取りこぼすのを防ぐ。
      */
     private function findSimilarInChannel(SubtitleFingerprint $fp, string $channelId, float $threshold): Collection
     {
@@ -88,6 +92,7 @@ class SubtitleMatchingService
 
         SubtitleFingerprint::whereIn('video_id', $videoIds)
             ->where('ts_item_id', '!=', $fp->ts_item_id)
+            ->where('duration_sec', $fp->duration_sec)
             ->chunkById(500, function ($chunk) use ($targetTrigrams, $threshold, &$results) {
                 foreach ($chunk as $other) {
                     $similarity = self::jaccardSimilarity($targetTrigrams, $other->trigrams);
@@ -112,7 +117,8 @@ class SubtitleMatchingService
         $targetTrigrams = $fp->trigrams;
         $results = collect();
 
-        $query = SubtitleFingerprint::where('ts_item_id', '!=', $fp->ts_item_id);
+        $query = SubtitleFingerprint::where('ts_item_id', '!=', $fp->ts_item_id)
+            ->where('duration_sec', $fp->duration_sec);
         if (! empty($excludeTsItemIds)) {
             $query->whereNotIn('ts_item_id', $excludeTsItemIds);
         }

--- a/tests/Feature/SubtitleApiTest.php
+++ b/tests/Feature/SubtitleApiTest.php
@@ -19,6 +19,11 @@ class SubtitleApiTest extends TestCase
 {
     use RefreshDatabase;
 
+    /**
+     * フィンガープリントの最小トライグラム数を満たす歌詞相当のテキスト
+     */
+    private const LYRICS_TEXT = 'あいうえおかきくけこさしすせそたちつてとなにぬねの';
+
     protected User $superAdmin;
 
     protected User $channelAdmin;
@@ -273,6 +278,154 @@ class SubtitleApiTest extends TestCase
     }
 
     // ==========================================
+    // フィンガープリント生成のテスト
+    // ==========================================
+
+    public function test_store_generates_fingerprint_with_configured_window(): void
+    {
+        $tsItem = TsItem::factory()->create([
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_num' => 60,
+            'text' => 'テスト曲',
+            'is_display' => '1',
+        ]);
+
+        // 前奏が長く、歌詞は歌い出しの45秒後から出はじめる
+        $response = $this->actingAs($this->superAdmin)
+            ->postJson('/api/manage/archives/subtitles/store', [
+                'video_id' => 'dQw4w9WgXcQ',
+                'language_code' => 'ja',
+                'kind' => 'asr',
+                'subtitles' => [
+                    ['start' => 60, 'duration' => 40, 'text' => '[音楽]'],
+                    ['start' => 105, 'duration' => 5, 'text' => self::LYRICS_TEXT],
+                ],
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('fingerprints_generated', 1);
+
+        $this->assertDatabaseHas('subtitle_fingerprints', [
+            'ts_item_id' => $tsItem->id,
+            'duration_sec' => SubtitleFingerprintService::WINDOW_DURATION_SEC,
+        ]);
+    }
+
+    public function test_store_skips_fingerprint_for_music_only_window(): void
+    {
+        $tsItem = TsItem::factory()->create([
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_num' => 60,
+            'text' => 'テスト曲',
+            'is_display' => '1',
+        ]);
+
+        // 旧仕様で作られた既存のフィンガープリント。1件も生成されない場合でも削除される
+        SubtitleFingerprint::create([
+            'id' => Str::ulid(),
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_item_id' => $tsItem->id,
+            'start_sec' => 60,
+            'duration_sec' => 30,
+            'fingerprint_text' => self::LYRICS_TEXT,
+            'trigrams' => SubtitleFingerprintService::generateTrigrams(self::LYRICS_TEXT),
+        ]);
+
+        // 窓が効果音アノテーションだけの場合、トライグラムが数種類まで縮退して
+        // 別の楽曲と一致してしまうため、フィンガープリントを作らない
+        $response = $this->actingAs($this->superAdmin)
+            ->postJson('/api/manage/archives/subtitles/store', [
+                'video_id' => 'dQw4w9WgXcQ',
+                'language_code' => 'ja',
+                'kind' => 'asr',
+                'subtitles' => [
+                    ['start' => 60, 'duration' => 30, 'text' => '[音楽]'],
+                    ['start' => 90, 'duration' => 30, 'text' => '[音楽]'],
+                ],
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('fingerprints_generated', 0);
+
+        $this->assertDatabaseCount('subtitle_fingerprints', 0);
+    }
+
+    public function test_store_prunes_stale_fingerprints(): void
+    {
+        $keptTsItem = TsItem::factory()->create([
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_num' => 60,
+            'text' => '残る曲',
+            'is_display' => '1',
+        ]);
+
+        $staleTsItem = TsItem::factory()->create([
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_num' => 600,
+            'text' => '消える曲',
+            'is_display' => '1',
+        ]);
+
+        // 旧仕様（30秒窓）で作られたフィンガープリントが残っている状態を作る
+        SubtitleFingerprint::create([
+            'id' => Str::ulid(),
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_item_id' => $staleTsItem->id,
+            'start_sec' => 600,
+            'duration_sec' => 30,
+            'fingerprint_text' => self::LYRICS_TEXT,
+            'trigrams' => SubtitleFingerprintService::generateTrigrams(self::LYRICS_TEXT),
+        ]);
+
+        // 再生成後、字幕のない ts_item のフィンガープリントは残らない
+        $this->actingAs($this->superAdmin)
+            ->postJson('/api/manage/archives/subtitles/store', [
+                'video_id' => 'dQw4w9WgXcQ',
+                'language_code' => 'ja',
+                'kind' => 'asr',
+                'subtitles' => [
+                    ['start' => 60, 'duration' => 10, 'text' => self::LYRICS_TEXT],
+                ],
+            ])
+            ->assertStatus(200)
+            ->assertJsonPath('fingerprints_generated', 1);
+
+        $this->assertDatabaseHas('subtitle_fingerprints', ['ts_item_id' => $keptTsItem->id]);
+        $this->assertDatabaseMissing('subtitle_fingerprints', ['ts_item_id' => $staleTsItem->id]);
+    }
+
+    public function test_generate_command_rebuilds_fingerprints(): void
+    {
+        $tsItem = TsItem::factory()->create([
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_num' => 60,
+            'text' => 'テスト曲',
+            'is_display' => '1',
+        ]);
+
+        VideoSubtitle::create([
+            'id' => Str::ulid(),
+            'video_id' => 'dQw4w9WgXcQ',
+            'language_code' => 'ja',
+            'kind' => 'asr',
+            'subtitle_data' => [
+                ['start' => 60, 'duration' => 10, 'text' => self::LYRICS_TEXT],
+            ],
+            'segment_count' => 1,
+        ]);
+
+        $this->assertDatabaseCount('subtitle_fingerprints', 0);
+
+        $this->artisan('subtitle-fingerprints:generate')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('subtitle_fingerprints', [
+            'ts_item_id' => $tsItem->id,
+            'duration_sec' => SubtitleFingerprintService::WINDOW_DURATION_SEC,
+        ]);
+    }
+
+    // ==========================================
     // matchCandidates（楽曲マッチング）のテスト
     // ==========================================
 
@@ -357,6 +510,65 @@ class SubtitleApiTest extends TestCase
             ->assertJsonPath('candidates.0.song_id', $song->id)
             ->assertJsonPath('candidates.0.song_title', 'テスト曲A')
             ->assertJsonPath('candidates.0.similarity', fn ($v) => abs($v - 1.0) < 0.001);
+    }
+
+    public function test_match_candidates_ignores_different_window_duration(): void
+    {
+        $tsItem1 = TsItem::factory()->create([
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_num' => 60,
+            'text' => 'テスト曲A',
+            'is_display' => '1',
+        ]);
+
+        Archive::factory()->create([
+            'channel_id' => $this->channel->channel_id,
+            'video_id' => 'abcdefghijk',
+        ]);
+        $tsItem2 = TsItem::factory()->create([
+            'video_id' => 'abcdefghijk',
+            'ts_num' => 120,
+            'text' => 'テスト曲A',
+            'is_display' => '1',
+        ]);
+
+        $trigrams = SubtitleFingerprintService::generateTrigrams(self::LYRICS_TEXT);
+
+        // トライグラムは完全一致だが、窓の長さが異なる（旧仕様で作られた行）
+        SubtitleFingerprint::create([
+            'id' => Str::ulid(),
+            'video_id' => 'dQw4w9WgXcQ',
+            'ts_item_id' => $tsItem1->id,
+            'start_sec' => 60,
+            'duration_sec' => 60,
+            'fingerprint_text' => self::LYRICS_TEXT,
+            'trigrams' => $trigrams,
+        ]);
+
+        SubtitleFingerprint::create([
+            'id' => Str::ulid(),
+            'video_id' => 'abcdefghijk',
+            'ts_item_id' => $tsItem2->id,
+            'start_sec' => 120,
+            'duration_sec' => 30,
+            'fingerprint_text' => self::LYRICS_TEXT,
+            'trigrams' => $trigrams,
+        ]);
+
+        // 窓の長さが違うものは同一楽曲でも類似度が構造的に下がるため比較しない
+        $this->actingAs($this->superAdmin)
+            ->getJson("/api/manage/subtitle-matches/{$tsItem1->id}")
+            ->assertStatus(200)
+            ->assertJsonPath('has_fingerprint', true)
+            ->assertJsonCount(0, 'candidates');
+
+        // 窓の長さを揃えれば候補として返る
+        SubtitleFingerprint::where('ts_item_id', $tsItem2->id)->update(['duration_sec' => 60]);
+
+        $this->actingAs($this->superAdmin)
+            ->getJson("/api/manage/subtitle-matches/{$tsItem1->id}")
+            ->assertStatus(200)
+            ->assertJsonCount(1, 'candidates');
     }
 
     public function test_match_candidates_returns_404_for_unknown_ts_item(): void

--- a/tests/Unit/SubtitleFingerprintServiceTest.php
+++ b/tests/Unit/SubtitleFingerprintServiceTest.php
@@ -66,6 +66,40 @@ class SubtitleFingerprintServiceTest extends TestCase
         $this->assertEquals('abcd', $result);
     }
 
+    public function test_normalize_removes_asr_annotations(): void
+    {
+        $this->assertEquals(
+            'きみのこえ',
+            SubtitleFingerprintService::normalizeForFingerprint('[音楽] きみのこえ [拍手]')
+        );
+
+        // 全角の角括弧・英語表記のアノテーションも除去する
+        $this->assertEquals(
+            'きみのこえ',
+            SubtitleFingerprintService::normalizeForFingerprint('［音楽］きみのこえ[Applause]')
+        );
+    }
+
+    public function test_normalize_music_only_window_becomes_empty(): void
+    {
+        // 前奏や間奏の窓は [音楽] だけになる。角括弧ごと除去しないと「音楽」が本文として
+        // 残り、内容の異なる楽曲どうしが同じトライグラムを持ってしまう。
+        $normalized = SubtitleFingerprintService::normalizeForFingerprint('[音楽] [音楽] [音楽] [音楽]');
+
+        $this->assertEquals('', $normalized);
+        $this->assertEquals([], SubtitleFingerprintService::generateTrigrams($normalized));
+    }
+
+    public function test_normalize_keeps_long_bracketed_text(): void
+    {
+        // 括弧内が長いものは効果音アノテーションとみなさず、本文として残す
+        $long = str_repeat('あ', 21);
+
+        $result = SubtitleFingerprintService::normalizeForFingerprint("[{$long}]");
+
+        $this->assertEquals($long, $result);
+    }
+
     // ==========================================
     // 字幕ウィンドウ抽出のテスト
     // ==========================================
@@ -122,6 +156,28 @@ class SubtitleFingerprintServiceTest extends TestCase
         $result = $service->extractSubtitleWindow([], 60, 30);
 
         $this->assertEquals('', $result);
+    }
+
+    public function test_extract_subtitle_window_defaults_to_configured_duration(): void
+    {
+        $service = new SubtitleFingerprintService;
+
+        $segments = [
+            // 歌い出しの45秒後。前奏が長い楽曲ではこのあたりから歌詞が出はじめる
+            ['start' => 105, 'duration' => 3, 'text' => '歌い出しの45秒後'],
+        ];
+
+        // 既定の窓（ts_num=60 から WINDOW_DURATION_SEC 秒）には含まれる
+        $this->assertStringContainsString(
+            '歌い出しの45秒後',
+            $service->extractSubtitleWindow($segments, 60)
+        );
+
+        // 旧来の30秒窓では取りこぼしていた
+        $this->assertStringNotContainsString(
+            '歌い出しの45秒後',
+            $service->extractSubtitleWindow($segments, 60, 30)
+        );
     }
 
     // ==========================================


### PR DESCRIPTION
## 背景

ブラウザ拡張側で楽曲候補を受け取る機能を実装するにあたり、その土台となる字幕フィンガープリントを先行して改善する。

前奏が30秒程度ある楽曲では、30秒窓に歌詞がまったく入らず自動字幕の `[音楽]` だけになる。`normalizeForFingerprint` は角括弧を記号（`\p{P}` / `\p{S}`）として除去するため「音楽」が本文として残り、`generateTrigrams` の `array_unique` を経て**ユニークなトライグラムが2種類まで縮退**していた。

```
"[音楽] [音楽] [音楽] [音楽]"  →  "音楽音楽音楽音楽"  →  ["音楽音", "楽音楽"]
```

既存のガードは `if (empty($trigrams))` のみで最小個数を見ていないため、この2種類だけのフィンガープリントがそのまま保存される。結果、**前奏の長い楽曲どうしが内容と無関係に類似度1.0で一致し、誤った候補が最上位に出ていた**。

## 変更内容

- 窓の長さを30秒から**60秒**に拡大し、`WINDOW_DURATION_SEC` 定数として切り出した。あわせて窓の先頭オフセットも `WINDOW_LEAD_SEC` として定数化
- 効果音アノテーション（`[音楽]` `[拍手]` `[Music]` など）を**角括弧ごと除去**するようにした。全角の `［］` にも対応。歌詞側の誤除去を避けるため括弧内の長さに上限（20文字）を設けている
- 最小トライグラム数（`MIN_TRIGRAM_COUNT` = 20）を下回るものはフィンガープリントを生成しないようにした
- **窓の長さが異なるフィンガープリントを照合対象から除外**した。短い窓のトライグラム集合は長い窓のほぼ部分集合になるため、同一楽曲でも Jaccard 類似度が `|A|/|B|` 近くまで下がり、しきい値0.5を割り込む。混在状態で静かに取りこぼすのを防ぐ
- `generateFingerprintsForVideo` で、生成対象から外れた古いフィンガープリントを削除するようにした（窓の長さ変更・ts_item の非表示化・字幕の差し替えで発生する残骸の掃除）
- 再生成用の artisan コマンド `subtitle-fingerprints:generate` を追加

### 窓の長さ変更が同一楽曲の照合に与える影響（実測）

同一パフォーマンスの字幕を30秒窓・60秒窓それぞれで処理して比較した値:

| 比較 | trigram数 | Jaccard |
|---|---|---|
| 30秒窓 vs 60秒窓（内容は同一） | 18 vs 42 | **0.4286**（しきい値割れ） |
| 60秒窓 vs 60秒窓（内容は同一） | 42 vs 42 | 1.0000 |

窓の長さが混在すると同一楽曲でもマッチしなくなるため、`duration_sec` の一致を照合条件に加えている。

## デプロイ後に必要な作業

**既存のフィンガープリントは30秒窓で作られているため、新規生成分と相互に照合されない。** マージ・デプロイ後に一度だけ全件再生成すること。

```bash
php artisan subtitle-fingerprints:generate
```

特定の動画だけ作り直す場合は `--video=<video_id>` を指定する。毎デプロイで流す性質のものではないため `deploy.sh` には組み込んでいない。

## テスト

- Unit 4ケース追加: アノテーション除去、`[音楽]` のみの窓が空になること、長い括弧内テキストを本文として残すこと、既定の窓長が適用されること
- Feature 5ケース追加: 60秒窓でのフィンガープリント生成、`[音楽]` のみの窓で生成されないこと、古いフィンガープリントの削除（生成0件のケースを含む）、コマンドによる再生成、窓の長さが異なる場合に照合されないこと
- 全体: 559 passed（警告2件は `.env` 不在によるもので、develop でも同一に発生する既存の環境要因）
- `./vendor/bin/pint` 適用済み

## 本PRに含めていないもの

- **拡張向けの候補取得API・拡張側UI**: 本PRの再生成後に実データで候補の当たり具合を確認してから着手する
- **`generateFingerprintsForVideo` の字幕選択**: 保存済み字幕から `orderBy('kind', 'asc')` で1本だけ選ぶ実装のため、同一 `kind` で複数言語が保存されていると選択が不定になる。日本語の歌枠で英語字幕が選ばれると精度が出ないが、本PRの範囲外のため別途 Issue とする
- **しきい値0.5の妥当性**: 窓の長さを変えたことで類似度の分布が変わるため、再生成後の実データで見直したい

@CodiumAI-Agent /improve

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXyF3gPSEGXvBo3iU6W8Sf)_