### PR TITLE
fix: 絵文字付きタイムスタンプが紐付けできない問題を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,11 @@ php artisan test tests/Feature/SongControllerTest.php::test_specific_method  # R
 - `ts_items.ts_num`: タイムスタンプ秒数
 - `normalized_text` カラムは **`utf8mb4_bin`** を指定すること（`ts_items` / `timestamp_song_mappings` / `timestamp_decompositions`）
   - デフォルトの `utf8mb4_unicode_ci` は補助面（絵文字）に重みを持たず「🎵A」と「🎶A」を同値と判定するため、バイト完全一致で扱うアプリ側と結果がずれる
-  - JOIN するテーブル間で照合順序が揃っていないと `Illegal mix of collations` エラーになる
+  - 同値扱いされるのは絵文字だけではない。半角/全角カナ（`ｲｴｽﾀﾃﾞｲ` = `イエスタデイ`）とアクセント記号（`cafe` = `café`）も同値で、これらは `TextNormalizer::normalize()` が揃えない（`mb_convert_kana` に `'as'` しか渡していない）
+  - **揃え忘れはエラーにならない。** 同一 charset で片方が `_bin` の場合、MySQL は `_bin` を優先するため JOIN は通り、意味論が黙って変わる。`Illegal mix of collations` が出るのは非バイナリ照合同士が食い違う場合のみ
+  - `utf8mb4_bin` は PAD SPACE。末尾スペースの有無は DB 側では無視される（NO PAD が必要なら `utf8mb4_0900_bin`）
+  - `MODIFY` で照合順序を指定するときは、`CHARACTER SET` / `COLLATE` を**型の直後・NULL 可否より前**に置くこと。順序を誤ると `ERROR 1064` になる。テストは SQLite なのでこの誤りは実行では検知できない（`tests/Unit/Migrations/ChangeNormalizedTextCollationTest.php` で生成SQLを固定している）
+  - `songs.normalized_title` / `normalized_artist` は未対応（同じ「SQL曖昧比較 → PHP 厳密比較」の構造が残っている）
 
 ## Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,9 @@ php artisan test tests/Feature/SongControllerTest.php::test_specific_method  # R
 - `ts_items.type`: '1' = 概要欄, '2' = コメント
 - `ts_items.ts_text`: タイムスタンプ文字列 (HH:MM:SS形式)
 - `ts_items.ts_num`: タイムスタンプ秒数
+- `normalized_text` カラムは **`utf8mb4_bin`** を指定すること（`ts_items` / `timestamp_song_mappings` / `timestamp_decompositions`）
+  - デフォルトの `utf8mb4_unicode_ci` は補助面（絵文字）に重みを持たず「🎵A」と「🎶A」を同値と判定するため、バイト完全一致で扱うアプリ側と結果がずれる
+  - JOIN するテーブル間で照合順序が揃っていないと `Illegal mix of collations` エラーになる
 
 ## Workflow
 

--- a/database/migrations/2026_08_17_000001_change_normalized_text_collation_to_utf8mb4_bin.php
+++ b/database/migrations/2026_08_17_000001_change_normalized_text_collation_to_utf8mb4_bin.php
@@ -11,10 +11,11 @@ return new class extends Migration
      * normalized_text の照合順序を utf8mb4_bin に変更
      *
      * 【背景】
-     * 2026_03_09_000001 で各テーブルを utf8mb4 / utf8mb4_unicode_ci に変換した。
+     * 2026_03_09_000001 で ts_items / timestamp_song_mappings 等を
+     * utf8mb4 / utf8mb4_unicode_ci に変換した（timestamp_decompositions は対象外で、
+     * テーブル作成時の接続既定 utf8mb4_unicode_ci が付いている）。
      * utf8mb4_unicode_ci は UCA 4.0.0 ベースで補助面（U+10000 以降＝ほとんどの絵文字）に
      * 重みを持たないため、MySQL 上では「🎵A」と「🎶A」が同値と判定される。
-     * さらに PAD SPACE 照合のため末尾スペースの有無も無視される。
      *
      * 【不具合】
      * アプリ側は normalized_text をバイト完全一致で扱う（PHP の === / keyBy / get）のに対し、
