### PR TITLE
feat: タイムスタンプ一覧に公開日（期間）フィルターを追加

### DIFF
--- a/app/Http/Controllers/ChannelController.php
+++ b/app/Http/Controllers/ChannelController.php
@@ -159,6 +159,8 @@ class ChannelController extends Controller
             'page' => 'integer|min:1',
             'search' => 'string|max:255',
             'index' => ['nullable', 'string', Rule::in(CharacterCategorizer::getAllCategories())],
+            'published_from' => 'nullable|date_format:Y-m-d',
+            'published_to' => 'nullable|date_format:Y-m-d',
         ]);
 
         $result = $this->timestampService->getTimestampsWithMapping(
@@ -166,7 +168,9 @@ class ChannelController extends Controller
             $validated['per_page'] ?? 50,
             $validated['page'] ?? 1,
             $validated['search'] ?? '',
-            $validated['index'] ?? ''
+            $validated['index'] ?? '',
+            $validated['published_from'] ?? '',
+            $validated['published_to'] ?? ''
         );
 
         return response()->json($result);
@@ -183,6 +187,8 @@ class ChannelController extends Controller
         $validated = $request->validate([
             'search' => 'nullable|string|max:255',
             'index' => ['nullable', 'string', Rule::in(CharacterCategorizer::getAllCategories())],
+            'published_from' => 'nullable|date_format:Y-m-d',
+            'published_to' => 'nullable|date_format:Y-m-d',
         ]);
 
         $excludeVideoId = $request->query('exclude_video_id');
@@ -194,7 +200,9 @@ class ChannelController extends Controller
             50,
             $excludeVideoId,
             $validated['search'] ?? '',
-            $validated['index'] ?? ''
+            $validated['index'] ?? '',
+            $validated['published_from'] ?? '',
+            $validated['published_to'] ?? ''
         );
 
         if (! $result) {

--- a/app/Services/TimestampService.php
+++ b/app/Services/TimestampService.php
@@ -33,7 +33,9 @@ class TimestampService
         int $perPage = 50,
         int $currentPage = 1,
         string $search = '',
-        string $index = ''
+        string $index = '',
+        string $publishedFrom = '',
+        string $publishedTo = ''
     ): array {
         // ベースクエリ: ts_itemsとtimestamp_song_mappings、songsをLEFT JOIN
         $query = TsItem::with(['archive'])
@@ -67,14 +69,14 @@ class TimestampService
                 ->orWhere('timestamp_song_mappings.is_not_song', false);
         });
 
-        // 検索・頭文字インデックスで絞り込み
-        $this->applyFilters($query, $search, $index);
+        // 検索・頭文字インデックス・公開日で絞り込み
+        $this->applyFilters($query, $search, $index, $publishedFrom, $publishedTo);
 
         // 楽曲名順でソート（楽曲名がなければタイムスタンプテキストを使用）
         $query->orderByRaw('COALESCE(songs.title, ts_items.text) ASC');
 
         // 利用可能な頭文字カテゴリを取得（フィルタリング前のベースクエリで）
-        $availableIndexes = $this->fetchAvailableIndexes($channel, $search);
+        $availableIndexes = $this->fetchAvailableIndexes($channel, $search, $publishedFrom, $publishedTo);
 
         // DBページネーション
         $paginated = $query->paginate($perPage, ['*'], 'page', $currentPage);
@@ -125,8 +127,10 @@ class TimestampService
      *
      * @param  string  $search  検索キーワード（スペース区切りでAND検索）
      * @param  string  $index  頭文字インデックス（カテゴリ名）
+     * @param  string  $publishedFrom  アーカイブ公開日の開始日（Y-m-d、空文字は指定なし）
+     * @param  string  $publishedTo  アーカイブ公開日の終了日（Y-m-d、空文字は指定なし）
      */
