### PR TITLE
fix: 楽曲ガチャがアーカイブ末尾で停止する問題を修正

### DIFF
--- a/app/Services/TimestampService.php
+++ b/app/Services/TimestampService.php
@@ -420,7 +420,11 @@ class TimestampService
     }
 
     /**
-     * 同じ動画内の次のタイムスタンプ（秒数）を取得
+     * 同じ動画内の次の楽曲タイムスタンプ（秒数）を取得
+     *
+     * 抽出条件はgetNextTimestampInArchive()と揃える。
+     * 条件がずれていると「next_ts_numはあるのに次の楽曲は取得できない」状態になり、
+     * 表示更新の監視が行き止まりになる。
      */
     private function getNextTimestampInVideo(string $videoId, ?int $currentTsNum): ?int
     {
@@ -428,13 +432,21 @@ class TimestampService
             return null;
         }
 
-        $nextItem = TsItem::where('video_id', $videoId)
-            ->where('ts_num', '>', $currentTsNum)
-            ->where('is_display', 1)
-            ->whereNotNull('text')
-            ->where('text', '!=', '')
-            ->orderBy('ts_num', 'asc')
-            ->first(['ts_num']);
+        $nextItem = TsItem::query()
+            ->leftJoin('timestamp_song_mappings', 'ts_items.normalized_text', '=', 'timestamp_song_mappings.normalized_text')
+            ->where('ts_items.video_id', $videoId)
+            ->where('ts_items.ts_num', '>', $currentTsNum)
+            ->where('ts_items.is_display', 1)
+            ->whereNotNull('ts_items.text')
+            ->where('ts_items.text', '!=', '')
+            ->whereNotNull('ts_items.normalized_text')
+            // 「楽曲ではない」を除外
+            ->where(function ($q) {
+                $q->whereNull('timestamp_song_mappings.id')
+                    ->orWhere('timestamp_song_mappings.is_not_song', false);
+            })
+            ->orderBy('ts_items.ts_num', 'asc')
+            ->first(['ts_items.ts_num']);
 
         return $nextItem?->ts_num;
     }

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -667,13 +667,10 @@ function registerArchiveListComponent() {
                         this.loadAndPlayVideo(timestamp.video_id, timestamp.ts_num || 0);
                     }
 
-                    // 次のタイムスタンプがある場合は表示更新用の監視を開始
+                    // 表示更新・アーカイブ末尾検知用の監視を開始
                     if (timestamp) {
-                        const endTime = autoReshuffleManager.calculateEndTime(timestamp);
-                        autoReshuffleManager.setEndTime(endTime);
-                        if (endTime !== null) {
-                            autoReshuffleManager.startMonitor();
-                        }
+                        autoReshuffleManager.setEndTime(autoReshuffleManager.calculateEndTime(timestamp));
+                        autoReshuffleManager.startMonitor();
                     }
                 },
 
@@ -716,13 +713,10 @@ function registerArchiveListComponent() {
                         this.loadAndPlayVideo(timestamp.video_id, timestamp.ts_num || 0);
                     }
 
-                    // 次のタイムスタンプがある場合は表示更新用の監視を開始
+                    // 表示更新・アーカイブ末尾検知用の監視を開始
                     if (timestamp) {
-                        const endTime = autoReshuffleManager.calculateEndTime(timestamp);
-                        autoReshuffleManager.setEndTime(endTime);
-                        if (endTime !== null) {
-                            autoReshuffleManager.startMonitor();
-                        }
+                        autoReshuffleManager.setEndTime(autoReshuffleManager.calculateEndTime(timestamp));
+                        autoReshuffleManager.startMonitor();
                     }
                 },
 
@@ -849,6 +843,11 @@ function registerArchiveListComponent() {
                     autoReshuffleManager.onNextTimestampReached = () => {
                         this.updateDisplayForNextTimestamp();
                     };
+
+                    // 自動再抽選OFFでアーカイブ末尾に到達したとき
+                    autoReshuffleManager.onArchiveEndWithoutReshuffle = () => {
+                        toast.info('アーカイブの再生が終わりました。自動再抽選をONにすると次の曲を自動で選びます');
+                    };
                 },
 
                 // YouTube IFrame APIの読み込み