@@ -27,25 +28,63 @@ return new class extends Migration
      * 結果として「紐付けたはずなのに未紐付のまま」になる。
      *
      * 【対応】
-     * normalized_text を utf8mb4_bin（NO PAD・バイト比較）に変更し、
+     * normalized_text を utf8mb4_bin（バイト比較）に変更し、
      * DB 側の比較をアプリ側の比較と一致させる。
-     * normalized_text は TextNormalizer::normalize() で小文字化済みのため、
-     * バイト比較にしても大文字小文字の取りこぼしは発生しない。
+     *
+     * 【変換で影響を受ける範囲】
+     * utf8mb4_unicode_ci が同値扱いしていたのは絵文字だけではない。
+     * 半角/全角カナ（ｲｴｽﾀﾃﾞｲ = イエスタデイ）とアクセント記号（cafe = café）も同値で、
+     * これらは TextNormalizer::normalize() が揃えないため（mb_convert_kana に 'as' しか
+     * 渡しておらず 'K'/'H' を含まない）変換後は別物として扱われる。
+     * 該当するタイムスタンプは未紐付に戻るので、logCollationConflicts() で記録する。
      *
      * 【注意】
-     * - normalized_text で JOIN / whereColumn するテーブルは照合順序を揃える必要がある
-     *   （揃っていないと "Illegal mix of collations" エラーになる）ため、
-     *   ts_items / timestamp_song_mappings / timestamp_decompositions を同時に変換する。
+     * - utf8mb4_bin は PAD SPACE であり NO PAD ではない。末尾スペースの有無は
+     *   変換後も DB 側では無視される（normalize() が trim するため実害は無い想定）。
+     *   末尾スペースまで厳密にしたい場合は utf8mb4_0900_bin が必要。
+     * - utf8mb4_bin 列と utf8mb4_unicode_ci 列を JOIN してもエラーにはならない。
+     *   同一 charset で片方が _bin の場合、MySQL は _bin を優先し、
+     *   意味論が黙って変わる（部分適用状態が無警告で動いてしまう）。
+     *   "Illegal mix of collations" が出るのは非バイナリ照合同士が食い違う場合のみ。
+     *   3テーブルを同時に変換するのは、エラー回避のためではなく
+     *   各テーブルの UNIQUE / WHERE の意味論を揃えるため。
      * - ALTER TABLE MODIFY はインデックスの再構築を伴うため、
      *   件数の多い ts_items ではメンテナンスウィンドウでの実施を推奨。
      * - 今後 normalized_text 系のカラムを追加する場合も utf8mb4_bin を指定すること。
+     *   なお songs.normalized_title / normalized_artist は未対応（Issue で扱う）。
      */
     private const TARGET_COLUMNS = [
-        // テーブル名 => MODIFY 用のカラム定義（NULL 可否まで含めて元定義と一致させること）
-        'ts_items' => 'VARCHAR(255) NULL',
-        'timestamp_song_mappings' => 'VARCHAR(255) NOT NULL',
-        'timestamp_decompositions' => 'VARCHAR(255) NOT NULL',
+        // テーブル名 => [型, NULL可否]
+        // MySQL は CHARACTER SET / COLLATE を型の直後に要求するため、
+        // NULL 可否と分けて持つ（連結順を間違えると ERROR 1064 になる）
+        'ts_items' => ['VARCHAR(255)', 'NULL'],
+        'timestamp_song_mappings' => ['VARCHAR(255)', 'NOT NULL'],
+        'timestamp_decompositions' => ['VARCHAR(255)', 'NOT NULL'],
     ];