-    private function applyFilters(Builder $query, string $search, string $index): void
+    private function applyFilters(Builder $query, string $search, string $index, string $publishedFrom = '', string $publishedTo = ''): void
     {
         // 検索条件（スペース区切りでAND検索、正規化して類似文字を吸収）
         if ($search) {
@@ -142,6 +146,31 @@ class TimestampService
         if ($index) {
             $this->applyIndexFilter($query, $index);
         }
+
+        // アーカイブ公開日でフィルタリング
+        $this->applyPublishedDateFilter($query, $publishedFrom, $publishedTo);
+    }
+
+    /**
+     * アーカイブ公開日（from/to）でフィルタリング
+     *
+     * @param  string  $publishedFrom  開始日（Y-m-d、空文字は指定なし）
+     * @param  string  $publishedTo  終了日（Y-m-d、空文字は指定なし）
+     */
+    private function applyPublishedDateFilter(Builder $query, string $publishedFrom, string $publishedTo): void
+    {
+        if ($publishedFrom === '' && $publishedTo === '') {
+            return;
+        }
+
+        $query->whereHas('archive', function ($q) use ($publishedFrom, $publishedTo) {
+            if ($publishedFrom !== '') {
+                $q->whereDate('published_at', '>=', $publishedFrom);
+            }
+            if ($publishedTo !== '') {
+                $q->whereDate('published_at', '<=', $publishedTo);
+            }
+        });
     }
 
     /**
@@ -229,7 +258,7 @@ class TimestampService
     /**
      * 利用可能な頭文字カテゴリを取得
      */
-    private function fetchAvailableIndexes(Channel $channel, string $search): array
+    private function fetchAvailableIndexes(Channel $channel, string $search, string $publishedFrom = '', string $publishedTo = ''): array
     {
         // ベースクエリを構築（頭文字抽出用）
         $query = TsItem::query()
@@ -248,15 +277,8 @@ class TimestampService
                     ->orWhere('timestamp_song_mappings.is_not_song', false);
             });
 
-        // 検索条件（スペース区切りでAND検索、正規化して類似文字を吸収）
-        if ($search) {
-            $keywords = QueryHelper::splitSearchKeywords($search);
-            foreach ($keywords as $keyword) {
-                $normalizedKeyword = TextNormalizer::normalize($keyword);
-                $escaped = QueryHelper::escapeLikeString($normalizedKeyword);
-                $query->where('ts_items.normalized_text', 'like', "%{$escaped}%");
-            }
-        }
+        // 検索・公開日で絞り込み（頭文字インデックスはカテゴリ抽出対象のため適用しない）
+        $this->applyFilters($query, $search, '', $publishedFrom, $publishedTo);
 
         // 頭文字を取得（楽曲名優先、なければタイムスタンプテキスト）
         $firstChars = $query
@@ -283,6 +305,8 @@ class TimestampService
      * @param  int  $perPage  1ページあたりの件数（ページ番号計算用）
      * @param  string  $search  検索キーワード（一覧と同じ条件で絞り込む）
      * @param  string  $index  頭文字インデックス（一覧と同じ条件で絞り込む）
+     * @param  string  $publishedFrom  アーカイブ公開日の開始日（一覧と同じ条件で絞り込む）
+     * @param  string  $publishedTo  アーカイブ公開日の終了日（一覧と同じ条件で絞り込む）
      * @return array|null タイムスタンプデータ（見つからない場合はnull）
      */
     public function getRandomTimestamp(
@@ -290,7 +314,9 @@ class TimestampService
         int $perPage = 50,
         ?string $excludeVideoId = null,
         string $search = '',
-        string $index = ''
+        string $index = '',
+        string $publishedFrom = '',
+        string $publishedTo = ''
     ): ?array {
         // ベースクエリ: ts_itemsとtimestamp_song_mappings、songsをLEFT JOIN
         $query = TsItem::with(['archive'])
@@ -322,8 +348,8 @@ class TimestampService
                 ->orWhere('timestamp_song_mappings.is_not_song', false);
         });
 