@@ -896,6 +895,8 @@ function registerArchiveListComponent() {
 
                 // 動画プレイヤーを閉じる
                 closeVideoPlayer() {
+                    // 停止時のENDEDで再抽選が走らないよう、先に監視を中断する
+                    autoReshuffleManager.suspend();
                     videoPlayerManager.close(() => this.resetPlayerPosition());
                     updateDocumentTitle(null);
                 },
@@ -996,8 +997,7 @@ function registerArchiveListComponent() {
                         }
 
                         // 自動再抽選用: 終了時刻を計算・設定
-                        const endTime = autoReshuffleManager.calculateEndTime(timestamp);
-                        autoReshuffleManager.setEndTime(endTime);
+                        autoReshuffleManager.setEndTime(autoReshuffleManager.calculateEndTime(timestamp));
 
                         // 動画を再生
                         if (timestamp.video_id) {
@@ -1035,10 +1035,8 @@ function registerArchiveListComponent() {
                         this.showGachaShare = true;
                         this.startGachaShareTimer();
 
-                        // 次のタイムスタンプがある場合は表示更新用の監視を開始
-                        if (endTime !== null) {
-                            autoReshuffleManager.startMonitor();
-                        }
+                        // 表示更新・アーカイブ末尾検知用の監視を開始
+                        autoReshuffleManager.startMonitor();
                     } catch (error) {
                         console.error('ランダム再生に失敗しました:', error);
                         toast.error(error.message || 'ランダム再生に失敗しました');
@@ -1221,16 +1219,19 @@ function registerArchiveListComponent() {
                             updateDocumentTitle(this.selectedSong);
 
                             // 次のタイムスタンプまでの監視を再設定
-                            const endTime = autoReshuffleManager.calculateEndTime(nextTimestamp);
-                            autoReshuffleManager.setEndTime(endTime);
-                            if (endTime !== null) {
-                                autoReshuffleManager.startMonitor();
-                            }
+                            autoReshuffleManager.setEndTime(autoReshuffleManager.calculateEndTime(nextTimestamp));
+                            autoReshuffleManager.startMonitor();
                         } else {
+                            // アーカイブ内に次の楽曲がない場合は末尾検知のみの監視に切り替える
                             console.debug('[DisplayUpdate] no next timestamp found (last in archive)');
+                            autoReshuffleManager.setEndTime(null);
+                            autoReshuffleManager.startMonitor();
                         }
                     } catch (error) {
                         console.error('[DisplayUpdate] API error:', error);
+                        // 取得に失敗しても末尾検知は継続する
+                        autoReshuffleManager.setEndTime(null);
+                        autoReshuffleManager.startMonitor();
                     }
                 },
 
@@ -1272,8 +1273,7 @@ function registerArchiveListComponent() {
                         }
 
                         // 自動再抽選用: 終了時刻を計算・設定
-                        const endTime = autoReshuffleManager.calculateEndTime(timestamp);
-                        autoReshuffleManager.setEndTime(endTime);
+                        autoReshuffleManager.setEndTime(autoReshuffleManager.calculateEndTime(timestamp));
 
                         // 動画を再生（同じアーカイブ内なのでシーク）
                         if (timestamp.video_id) {
@@ -1288,10 +1288,8 @@ function registerArchiveListComponent() {
                             toast.success('次の曲を再生します');
                         }
 
-                        // 次のタイムスタンプがある場合は表示更新用の監視を開始
-                        if (endTime !== null) {
-                            autoReshuffleManager.startMonitor();
-                        }
+                        // 表示更新・アーカイブ末尾検知用の監視を開始
+                        autoReshuffleManager.startMonitor();
                     } finally {
                         this.isPlaybackTransitioning = false;
                     }

--- a/resources/js/channels/managers/AutoReshuffleManager.js
+++ b/resources/js/channels/managers/AutoReshuffleManager.js
@@ -29,11 +29,17 @@ export class AutoReshuffleManager {
         this.lastPlaybackTime = 0;
         this.stallCount = 0;
 
+        // アーカイブ末尾の多重処理防止フラグ
+        // 動画終端の検知はENDEDイベント・監視・PAUSEDの3経路があるため、
+        // 1回の再生につき1度だけ末尾処理を実行する
+        this.archiveEndHandled = false;
+
         // コールバック
         this.onSongEnd = null;          // 動画終了時に呼び出される（自動再抽選用）
         this.onStallDetected = null;    // スタック検知時に呼び出される
         this.onBufferingTimeout = null; // バッファリングタイムアウト時に呼び出される
         this.onNextTimestampReached = null; // 次のタイムスタンプ到達時に呼び出される（表示更新用）
+        this.onArchiveEndWithoutReshuffle = null; // 自動再抽選OFFで末尾に到達したときに呼び出される
     }
 
     /**
@@ -119,6 +125,8 @@ export class AutoReshuffleManager {
     setEndTime(endTime) {
         console.debug('[Monitor] setEndTime:', endTime);
         this.currentSongEndTime = endTime;
+        // 新しい再生位置に移ったので末尾処理フラグをリセット
+        this.archiveEndHandled = false;
     }
 
     /**
@@ -131,14 +139,16 @@ export class AutoReshuffleManager {
 
     /**
      * 再生位置監視を開始
+     *
+     * 次のタイムスタンプがない（＝アーカイブ内の最後の楽曲）場合も監視を続ける。
+     * ENDEDイベントが届かないアーカイブでも末尾を検知できるようにするため。
      */
     startMonitor() {
         // 既存の監視を停止
         this.stopMonitor();
 
-        if (!videoPlayerManager.isInitialized() || this.currentSongEndTime === null) {
-            console.debug('[Monitor] startMonitor aborted: initialized=%s, endTime=%s',
-                videoPlayerManager.isInitialized(), this.currentSongEndTime);
+        if (!videoPlayerManager.isInitialized()) {
+            console.debug('[Monitor] startMonitor aborted: player not initialized');
             return;
         }
 
@@ -160,9 +170,27 @@ export class AutoReshuffleManager {
 
             const currentTime = videoPlayerManager.getCurrentTime();
             const isPlaying = videoPlayerManager.getIsPlaying();
+            const nearVideoEnd = this.isNearVideoEnd(currentTime);
+
+            // 動画終端に到達（ENDEDイベントが届かないケースの保険）
+            // 再生中のみ判定する。停止中は動画の切り替え待ちの可能性があり、
+            // 前の動画の終端値を拾って再抽選が連鎖するおそれがあるため
+            if (isPlaying && nearVideoEnd) {
+                console.debug('[Monitor] videoEndReached: currentTime=%s, duration=%s',
+                    currentTime, videoPlayerManager.getDuration());
+                this.handleArchiveEnd();
+                return;
+            }
+
+            // 終端から離れた位置を再生している（シーク戻しなど）場合は
+            // 末尾処理フラグを戻し、再度末尾に到達したときに処理できるようにする
+            if (this.archiveEndHandled && !nearVideoEnd) {
+                this.archiveEndHandled = false;
+            }
 
             // スタック検知: 再生中なのに時間が進まない状態を検知
-            if (isPlaying) {
+            // 自動再抽選がOFFのときは勝手に次の曲へ進めない（バッファリング検知と同じ扱い）
+            if (isPlaying && this.enabled) {
                 if (Math.abs(currentTime - this.lastPlaybackTime) < 0.1) {
                     this.stallCount++;
                     if (this.stallCount >= MAX_STALL_COUNT) {
@@ -182,7 +210,7 @@ export class AutoReshuffleManager {
 
             // 次のタイムスタンプに到達（表示更新のみ、動画は継続再生）
             // フェードアウトは行わない
-            if (currentTime >= this.currentSongEndTime) {
+            if (this.currentSongEndTime !== null && currentTime >= this.currentSongEndTime) {
                 console.debug('[Monitor] nextTimestampReached: currentTime=%s, endTime=%s',
                     currentTime, this.currentSongEndTime);
                 this.stopMonitor();
@@ -191,6 +219,69 @@ export class AutoReshuffleManager {
                 }
             }
         }, CHECK_INTERVAL);
+    }
+
+    /**
+     * 動画の終端付近かどうか
+     *
+     * 動画長が取得できない（ライブアーカイブのメタデータ未確定など）場合や、
+     * 動画の切り替えが完了していない場合は判定できないためfalseを返す。
+     *
+     * @param {number} currentTime - 現在の再生位置（秒）
+     * @returns {boolean}
+     */
+    isNearVideoEnd(currentTime) {
+        const VIDEO_END_THRESHOLD = 1.5; // 終端とみなす残り秒数
+
+        if (!videoPlayerManager.isCurrentVideoLoaded()) {
+            return false;
+        }
+
+        const duration = videoPlayerManager.getDuration();
+
+        return duration > 0 && currentTime >= duration - VIDEO_END_THRESHOLD;
+    }
+
+    /**
+     * アーカイブ末尾到達時の処理
+     *
+     * ENDEDイベント・再生位置監視・終端での一時停止のいずれから呼ばれても
+     * 1回の再生につき1度だけ処理する。
+     */
+    handleArchiveEnd() {
+        if (this.archiveEndHandled) {
+            return;
+        }
+        this.archiveEndHandled = true;
+        this.stopMonitor();
+
+        if (!this.enabled) {
+            // 自動再抽選OFFのときは何も選ばずに停止する（仕様）
+            // ただし無言で止まると不具合に見えるため呼び出し元に通知する
+            console.debug('[Monitor] archiveEnd (auto reshuffle off)');
+            if (this.onArchiveEndWithoutReshuffle) {
+                this.onArchiveEndWithoutReshuffle();
+            }
+            return;
+        }
+
+        console.debug('[Monitor] archiveEnd: reshuffling');
+        if (this.onSongEnd) {
+            this.onSongEnd();
+        }
+    }
+
+    /**
+     * 監視を中断し、以降の末尾処理を抑止する
+     *
+     * プレイヤーを閉じたときなど、stopVideo()由来のENDEDで
+     * 意図しない再抽選が走らないようにするために使う。
+     */
+    suspend() {
+        this.stopMonitor();
+        this.clearBufferingTimeout();
+        this.currentSongEndTime = null;
+        this.archiveEndHandled = true;
     }
 
     /**
@@ -339,8 +430,9 @@ export class AutoReshuffleManager {
             if (this.needsFadeIn) {
                 this.startFadeIn();
             }
-            // 一時停止から再開した場合、表示更新用の監視を再開
-            if (this.currentSongEndTime !== null && !this.reshuffleMonitorId) {
+            // 一時停止から再開した場合、監視を再開
+            // 次のタイムスタンプがない（最後の楽曲）場合も末尾検知のため監視する
+            if (!this.reshuffleMonitorId) {
                 this.startMonitor();
             }
         }
@@ -352,14 +444,16 @@ export class AutoReshuffleManager {
             this.clearBufferingTimeout();
         }
 
-        // 動画終了時に次のタイムスタンプに遷移（自動再抽選が有効な場合）
-        if (event.data === YT.PlayerState.ENDED && this.enabled) {
-            this.stopMonitor();
-            if (this.onSongEnd) {
-                this.onSongEnd();
-            }
+        // 動画終了時はアーカイブ末尾として扱う
+        if (event.data === YT.PlayerState.ENDED) {
+            this.handleArchiveEnd();
         } else if (event.data === YT.PlayerState.PAUSED) {
-            this.stopMonitor();
+            // 終端で一時停止扱いになるプレイヤーもあるため、末尾かどうかを確認する
+            if (this.isNearVideoEnd(videoPlayerManager.getCurrentTime())) {
+                this.handleArchiveEnd();
+            } else {
+                this.stopMonitor();
+            }
         }
     }
 

--- a/resources/js/channels/managers/AutoReshuffleManager.js
+++ b/resources/js/channels/managers/AutoReshuffleManager.js
@@ -67,8 +67,10 @@ export class AutoReshuffleManager {
         this.saveSettings();
 
         if (this.enabled) {
-            // ONにした場合、現在再生中で終了時刻が設定されていれば監視開始
-            if (isPlaying && this.currentSongEndTime !== null) {
+            // ONにした場合、再生中であれば監視開始。
+            // 終了時刻がない（＝アーカイブ内の最後の楽曲）場合も
+            // 末尾検知のために監視する必要があるため条件に含めない
+            if (isPlaying) {
                 this.startMonitor();
             }
             toast.success('自動再抽選をONにしました');

--- a/resources/js/channels/managers/AutoReshuffleManager.js
+++ b/resources/js/channels/managers/AutoReshuffleManager.js
@@ -280,7 +280,7 @@ export class AutoReshuffleManager {
     suspend() {
         this.stopMonitor();
         this.clearBufferingTimeout();
-        this.currentSongEndTime = null;
+        // 終了時刻は保持する。再度再生したときに曲送り表示を継続するため
         this.archiveEndHandled = true;
     }
 

--- a/resources/js/channels/managers/VideoPlayerManager.js
+++ b/resources/js/channels/managers/VideoPlayerManager.js
@@ -405,6 +405,58 @@ export class VideoPlayerManager {
     }
 
     /**
+     * 動画の長さ（秒）を取得
+     *
+     * メタデータ未読み込み時や取得できない場合は0を返す。
+     *
+     * @returns {number}
+     */
+    getDuration() {
+        if (this.player && typeof this.player.getDuration === 'function') {
+            const duration = this.player.getDuration();
+            return typeof duration === 'number' && isFinite(duration) && duration > 0 ? duration : 0;
+        }
+        return 0;
+    }
+
+    /**
+     * 実際にプレイヤーに読み込まれている動画IDを取得
+     *
+     * loadAndPlay()直後は切り替えが完了しておらず、前の動画のIDが返る。
+     * 取得手段がない場合はnullを返す。
+     *
+     * @returns {string|null}
+     */
+    getPlayingVideoId() {
+        if (!this.player || typeof this.player.getVideoData !== 'function') {
+            return null;
+        }
+
+        try {
+            return this.player.getVideoData()?.video_id || null;
+        } catch (error) {
+            // getVideoDataは非公開APIのため、取得できない場合は判定を諦める
+            return null;
+        }
+    }
+
+    /**
+     * 再生指示した動画の読み込みが完了しているかどうか
+     *
+     * 動画の切り替え中に前の動画の再生位置・長さを参照してしまうのを防ぐために使う。
+     * 判定手段がない場合は処理を止めないようtrueを返す。
+     *
+     * @returns {boolean}
+     */
+    isCurrentVideoLoaded() {
+        const playingVideoId = this.getPlayingVideoId();
+        if (playingVideoId === null || this.currentVideoId === null) {
+            return true;
+        }
+        return playingVideoId === this.currentVideoId;
+    }
+
+    /**
      * プレイヤーが初期化済みかどうか
      * @returns {boolean}
      */

--- a/tests/Unit/Services/TimestampServiceRandomTest.php
+++ b/tests/Unit/Services/TimestampServiceRandomTest.php
@@ -275,4 +275,59 @@ class TimestampServiceRandomTest extends TestCase
         $this->assertEquals('3曲目', $result['text']);
         $this->assertEquals(360, $result['ts_num']);
     }
+
+    public function test_next_ts_num_skips_not_song_items(): void
+    {
+        // 「楽曲ではない」項目が next_ts_num に混ざると、その時刻に表示更新が走った際に
+        // 次の楽曲が取得できず監視が行き止まりになる
+        $this->createTsItem(['text' => '1曲目', 'ts_text' => '0:00', 'ts_num' => 0]);
+        $notSongItem = $this->createTsItem(['text' => 'MC', 'ts_text' => '3:00', 'ts_num' => 180]);
+        $this->createTsItem(['text' => '3曲目', 'ts_text' => '6:00', 'ts_num' => 360]);
+
+        TimestampSongMapping::create([
+            'id' => Str::ulid(),
+            'normalized_text' => $notSongItem->normalized_text,
+            'is_not_song' => true,
+        ]);
+
+        $result = $this->service->getNextTimestampInArchive($this->channel, $this->archive->video_id, 0);
+
+        $this->assertNotNull($result);
+        $this->assertEquals(360, $result['ts_num']);
+        // 3曲目の後には楽曲がないため末尾として扱われる
+        $this->assertNull($result['next_ts_num']);
+        $this->assertTrue($result['is_last_in_archive']);
+    }
+
+    public function test_next_ts_num_marks_last_song_followed_by_not_song_as_last(): void
+    {
+        // 最後の楽曲の後ろに「楽曲ではない」項目だけが残るケース
+        $this->createTsItem(['text' => '最後の曲', 'ts_text' => '0:00', 'ts_num' => 0]);
+        $endingItem = $this->createTsItem(['text' => 'エンディング', 'ts_text' => '5:00', 'ts_num' => 300]);
+
+        TimestampSongMapping::create([
+            'id' => Str::ulid(),
+            'normalized_text' => $endingItem->normalized_text,
+            'is_not_song' => true,
+        ]);
+
+        $result = $this->service->getRandomTimestamp($this->channel);
+
+        $this->assertNotNull($result);
+        $this->assertEquals('最後の曲', $result['text']);
+        $this->assertNull($result['next_ts_num']);
+    }
+
+    public function test_next_ts_num_skips_hidden_items(): void
+    {
+        $this->createTsItem(['text' => '1曲目', 'ts_text' => '0:00', 'ts_num' => 0]);
+        $this->createTsItem(['text' => '非表示曲', 'ts_text' => '3:00', 'ts_num' => 180, 'is_display' => 0]);
+        $this->createTsItem(['text' => '3曲目', 'ts_text' => '6:00', 'ts_num' => 360]);
+
+        $result = $this->service->getNextTimestampInArchive($this->channel, $this->archive->video_id, 0);
+
+        $this->assertNotNull($result);
+        $this->assertEquals(360, $result['ts_num']);
+        $this->assertNull($result['next_ts_num']);
+    }
 }


### PR DESCRIPTION
@CodiumAI-Agent /improve

## 概要

楽曲ガチャでアーカイブの最後まで進んだとき、次の曲が抽選されずに再生が止まってしまう事象を修正します。

## 原因

アーカイブ末尾での再抽選が YouTube IFrame API の `ENDED` イベント**単独**に依存していました。

1. **最後の楽曲では監視が一切動かない**
   `calculateEndTime()` は `next_ts_num` が null（＝アーカイブ内の最後）だと null を返し、呼び出し側は `endTime !== null` のときしか `startMonitor()` していませんでした。そのため最後の楽曲の再生中は再生位置監視もスタック検知も動かず、`ENDED` が届かなければ復帰手段がありませんでした。

2. **表示更新が行き止まりになる**
   `next_ts_num` を作る `getNextTimestampInVideo()` は `is_not_song` を除外していないのに、`getNextTimestampInArchive()` は除外していました。末尾に雑談・告知などの非楽曲タイムスタンプがあるアーカイブでは、監視がその時刻に到達 → 次の楽曲は取得できず null → 何もせず終了、となり以降まったくの受け身になっていました。API が返している `is_last_in_archive` もログ出力にしか使われていませんでした。

3. **`ENDED` だけが自動再抽選ONでガードされていた**
   表示更新用の監視は自動再抽選の状態に関係なく動くため、OFF のままでも曲送り表示は進み「自動再生されている」ように見えます。ところが末尾処理だけ OFF では動かず、無言で停止していました。

## 変更内容

### フロントエンド

- `AutoReshuffleManager`
  - 次のタイムスタンプがない場合も監視を継続し、動画長ベースで終端を検知して再抽選する（`ENDED` が届かないケースの保険）
  - 終端で一時停止扱いになるプレイヤー向けに `PAUSED` でも終端かどうかを判定する
  - `ENDED` / 監視 / `PAUSED` の多重発火を防ぐ `archiveEndHandled` フラグを追加。シーク戻し時は自動で解除する
  - 自動再抽選OFFで末尾に到達した場合はコールバックで呼び出し元に通知する
  - 監視範囲の拡大に伴い、スタック検知をバッファリング検知と同様に自動再抽選ON時のみに限定する
- `VideoPlayerManager`
  - `getDuration()` / `getPlayingVideoId()` / `isCurrentVideoLoaded()` を追加。動画の切り替え中に前の動画の終端値を拾って再抽選が連鎖するのを防ぐ
- `archive-list.js`
  - 各再生経路で `endTime` の有無にかかわらず監視を開始する
  - 表示更新で次の楽曲が取得できなかった場合・API エラー時も、末尾検知のみの監視に切り替える
  - 自動再抽選OFFで末尾に到達した際にトーストで通知する
  - プレイヤーを閉じた際の `stopVideo()` 由来の `ENDED` で再抽選が走らないよう監視を中断する

### バックエンド

- `TimestampService::getNextTimestampInVideo()` の抽出条件を `getNextTimestampInArchive()` と揃え、「楽曲ではない」項目・`normalized_text` が null の項目を除外する。これにより `next_ts_num` と `is_last_in_archive` が実態と一致する

## テスト

- `TimestampServiceRandomTest` に3ケース追加
  - `next_ts_num` が「楽曲ではない」項目をスキップすること
  - 最後の楽曲の後ろに非楽曲項目だけが残る場合に末尾と判定されること
  - `next_ts_num` が非表示項目をスキップすること
- `php artisan test`: 628 passed（警告2件は本変更前から発生している既存のもの）
- `npm run build` 成功
- `./vendor/bin/pint --test` PASS

## 動作確認のお願い

ブラウザでの再生を伴うため、以下の観点でご確認いただけると助かります。

- 自動再抽選ONでアーカイブ末尾まで再生 → 次の曲が抽選されること
- アーカイブ途中の曲送り表示がこれまで通り動くこと
- 自動再抽選OFFで末尾到達時にトーストが表示されること
- 連続で再抽選が走るなどの誤検知がないこと

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7E1nQ3v1Pu8c8e9QakuiS)_