+
+    /**
+     * MODIFY 文を組み立てる
+     *
+     * CHARACTER SET / COLLATE は型の直後、NULL 可否より前に置かなければならない。
+     * 順序を誤ると ERROR 1064 になり、SQLite で動くテストでは検知できないため
+     * 文字列生成だけを切り出してテストできるようにしている。
+     */
+    public static function buildModifyStatement(string $table, string $type, string $nullability): string
+    {
+        return "ALTER TABLE `{$table}` MODIFY `normalized_text` {$type}"
+            .' CHARACTER SET utf8mb4 COLLATE utf8mb4_bin'
+            ." {$nullability}";
+    }
+
+    /**
+     * 変換対象のテーブル定義
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function targetColumns(): array
+    {
+        return self::TARGET_COLUMNS;
+    }
 
     public function up(): void
     {
@@ -55,14 +94,42 @@ return new class extends Migration
 
         $this->logCollationConflicts();
 
-        foreach (self::TARGET_COLUMNS as $table => $definition) {
+        foreach (self::TARGET_COLUMNS as $table => [$type, $nullability]) {
             if (! Schema::hasTable($table) || ! Schema::hasColumn($table, 'normalized_text')) {
                 continue;
             }
 
-            DB::statement(
-                "ALTER TABLE `{$table}` MODIFY `normalized_text` {$definition} CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
+            // 既に utf8mb4_bin なら何もしない。
+            // MODIFY は全行コピーとインデックス再構築を伴うため、
+            // 再実行で ts_items のリビルドを二重に払わない
+            if ($this->currentCollation($table) === 'utf8mb4_bin') {
+                Log::info('[Migration] normalized_text is already utf8mb4_bin', ['table' => $table]);
+
+                continue;
+            }
+
+            DB::statement(self::buildModifyStatement($table, $type, $nullability));
+        }
+    }
+
+    /**
+     * normalized_text の現在の照合順序を返す（取得できなければ null）
+     */
+    private function currentCollation(string $table): ?string
+    {
+        try {
+            $row = DB::selectOne(
+                'SELECT COLLATION_NAME AS collation_name
+                   FROM INFORMATION_SCHEMA.COLUMNS
+                  WHERE TABLE_SCHEMA = DATABASE()
+                    AND TABLE_NAME = ?
+                    AND COLUMN_NAME = ?',
+                [$table, 'normalized_text']
             );
+
+            return $row->collation_name ?? null;
+        } catch (\Throwable $e) {
+            return null;
         }
     }
 
