### PR TITLE
fix: 楽曲マスタ一覧は絞り込み条件がないときは検索・表示しない

### DIFF
--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -1434,8 +1434,13 @@ class TimestampNormalization {
 
             // 一覧タブに戻ってきたタイミングで再検索する。
             // 「検索→見つからず登録→一覧に戻る」の流れで、登録したばかりの
-            // 楽曲が古い検索結果のせいで表示されない問題を防ぐ
-            this.loadSongs(document.getElementById('songsSearch')?.value ?? '');
+            // 楽曲が古い検索結果のせいで表示されない問題を防ぐ。
+            // ただし検索文字列が空の場合は古い検索結果が残る心配がなく、
+            // タブを切り替えるたびに一覧が再取得されて邪魔なので何もしない
+            const songsSearch = document.getElementById('songsSearch')?.value ?? '';
+            if (songsSearch.trim() !== '') {
+                this.loadSongs(songsSearch);
+            }
         }
     }
 

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -859,7 +859,9 @@ class TimestampNormalization {
         this.lastDisplayedSongsTotal = total;
 
         container.innerHTML = '';
-        this.updateSongsCount(total !== null ? total : songs.length);
+        // 絞り込み条件がないときは検索していないので、「0件」と出すと
+        // 検索してヒットしなかったように見えてしまう
+        this.updateSongsCount(this.hasSongsQuery() ? (total !== null ? total : songs.length) : null);
 
         if (!Array.isArray(songs)) {
             console.error('songs is not an array:', songs);
@@ -965,10 +967,14 @@ class TimestampNormalization {
         return div;
     }
 
+    /**
+     * 楽曲マスタ一覧の件数表示を更新
+     * @param {number|null} count - 件数。nullを渡すと件数を表示しない
+     */
     updateSongsCount(count) {
         const countDiv = document.getElementById('songsCount');
         if (countDiv) {
-            countDiv.textContent = `${count}件`;
+            countDiv.textContent = count === null ? '' : `${count}件`;
         }
     }
 
@@ -1456,12 +1462,10 @@ class TimestampNormalization {
             // 一覧タブに戻ってきたタイミングで再検索する。
             // 「検索→見つからず登録→一覧に戻る」の流れで、登録したばかりの
             // 楽曲が古い検索結果のせいで表示されない問題を防ぐ。
-            // ただし検索文字列が空の場合は古い検索結果が残る心配がなく、
-            // タブを切り替えるたびに一覧が再取得されて邪魔なので何もしない
+            // 絞り込み条件がないときは loadSongs() がAPIを叩かずに
+            // 検索を促すメッセージを描画する（初回表示時もここを通る）。
             const songsSearch = document.getElementById('songsSearch')?.value ?? '';
-            if (songsSearch.trim() !== '') {
-                this.loadSongs(songsSearch);
-            }
+            this.loadSongs(songsSearch);
         }
     }
 

--- a/resources/js/songs/normalize.js
+++ b/resources/js/songs/normalize.js
@@ -814,7 +814,25 @@ class TimestampNormalization {
         }
     }
 
+    /**
+     * 楽曲マスタ一覧の絞り込み条件が指定されているか
+     * @returns {boolean} 検索文字列またはreview_statusフィルタが指定されていればtrue
+     */
+    hasSongsQuery() {
+        const search = document.getElementById('songsSearch')?.value ?? '';
+
+        return search.trim() !== '' || this.songReviewStatus !== null;
+    }
+
     async loadSongs(search = '') {
+        // 絞り込み条件がない場合は全件が返ってくるだけで実用的ではないため、
+        // APIを叩かず一覧を空のままにする（ページ表示直後と同じ状態）
+        if (search.trim() === '' && this.songReviewStatus === null) {
+            this.displaySongs([], 0);
+
+            return;
+        }
+
         try {
             const response = await songApiService.fetchSongs(search, this.songReviewStatus);
 
@@ -850,7 +868,10 @@ class TimestampNormalization {
         }
 
         if (songs.length === 0) {
-            container.innerHTML = '<p class="text-gray-500 dark:text-gray-400 text-sm">楽曲マスタがありません。</p>';
+            const message = this.hasSongsQuery()
+                ? '楽曲マスタがありません。'
+                : '楽曲名・アーティスト名で検索してください。';
+            container.innerHTML = `<p class="text-gray-500 dark:text-gray-400 text-sm">${message}</p>`;
             return;
         }
 


### PR DESCRIPTION
## 概要

#636 で一覧タブ（songsTab）への切り替え時に `loadSongs` を再実行するようにしたが、検索していない状態でもタブを切り替えるたびに一覧が再取得されて邪魔だった。

調べたところ `SongController::fetchSongs()` は検索文字列が空の場合、楽曲マスタを**全件（上限なし）**返す。またページ表示直後は一覧が空（`init()` は `loadSongs` を呼ばない）なので、「空検索＝全件表示」は表示直後の状態とも一貫していなかった。

そもそも絞り込みなしの全件一覧に用途がないため、空検索時は一覧を取得しないようにする。

## 変更内容

`resources/js/songs/normalize.js`

- `showTab()`: 一覧タブへの切り替え時、検索欄が空なら再検索しない（検索文字列があるときは #636 どおり再検索）
- `loadSongs()`: 検索文字列が空 かつ review_status フィルタも未指定なら API を叩かず一覧を空にする
- `displaySongs()`: 絞り込み条件がない状態の空表示は「楽曲名・アーティスト名で検索してください。」と案内する（絞り込み済みで0件のときは従来どおり「楽曲マスタがありません。」）
- `hasSongsQuery()` を追加（検索文字列 / review_status フィルタの有無を判定）

これにより、検索クリアボタンや楽曲の更新・削除後の再読込も含めて、絞り込みなしで全件が表示されることはなくなる。review_status のみの絞り込み（「要確認」だけ一覧したい）は従来どおり動作する。

## 動作確認

- JSのみの変更のため、PHPテストへの影響なし
- 構文チェック済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rEfskdnNrrb5pZg2p8Cvx