-        // 一覧と同じ検索・頭文字インデックスの条件で絞り込む
-        $this->applyFilters($query, $search, $index);
+        // 一覧と同じ検索・頭文字インデックス・公開日の条件で絞り込む
+        $this->applyFilters($query, $search, $index, $publishedFrom, $publishedTo);
 
         // 直前のアーカイブを除外してランダムに1件取得（同じアーカイブの連続再生を防止）
         $item = null;
@@ -353,7 +379,7 @@ class TimestampService
         // 選ばれたアイテムのソート順での位置を計算（ページ番号算出用）
         // 一覧側も同じ絞り込みが効いているため、同条件でカウントしないとページがずれる
         $sortKey = $item->song_title ?? $item->text;
-        $position = $this->calculateItemPosition($channel, $sortKey, $item->id, $search, $index);
+        $position = $this->calculateItemPosition($channel, $sortKey, $item->id, $search, $index, $publishedFrom, $publishedTo);
         $page = (int) ceil($position / $perPage);
 
         // 同じ動画内の次のタイムスタンプを取得（自動再抽選用）
@@ -509,7 +535,9 @@ class TimestampService
         string $sortKey,
         string $itemId,
         string $search = '',
-        string $index = ''
+        string $index = '',
+        string $publishedFrom = '',
+        string $publishedTo = ''
     ): int {
         // ソートキーより前にあるアイテム数をカウント
         $countBeforeQuery = TsItem::query()
@@ -528,7 +556,7 @@ class TimestampService
                     ->orWhere('timestamp_song_mappings.is_not_song', false);
             })
             ->whereRaw('COALESCE(songs.title, ts_items.text) < ?', [$sortKey]);
-        $this->applyFilters($countBeforeQuery, $search, $index);
+        $this->applyFilters($countBeforeQuery, $search, $index, $publishedFrom, $publishedTo);
         $countBefore = $countBeforeQuery->count();
 
         // 同じソートキーを持つアイテムの中での位置も考慮
@@ -549,7 +577,7 @@ class TimestampService
             })
             ->whereRaw('COALESCE(songs.title, ts_items.text) = ?', [$sortKey])
             ->where('ts_items.id', '<', $itemId);