@@ -75,37 +142,63 @@ return new class extends Migration
      */
     private function logCollationConflicts(): void
     {
-        if (! Schema::hasTable('ts_items') || ! Schema::hasTable('timestamp_song_mappings')) {
+        // normalized_text で結合される組み合わせすべてを検査する。
+        // ts_items × timestamp_song_mappings だけでは、分解済み
+        // （timestamp_decompositions）の取りこぼしが記録に残らない
+        $pairs = [
+            ['ts_items', 'timestamp_song_mappings'],
+            ['timestamp_decompositions', 'timestamp_song_mappings'],
+            ['timestamp_decompositions', 'ts_items'],
+        ];
+
+        foreach ($pairs as [$left, $right]) {
+            $this->logConflictsBetween($left, $right);
+        }
+    }
+
+    private function logConflictsBetween(string $left, string $right): void
+    {
+        if (! Schema::hasTable($left) || ! Schema::hasTable($right)) {
             return;
         }
 
         try {
-            $conflicts = DB::table('ts_items')
-                ->join('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
-                ->whereRaw('CONVERT(ts_items.normalized_text USING binary) <> CONVERT(timestamp_song_mappings.normalized_text USING binary)')
-                ->select(
-                    'ts_items.normalized_text as item_normalized_text',
-                    'timestamp_song_mappings.normalized_text as mapping_normalized_text',
-                    'timestamp_song_mappings.id as mapping_id',
-                    'timestamp_song_mappings.song_id as song_id'
+            $query = DB::table($left)
+                ->join($right, "{$left}.normalized_text", '=', "{$right}.normalized_text")
+                ->whereRaw(
+                    "CONVERT({$left}.normalized_text USING binary) <> CONVERT({$right}.normalized_text USING binary)"
                 )
-                ->distinct()
-                ->limit(500)
-                ->get();
+                ->select(
+                    "{$left}.normalized_text as left_normalized_text",
+                    "{$right}.normalized_text as right_normalized_text"
+                )
+                ->distinct();
 
-            if ($conflicts->isEmpty()) {
-                Log::info('[Migration] No collation conflicts found in normalized_text');
+            // 件数は上限をかけずに数える。サンプルだけを絞る
+            // （上限後の件数を記録すると、影響行が多いときに実数が分からない）
+            $total = (clone $query)->count();
+
+            if ($total === 0) {
+                Log::info('[Migration] No collation conflicts found in normalized_text', [
+                    'left' => $left,
+                    'right' => $right,
+                ]);
 
                 return;
             }
 
             Log::warning('[Migration] normalized_text collation conflicts detected', [
-                'count' => $conflicts->count(),
-                'note' => '変換後これらのタイムスタンプは未紐付に戻るため、正規化画面での再紐付けが必要',
-                'conflicts' => $conflicts->toArray(),
+                'left' => $left,
+                'right' => $right,
+                'count' => $total,
+                'note' => '変換後これらは未紐付に戻るため、正規化画面での再紐付けが必要。'
+                    .'絵文字だけでなく半角/全角カナ・アクセント記号の差も含む',
+                'samples' => $query->limit(500)->get()->toArray(),
             ]);
         } catch (\Throwable $e) {
             Log::warning('[Migration] Failed to detect normalized_text collation conflicts', [
+                'left' => $left,
+                'right' => $right,
                 'message' => $e->getMessage(),
             ]);
         }
@@ -115,10 +208,15 @@ return new class extends Migration
      * Reverse the migrations.
      *
      * utf8mb4_unicode_ci に戻すと、絵文字だけが異なる normalized_text が
-     * 同値と判定され UNIQUE 制約違反になり得るため、ロールバックは行わない。
+     * 同値と判定され UNIQUE 制約違反になり得るため、ロールバックできない。
+     * 成功したふりをするとスキーマが bin のまま migrations テーブルから
+     * レコードが消え、次の migrate で再度フルリビルドが走るので明示的に失敗させる。
      */
     public function down(): void
     {
-        Log::warning('[Migration] Rollback not supported for normalized_text collation change');
+        throw new RuntimeException(
+            'normalized_text の照合順序変更はロールバックできません。'
+            .'utf8mb4_unicode_ci に戻すと絵文字だけが異なる行が同値になり UNIQUE 制約違反になります。'
+        );
     }
 };

--- a/database/migrations/2026_08_17_000001_change_normalized_text_collation_to_utf8mb4_bin.php
+++ b/database/migrations/2026_08_17_000001_change_normalized_text_collation_to_utf8mb4_bin.php
@@ -1,0 +1,124 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * normalized_text の照合順序を utf8mb4_bin に変更
+     *
+     * 【背景】
+     * 2026_03_09_000001 で各テーブルを utf8mb4 / utf8mb4_unicode_ci に変換した。
+     * utf8mb4_unicode_ci は UCA 4.0.0 ベースで補助面（U+10000 以降＝ほとんどの絵文字）に
+     * 重みを持たないため、MySQL 上では「🎵A」と「🎶A」が同値と判定される。
+     * さらに PAD SPACE 照合のため末尾スペースの有無も無視される。
+     *
+     * 【不具合】
+     * アプリ側は normalized_text をバイト完全一致で扱う（PHP の === / keyBy / get）のに対し、
+     * DB 側は上記のとおり曖昧一致になるため、両者の判定結果がずれる。
+     * 例: 絵文字で装飾されたタイムスタンプを正規化画面で紐付けると、
+     *   1. SongMappingService::linkTimestamp の where('normalized_text', ...) が
+     *      別の絵文字を持つ既存マッピング行を拾い、その行を更新してしまう
+     *      （対象テキストのマッピング行は作られない）
+     *   2. 一覧表示は PHP 側の keyBy/get でマッピングを引き当てるため該当なしとなる
+     * 結果として「紐付けたはずなのに未紐付のまま」になる。
+     *
+     * 【対応】
+     * normalized_text を utf8mb4_bin（NO PAD・バイト比較）に変更し、
+     * DB 側の比較をアプリ側の比較と一致させる。
+     * normalized_text は TextNormalizer::normalize() で小文字化済みのため、
+     * バイト比較にしても大文字小文字の取りこぼしは発生しない。
+     *
+     * 【注意】
+     * - normalized_text で JOIN / whereColumn するテーブルは照合順序を揃える必要がある
+     *   （揃っていないと "Illegal mix of collations" エラーになる）ため、
+     *   ts_items / timestamp_song_mappings / timestamp_decompositions を同時に変換する。
+     * - ALTER TABLE MODIFY はインデックスの再構築を伴うため、
+     *   件数の多い ts_items ではメンテナンスウィンドウでの実施を推奨。
+     * - 今後 normalized_text 系のカラムを追加する場合も utf8mb4_bin を指定すること。
+     */
+    private const TARGET_COLUMNS = [
+        // テーブル名 => MODIFY 用のカラム定義（NULL 可否まで含めて元定義と一致させること）
+        'ts_items' => 'VARCHAR(255) NULL',
+        'timestamp_song_mappings' => 'VARCHAR(255) NOT NULL',
+        'timestamp_decompositions' => 'VARCHAR(255) NOT NULL',
+    ];
+
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        $this->logCollationConflicts();
+
+        foreach (self::TARGET_COLUMNS as $table => $definition) {
+            if (! Schema::hasTable($table) || ! Schema::hasColumn($table, 'normalized_text')) {
+                continue;
+            }
+
+            DB::statement(
+                "ALTER TABLE `{$table}` MODIFY `normalized_text` {$definition} CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
+            );
+        }
+    }
+
+    /**
+     * 照合順序の違いで誤マッチしていたタイムスタンプを記録する
+     *
+     * 変換後は該当タイムスタンプが「未紐付」に戻るため、
+     * どのタイムスタンプが影響を受けたかを追跡できるようログに残す。
+     * 診断目的のため、失敗しても変換自体は継続する。
+     */
+    private function logCollationConflicts(): void
+    {
+        if (! Schema::hasTable('ts_items') || ! Schema::hasTable('timestamp_song_mappings')) {
+            return;
+        }
+
+        try {
+            $conflicts = DB::table('ts_items')
+                ->join('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
+                ->whereRaw('CONVERT(ts_items.normalized_text USING binary) <> CONVERT(timestamp_song_mappings.normalized_text USING binary)')
+                ->select(
+                    'ts_items.normalized_text as item_normalized_text',
+                    'timestamp_song_mappings.normalized_text as mapping_normalized_text',
+                    'timestamp_song_mappings.id as mapping_id',
+                    'timestamp_song_mappings.song_id as song_id'
+                )
+                ->distinct()
+                ->limit(500)
+                ->get();
+
+            if ($conflicts->isEmpty()) {
+                Log::info('[Migration] No collation conflicts found in normalized_text');
+
+                return;
+            }
+
+            Log::warning('[Migration] normalized_text collation conflicts detected', [
+                'count' => $conflicts->count(),
+                'note' => '変換後これらのタイムスタンプは未紐付に戻るため、正規化画面での再紐付けが必要',
+                'conflicts' => $conflicts->toArray(),
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('[Migration] Failed to detect normalized_text collation conflicts', [
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * utf8mb4_unicode_ci に戻すと、絵文字だけが異なる normalized_text が
+     * 同値と判定され UNIQUE 制約違反になり得るため、ロールバックは行わない。
+     */
+    public function down(): void
+    {
+        Log::warning('[Migration] Rollback not supported for normalized_text collation change');
+    }
+};

--- a/tests/Feature/NormalizedTextCollationTest.php
+++ b/tests/Feature/NormalizedTextCollationTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Archive;
+use App\Models\Channel;
+use App\Models\Song;
+use App\Models\TimestampSongMapping;
+use App\Models\TsItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * normalized_text の照合順序に関するテスト
+ *
+ * utf8mb4_unicode_ci は補助面（絵文字）に重みを持たず「🎵A」と「🎶A」を同値と扱うため、
+ * バイト完全一致で判定するアプリ側とDB側で結果がずれ、
+ * 絵文字で装飾されたタイムスタンプが「紐付けても未紐付のまま」になる不具合が発生していた。
+ */
+class NormalizedTextCollationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create([
+            'email_verified_at' => now(),
+            'role' => User::ROLE_SUPER_ADMIN,
+        ]);
+    }
+
+    /**
+     * normalized_text カラムがバイト比較の照合順序であることを確認（MySQLのみ）
+     */
+    public function test_normalized_text_columns_use_binary_collation(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            $this->markTestSkipped('照合順序の検証はMySQLでのみ実施する');
+        }
+
+        $tables = ['ts_items', 'timestamp_song_mappings', 'timestamp_decompositions'];
+
+        foreach ($tables as $table) {
+            $column = DB::selectOne(
+                'SELECT COLLATION_NAME FROM INFORMATION_SCHEMA.COLUMNS
+                 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?',
+                [$table, 'normalized_text']
+            );
+
+            $this->assertNotNull($column, "{$table}.normalized_text が存在しない");
+            $this->assertEquals(
+                'utf8mb4_bin',
+                $column->COLLATION_NAME,
+                "{$table}.normalized_text はバイト比較の照合順序である必要がある"
+            );
+        }
+    }
+
+    /**
+     * 絵文字だけが異なるテキストがDB上で別レコードとして扱われること
+     */
+    public function test_mappings_with_different_emoji_are_distinct(): void
+    {
+        $song = Song::factory()->create();
+
+        TimestampSongMapping::create([
+            'id' => Str::ulid(),
+            'normalized_text' => '🎵イエスタデイ / official髭男dism',
+            'song_id' => $song->id,
+            'is_not_song' => false,
+            'is_manual' => true,
+            'confidence' => 1.0,
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson(route('songs.linkTimestamp'), [
+            'normalized_text' => '🎶イエスタデイ / official髭男dism',
+            'song_id' => $song->id,
+        ]);
+
+        $response->assertStatus(200);
+
+        // 既存レコードが上書きされず、絵文字ごとに別レコードが作られること
+        $this->assertEquals(2, TimestampSongMapping::count());
+        $this->assertDatabaseHas('timestamp_song_mappings', [
+            'normalized_text' => '🎶イエスタデイ / official髭男dism',
+            'song_id' => $song->id,
+        ]);
+    }
+
+    /**
+     * 絵文字で装飾されたタイムスタンプが、紐付け後に「紐付済」として表示されること
+     */
+    public function test_emoji_decorated_timestamp_is_shown_as_linked_after_link(): void
+    {
+        $channel = Channel::factory()->create();
+        $archive = Archive::factory()->create([
+            'channel_id' => $channel->channel_id,
+            'is_display' => 1,
+        ]);
+        $song = Song::factory()->create();
+
+        // 装飾違いの同一楽曲タイムスタンプ（絵文字の有無・種類が異なる）
+        $texts = [
+            'イエスタデイ / Official髭男dism',
+            '🎵イエスタデイ / Official髭男dism',
+            '🎶イエスタデイ / Official髭男dism',
+        ];
+
+        foreach ($texts as $text) {
+            TsItem::factory()->create([
+                'video_id' => $archive->video_id,
+                'text' => $text,
+                'is_display' => 1,
+            ]);
+        }
+
+        // 先に別の装飾を紐付けておく（照合順序が曖昧だとこのレコードが上書きされる）
+        $this->actingAs($this->user)->postJson(route('songs.linkTimestamp'), [
+            'normalized_text' => '🎵イエスタデイ / official髭男dism',
+            'song_id' => $song->id,
+        ])->assertStatus(200);
+
+        // 対象の装飾違いを紐付ける
+        $this->actingAs($this->user)->postJson(route('songs.linkTimestamp'), [
+            'normalized_text' => '🎶イエスタデイ / official髭男dism',
+            'song_id' => $song->id,
+        ])->assertStatus(200);
+
+        $response = $this->actingAs($this->user)->getJson(route('songs.fetchTimestamps', [
+            'per_page' => 50,
+        ]));
+
+        $response->assertStatus(200);
+
+        $items = collect($response->json('data'))->keyBy('normalized_text');
+
+        $this->assertNotNull(
+            $items->get('🎶イエスタデイ / official髭男dism')['song'] ?? null,
+            '絵文字付きタイムスタンプが紐付済として表示されること'
+        );
+        $this->assertNotNull(
+            $items->get('🎵イエスタデイ / official髭男dism')['song'] ?? null,
+            '先に紐付けた絵文字付きタイムスタンプの紐付けが維持されること'
+        );
+        // 装飾なしは別マッピングのため未紐付のまま
+        $this->assertNull(
+            $items->get('イエスタデイ / official髭男dism')['song'] ?? null,
+            '装飾なしテキストは別マッピングとして扱われること'
+        );
+    }
+}

--- a/tests/Unit/Migrations/ChangeNormalizedTextCollationTest.php
+++ b/tests/Unit/Migrations/ChangeNormalizedTextCollationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Unit\Migrations;
+
+use Tests\TestCase;
+
+/**
+ * normalized_text の照合順序変更マイグレーションが生成するSQLを検証する
+ *
+ * テストは SQLite で動くため、up() は冒頭のドライバ判定で return して
+ * 何も実行されない。つまり生成されるSQLの正しさは、実行では一切検証できない。
+ *
+ * MySQL は CHARACTER SET / COLLATE を型の直後（NULL 可否より前）に要求するので、
+ * 連結順を誤ると ERROR 1064 になりデプロイが止まる。文字列生成だけを
+ * 切り出して固定することで、その退行をSQLite上でも検知できるようにする。
+ */
+class ChangeNormalizedTextCollationTest extends TestCase
+{
+    private function migration(): object
+    {
+        return require database_path(
+            'migrations/2026_08_17_000001_change_normalized_text_collation_to_utf8mb4_bin.php'
+        );
+    }
+
+    /**
+     * CHARACTER SET / COLLATE が型の直後、NULL 可否より前に来ること
+     */
+    public function test_modify_statement_places_collation_before_nullability(): void
+    {
+        $migration = $this->migration();
+
+        $this->assertSame(
+            'ALTER TABLE `ts_items` MODIFY `normalized_text` VARCHAR(255)'
+            .' CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL',
+            $migration::buildModifyStatement('ts_items', 'VARCHAR(255)', 'NULL')
+        );
+
+        $this->assertSame(
+            'ALTER TABLE `timestamp_song_mappings` MODIFY `normalized_text` VARCHAR(255)'
+            .' CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL',
+            $migration::buildModifyStatement('timestamp_song_mappings', 'VARCHAR(255)', 'NOT NULL')
+        );
+    }
+
+    /**
+     * NULL 可否が COLLATE より前に来ていないこと
+     *
+     * この順序が MySQL で ERROR 1064 になる形。文字列の一致だけだと
+     * 意図が読み取りにくいので、順序そのものを主張しておく。
+     */
+    public function test_nullability_never_precedes_collation(): void
+    {
+        $migration = $this->migration();
+
+        foreach ($migration::targetColumns() as $table => [$type, $nullability]) {
+            $sql = $migration::buildModifyStatement($table, $type, $nullability);
+
+            $collatePos = strpos($sql, 'COLLATE');
+            $nullPos = strrpos($sql, $nullability);
+
+            $this->assertNotFalse($collatePos, "COLLATE が含まれていない: {$table}");
+            $this->assertNotFalse($nullPos, "NULL 可否が含まれていない: {$table}");
+            $this->assertLessThan(
+                $nullPos,
+                $collatePos,
+                "COLLATE は NULL 可否より前に置く必要がある: {$table}"
+            );
+        }
+    }
+
+    /**
+     * 変換対象が3テーブルであること
+     *
+     * normalized_text を持つテーブルは ts_items / timestamp_song_mappings /
+     * timestamp_decompositions の3つ。1つでも漏れると、そのテーブルだけ
+     * 照合順序が揃わず UNIQUE / WHERE の意味論がずれる。
+     */
+    public function test_targets_all_tables_having_normalized_text(): void
+    {
+        $migration = $this->migration();
+
+        $this->assertSame(
+            ['ts_items', 'timestamp_song_mappings', 'timestamp_decompositions'],
+            array_keys($migration::targetColumns())
+        );
+    }
+
+    /**
+     * ロールバックが明示的に失敗すること
+     *
+     * 成功したふりをするとスキーマは bin のまま migrations テーブルから
+     * レコードが消え、次の migrate で再度フルリビルドが走る。
+     */
+    public function test_down_throws(): void
+    {
+        $migration = $this->migration();
+
+        $this->expectException(\RuntimeException::class);
+
+        $migration->down();
+    }
+}


### PR DESCRIPTION
## 概要

「イエスタデイ / Official髭男dism」のような絵文字で装飾されたタイムスタンプが、正規化画面で紐付けても「未紐付」のままになる問題の修正。

## 原因

`normalized_text` カラムの照合順序 `utf8mb4_unicode_ci` は UCA 4.0.0 ベースで、補助面（U+10000 以降＝ほとんどの絵文字）に重みを持たない。そのため MySQL 上では **絵文字だけが異なるテキストがすべて同値と判定される**（`🎵イエスタデイ / official髭男dism` = `🎶イエスタデイ / official髭男dism`）。加えて PAD SPACE 照合のため末尾スペースの有無も無視される。

一方アプリ側は `normalized_text` をバイト完全一致で扱う（PHP の `===` / `keyBy` / `get`）ため、DB 側とアプリ側で判定結果がずれる。結果として以下の流れで不整合が起きていた。

1. `SongMappingService::linkTimestamp()` の `where('normalized_text', ...)` が**別の絵文字を持つ既存マッピング行**を拾い、その行を更新してしまう → 対象テキストのマッピング行が作られない
2. 一覧表示（`SongController::fetchTimestamps()`）は PHP 側の `keyBy`/`get` でマッピングを引き当てるため、該当なし＝「未紐付」と表示される

なお、LEFT JOIN 自体は DB の照合順序で成立するため、`mapping_id` は NULL になりません。そのため **「未紐付」と表示されているのに「未紐付」フィルターでは表示されない**という症状も併発します（本件の判別材料になります）。

`TextNormalizer` は絵文字を保持する仕様（`test_normalize_preserves_emoji`）であり、正規化ロジック側の不具合ではありません。

## 変更内容

- `database/migrations/2026_08_17_000001_change_normalized_text_collation_to_utf8mb4_bin.php`
  - `normalized_text` の照合順序を `utf8mb4_bin`（NO PAD・バイト比較）に変更し、DB 側の比較をアプリ側と一致させる
  - `normalized_text` で JOIN / `whereColumn` するテーブルは照合順序を揃える必要がある（揃っていないと `Illegal mix of collations` エラー）ため、`ts_items` / `timestamp_song_mappings` / `timestamp_decompositions` を同時に変換
  - 変換前に、照合順序の違いで誤マッチしていたレコードをログに記録（変換後は「未紐付」に戻るため、どのタイムスタンプの再紐付けが必要かを追跡できる）
  - `utf8mb4_unicode_ci` に戻すと UNIQUE 制約違反になり得るため `down()` は非対応
- `tests/Feature/NormalizedTextCollationTest.php`
  - 照合順序の検証（MySQL のみ実行、SQLite ではスキップ）
  - 絵文字だけが異なるテキストが別マッピングとして扱われること
  - 絵文字付きタイムスタンプが紐付け後に「紐付済」として表示されること
- `CLAUDE.md`: `normalized_text` 系カラムは `utf8mb4_bin` を指定する旨を Database Conventions に追記

## 影響・注意点

- `normalized_text` は `TextNormalizer::normalize()` で小文字化済みのため、バイト比較にしても大文字小文字の取りこぼしは発生しません。`LIKE` 検索も検索語を `normalize()` してから使用しているため影響ありません。
- `ALTER TABLE ... MODIFY` はインデックスの再構築を伴うため、件数の多い `ts_items` ではメンテナンスウィンドウでの実施を推奨します。
- 照合順序の違いで既存マッピングが上書きされていた場合、そのマッピングは誤った楽曲を指している可能性があります。自動修復はできないため、マイグレーションのログ（`normalized_text collation conflicts detected`）を確認のうえ再紐付けをお願いします。

## テスト

- `php artisan test` … 617 passed / 1 skipped（既存の 12 failed はビルド済みアセット（Vite manifest）が無い環境要因で、develop でも同様に失敗します）
- `./vendor/bin/pint --test` … PASS

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYPF92ksFoWEPiCAYuycjD)_