-        $this->applyFilters($countSameKeyQuery, $search, $index);
+        $this->applyFilters($countSameKeyQuery, $search, $index, $publishedFrom, $publishedTo);
         $countSameKey = $countSameKeyQuery->count();
 
         return $countBefore + $countSameKey + 1;

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -118,6 +118,8 @@ function registerArchiveListComponent() {
                 searchTimeout: null,
                 currentTimestampPage: 1,
                 selectedIndex: '',
+                publishedFrom: '',
+                publishedTo: '',
                 loading: false,
                 error: null,
                 isFiltered: false,
@@ -244,7 +246,9 @@ function registerArchiveListComponent() {
                     logUserAction('fetchTimestamps', {
                         page,
                         search,
-                        index
+                        index,
+                        publishedFrom: this.publishedFrom,
+                        publishedTo: this.publishedTo
                     });
 
                     try {
@@ -253,7 +257,14 @@ function registerArchiveListComponent() {
 
                         const data = await ChannelApiService.fetchTimestamps(
                             this.channel.handle,
-                            { page, per_page: 50, search, index }
+                            {
+                                page,
+                                per_page: 50,
+                                search,
+                                index,
+                                published_from: this.publishedFrom,
+                                published_to: this.publishedTo
+                            }
                         );
 
                         this.timestamps = data;
@@ -283,6 +294,24 @@ function registerArchiveListComponent() {
                     this.selectedIndex = '';
                     this.currentTimestampPage = 1;
                     this.fetchTimestamps(1, this.searchQuery, '');
+                },
+
+                // 公開日フィルター変更時の再検索（1ページ目に戻す）
+                changePublishedDateFilter() {
+                    this.currentTimestampPage = 1;
+                    this.fetchTimestamps(1, this.searchQuery, this.selectedIndex);
+                },
+
+                clearPublishedDateFilter() {
+                    this.publishedFrom = '';
+                    this.publishedTo = '';
+                    this.changePublishedDateFilter();
+                },
+
+                // 公開日フィルターの表示用ラベル（例: 2024-01-01〜2024-12-31）
+                get publishedDateFilterLabel() {
+                    if (!this.publishedFrom && !this.publishedTo) return '';
+                    return `${this.publishedFrom || ''}〜${this.publishedTo || ''}`;
                 },
 
                 toggleFilterExpanded() {
@@ -401,6 +430,12 @@ function registerArchiveListComponent() {
                         if (this.selectedIndex) {
                             params.set('index', this.selectedIndex);
                         }
+                        if (this.publishedFrom) {
+                            params.set('published_from', this.publishedFrom);
+                        }
+                        if (this.publishedTo) {
+                            params.set('published_to', this.publishedTo);
+                        }
                         if (this.currentTimestampPage && this.currentTimestampPage > 1) {
                             params.set('page', this.currentTimestampPage);
                         }
@@ -465,6 +500,12 @@ function registerArchiveListComponent() {
                         this.activeTab = 'timestamps';
                         this.searchQuery = search || '';
                         this.selectedIndex = params.get('index') || '';
+                        // 公開日はYYYY-MM-DD形式のみ受け付ける（不正な値はバックエンドで422になるため除外）
+                        const dateFormat = /^\d{4}-\d{2}-\d{2}$/;
+                        const publishedFrom = params.get('published_from') || '';
+                        const publishedTo = params.get('published_to') || '';
+                        this.publishedFrom = dateFormat.test(publishedFrom) ? publishedFrom : '';
+                        this.publishedTo = dateFormat.test(publishedTo) ? publishedTo : '';
                         this.currentTimestampPage = page;
                         this.fetchTimestamps(page, this.searchQuery, this.selectedIndex);
                     }
@@ -911,10 +952,12 @@ function registerArchiveListComponent() {
                         this.isPlaybackTransitioning = true;
 
                         const excludeVideoId = this.selectedTimestamp?.video_id || null;
-                        // 一覧の検索・頭文字フィルタと同じ条件で抽選する
+                        // 一覧の検索・頭文字・公開日フィルタと同じ条件で抽選する
                         const timestamp = await ChannelApiService.fetchRandomTimestamp(this.channel.handle, excludeVideoId, {
                             search: this.searchQuery,
                             index: this.selectedIndex,
+                            published_from: this.publishedFrom,
+                            published_to: this.publishedTo,
                         });
 
                         if (excludeVideoId && timestamp.video_id === excludeVideoId) {
@@ -925,6 +968,8 @@ function registerArchiveListComponent() {
                             excludeVideoId: excludeVideoId,
                             search: this.searchQuery,
                             index: this.selectedIndex,
+                            publishedFrom: this.publishedFrom,
+                            publishedTo: this.publishedTo,
                             timestampId: timestamp.id,
                             videoId: timestamp.video_id,
                             tsNum: timestamp.ts_num,

--- a/resources/js/channels/services/ChannelApiService.js
+++ b/resources/js/channels/services/ChannelApiService.js
@@ -25,9 +25,11 @@ export class ChannelApiService {
      * @param {number} options.per_page - 1ページあたりの件数
      * @param {string} options.search - 検索クエリ
      * @param {string} options.index - インデックスフィルター
+     * @param {string} options.published_from - アーカイブ公開日の開始日（YYYY-MM-DD）
+     * @param {string} options.published_to - アーカイブ公開日の終了日（YYYY-MM-DD）
      * @returns {Promise<Object>} タイムスタンプ一覧データ
      */
-    static async fetchTimestamps(channelHandle, { page = 1, per_page = 50, search = '', index = '' } = {}) {
+    static async fetchTimestamps(channelHandle, { page = 1, per_page = 50, search = '', index = '', published_from = '', published_to = '' } = {}) {
         const params = new URLSearchParams({ page, per_page });
 
         if (search) {
@@ -36,6 +38,14 @@ export class ChannelApiService {
 
         if (index) {
             params.set('index', index);
+        }
+
+        if (published_from) {
+            params.set('published_from', published_from);
+        }
+
+        if (published_to) {
+            params.set('published_to', published_to);
         }
 
         const response = await fetch(`/api/channels/${channelHandle}/timestamps?${params}`);
@@ -68,10 +78,10 @@ export class ChannelApiService {
      * ランダムなタイムスタンプを1件取得
      * @param {string} channelHandle - チャンネルハンドル
      * @param {string|null} excludeVideoId - 直前のアーカイブID（連続再生防止用）
-     * @param {{search?: string, index?: string}} filters - 一覧と同じ絞り込み条件
+     * @param {{search?: string, index?: string, published_from?: string, published_to?: string}} filters - 一覧と同じ絞り込み条件
      * @returns {Promise<Object>} ランダムなタイムスタンプデータ
      */
-    static async fetchRandomTimestamp(channelHandle, excludeVideoId = null, { search = '', index = '' } = {}) {
+    static async fetchRandomTimestamp(channelHandle, excludeVideoId = null, { search = '', index = '', published_from = '', published_to = '' } = {}) {
         const params = new URLSearchParams();
 
         if (excludeVideoId) {
@@ -84,6 +94,14 @@ export class ChannelApiService {
 
         if (index) {
             params.set('index', index);
+        }
+
+        if (published_from) {
+            params.set('published_from', published_from);
+        }
+
+        if (published_to) {
+            params.set('published_to', published_to);
         }
 
         const queryString = params.toString();

--- a/resources/views/channels/partials/timestamps-tab.blade.php
+++ b/resources/views/channels/partials/timestamps-tab.blade.php
@@ -30,7 +30,8 @@
     </div>
 
     {{-- 頭文字フィルタナビゲーション --}}
-    <div x-show="timestamps.available_indexes && timestamps.available_indexes.length > 0" class="mb-4 hidden sm:block">
+    {{-- 公開日フィルター適用中は0件でも表示を維持する（解除手段を残すため） --}}
+    <div x-show="(timestamps.available_indexes && timestamps.available_indexes.length > 0) || publishedFrom || publishedTo" class="mb-4 hidden sm:block">
         <div class="flex flex-wrap items-center gap-1">
             <button
                 @click="toggleFilterExpanded()"
@@ -48,6 +49,16 @@
                 class="channel-filter-btn">
                 すべて
             </button>
+            {{-- 折りたたみ中の公開日フィルター適用チップ --}}
+            <template x-if="publishedDateFilterLabel && !filterExpanded">
+                <button
+                    @click="clearPublishedDateFilter()"
+                    class="channel-filter-btn channel-filter-active-all"
+                    title="公開日フィルターを解除">
+                    <span x-text="'公開日: ' + publishedDateFilterLabel"></span>
+                    <span class="ml-1">✕</span>
+                </button>
+            </template>
             <template x-if="recentFilters.length > 0 && !filterExpanded">
                 <span class="flex items-center gap-1">
                     <span class="text-gray-300 dark:text-gray-600 mx-1">|</span>
@@ -123,6 +134,30 @@
                     </button>
                 </span>
             </template>
+        </div>
+        {{-- 公開日フィルター（折りたたみ内） --}}
+        <div x-show="filterExpanded" class="mt-2 flex flex-wrap items-center gap-2">
+            <span class="text-xs text-gray-500 dark:text-gray-400">公開日:</span>
+            <input
+                type="date"
+                x-model="publishedFrom"
+                @change="changePublishedDateFilter()"
+                aria-label="公開日フィルター（開始日）"
+                class="border p-1.5 rounded text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
+            <span class="text-gray-400 dark:text-gray-500">〜</span>
+            <input
+                type="date"
+                x-model="publishedTo"
+                @change="changePublishedDateFilter()"
+                aria-label="公開日フィルター（終了日）"
+                class="border p-1.5 rounded text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100" />
+            <button
+                type="button"
+                x-show="publishedFrom || publishedTo"
+                @click="clearPublishedDateFilter()"
+                class="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 underline">
+                解除
+            </button>
         </div>
     </div>
 

--- a/tests/Feature/ChannelTimestampDateFilterTest.php
+++ b/tests/Feature/ChannelTimestampDateFilterTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Archive;
+use App\Models\Channel;
+use App\Models\TsItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * タイムスタンプ一覧・ガチャAPIの公開日（期間）フィルターを検証する
+ */
+class ChannelTimestampDateFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Channel $channel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $user = User::factory()->create();
+
+        $this->channel = Channel::create([
+            'handle' => 'test-channel',
+            'channel_id' => 'UC123456789',
+            'title' => 'Test Channel',
+            'thumbnail' => 'https://example.com/thumb.jpg',
+            'user_id' => $user->id,
+        ]);
+    }
+
+    private function createArchiveWithTsItem(string $videoId, string $publishedAt, string $text): TsItem
+    {
+        Archive::create([
+            'id' => $videoId,
+            'channel_id' => $this->channel->channel_id,
+            'video_id' => $videoId,
+            'title' => 'Archive '.$publishedAt,
+            'thumbnail' => 'https://example.com/video.jpg',
+            'is_public' => true,
+            'is_display' => true,
+            'published_at' => $publishedAt,
+            'comments_updated_at' => now(),
+        ]);
+
+        return TsItem::factory()->create([
+            'video_id' => $videoId,
+            'text' => $text,
+            'ts_text' => '00:00:00',
+            'ts_num' => 0,
+            'is_display' => 1,
+        ]);
+    }
+
+    public function test_timestamps_endpoint_filters_by_published_from(): void
+    {
+        $this->createArchiveWithTsItem('video0000001', '2024-01-15 12:00:00', '古い曲');
+        $this->createArchiveWithTsItem('video0000002', '2024-06-15 12:00:00', '新しい曲');
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps?published_from=2024-06-01');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.text', '新しい曲');
+    }
+
+    public function test_timestamps_endpoint_filters_by_published_to(): void
+    {
+        $this->createArchiveWithTsItem('video0000001', '2024-01-15 12:00:00', '古い曲');
+        $this->createArchiveWithTsItem('video0000002', '2024-06-15 12:00:00', '新しい曲');
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps?published_to=2024-05-31');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.text', '古い曲');
+    }
+
+    public function test_timestamps_endpoint_filters_by_published_range(): void
+    {
+        $this->createArchiveWithTsItem('video0000001', '2024-01-15 12:00:00', '古い曲');
+        $this->createArchiveWithTsItem('video0000002', '2024-06-15 12:00:00', '期間内の曲');
+        $this->createArchiveWithTsItem('video0000003', '2024-12-15 12:00:00', '未来の曲');
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps?published_from=2024-06-01&published_to=2024-06-30');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.text', '期間内の曲');
+    }
+
+    public function test_timestamps_endpoint_includes_boundary_dates(): void
+    {
+        $this->createArchiveWithTsItem('video0000001', '2024-06-01 00:00:00', '開始日の曲');
+        $this->createArchiveWithTsItem('video0000002', '2024-06-30 23:59:59', '終了日の曲');
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps?published_from=2024-06-01&published_to=2024-06-30');
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'data');
+    }
+
+    public function test_timestamps_endpoint_combines_date_filter_with_search(): void
+    {
+        $this->createArchiveWithTsItem('video0000001', '2024-06-15 12:00:00', '夜に駆ける');
+        $this->createArchiveWithTsItem('video0000002', '2024-06-15 12:00:00', 'アイドル');
+        $this->createArchiveWithTsItem('video0000003', '2024-01-15 12:00:00', '夜に駆ける（旧）');
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps?published_from=2024-06-01&search='.urlencode('夜に駆ける'));
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.text', '夜に駆ける');
+    }
+
+    public function test_timestamps_endpoint_available_indexes_respect_date_filter(): void
+    {
+        $this->createArchiveWithTsItem('video0000001', '2024-01-15 12:00:00', 'あいうえお');
+        $this->createArchiveWithTsItem('video0000002', '2024-06-15 12:00:00', 'かきくけこ');
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps?published_from=2024-06-01');
+
+        $response->assertOk()
+            ->assertJsonPath('available_indexes', ['か']);
+    }
+
+    public function test_timestamps_endpoint_rejects_invalid_date_format(): void
+    {
+        $this->createArchiveWithTsItem('video0000001', '2024-06-15 12:00:00', '夜に駆ける');
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps?published_from=2024/06/01');
+
+        $response->assertStatus(422);
+    }
+
+    public function test_random_endpoint_respects_date_filter(): void
+    {
+        $this->createArchiveWithTsItem('video0000001', '2024-01-15 12:00:00', '古い曲');
+        $this->createArchiveWithTsItem('video0000002', '2024-06-15 12:00:00', '新しい曲');
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps/random?published_from=2024-06-01');
+
+        $response->assertOk()
+            ->assertJsonPath('text', '新しい曲');
+    }
+
+    public function test_random_endpoint_returns_404_when_date_filter_matches_nothing(): void
+    {
+        $this->createArchiveWithTsItem('video0000001', '2024-01-15 12:00:00', '古い曲');
+
+        $response = $this->getJson('/api/channels/test-channel/timestamps/random?published_from=2025-01-01');
+
+        $response->assertNotFound();
+    }
+}


### PR DESCRIPTION
@CodiumAI-Agent /improve

## 概要

チャンネルページのタイムスタンプ一覧に、アーカイブの**公開日**による絞り込みフィルター（from/to）を追加する。

Closes #582

## 変更内容

### バックエンド

- `ChannelController::fetchTimestamps` / `fetchRandomTimestamp` に `published_from` / `published_to` パラメータ（`Y-m-d`、バリデーション付き）を追加
- `TimestampService::applyFilters` に公開日条件（`whereHas('archive')` + `whereDate`）を追加
- **一覧・ガチャ（ランダム再生）・ページ位置計算・頭文字インデックス抽出の全てに同じ条件を適用**し、絞り込み中でもガチャのページジャンプ・件数がずれないようにした
- `fetchAvailableIndexes` の検索条件は `applyFilters` の呼び出しに共通化（ロジックは従来と同一）

### フロントエンド

- `ChannelApiService`: 一覧・ガチャAPIに公開日パラメータを追加
- `archive-list.js`: `publishedFrom` / `publishedTo` の状態管理、変更時は1ページ目から再検索、URLパラメータと同期（ブラウザ履歴・リロードで条件保持）
- `timestamps-tab.blade.php`: 既存の「絞り込み」折りたたみ内に日付入力（`<input type="date">`）を配置。折りたたみ中もフィルター適用中はチップを表示し、ワンクリックで解除可能

### 考慮した点

- 既存フィルター（検索・頭文字）とAND結合
- ページング・ソートとの併用時に条件が保持される
- 公開日フィルターで0件になった場合でも、絞り込みUIが消えて解除できなくなることがないよう表示条件を調整
- 境界日を含む（fromの0時〜toの23:59:59）ことをテストで担保

## テスト

- `tests/Feature/ChannelTimestampDateFilterTest.php` を新規追加（9件）
  - from / to / 範囲指定、境界日、検索との複合、available_indexesへの反映、不正形式の422、ガチャへの適用、0件時404
- 全テスト615件パス（既存の警告2件は `.env` 不在による環境起因で本変更と無関係）

## 検討事項（今回は見送り）

- プリセット（直近1年 / 今年 など）: Issueの要検討事項。必要なら別途対応
- モバイル表示: 既存の絞り込みUI自体が `hidden sm:block` のため、日付フィルターもデスクトップのみ。モバイル対応が必要なら別Issueで検討
- 日付比較はDB保存値（UTC）ベース。表示日付（ローカルタイム）と最大数時間の差が出るケースがあり得るが、既存の表示仕様と同等の扱い

---
_Generated by [Claude Code](https://claude.ai/code/session_015vCZE8t3eAb28KzMU8ks31)_