### PR TITLE
fix: アーカイブ一覧のサムネイルが大きくなりすぎる問題を修正

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -555,30 +555,32 @@
 
 .channel-archive-header {
     display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    padding: 1rem 1rem 0.75rem;
-}
-
-.channel-archive-header-compact {
     flex-direction: row;
     align-items: flex-start;
+    gap: 0.75rem;
+    padding: 1rem 1rem 0.75rem;
 }
 
 .channel-archive-thumb-wrap {
     position: relative;
     display: block;
+    /* サムネイルの実体はYouTubeのmedium（320x180）なので、
+       拡大表示すると粗が目立つ。表示幅は元画像より小さく保つ */
+    width: 120px;
     border-radius: 0.625rem;
     overflow: hidden;
     flex-shrink: 0;
 }
 
-.channel-archive-thumb-compact {
-    width: 120px;
+@media (min-width: 640px) {
+    .channel-archive-thumb-wrap {
+        width: 200px;
+    }
 }
 
 .channel-archive-thumb {
     width: 100%;
+    aspect-ratio: 16 / 9;
     object-fit: cover;
     display: block;
     transition: transform 0.3s ease;
@@ -615,6 +617,7 @@
 
 .channel-archive-info {
     min-width: 0;
+    flex: 1;
 }
 
 .channel-archive-title {

--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -122,7 +122,6 @@ function registerArchiveListComponent() {
                 publishedTo: '',
                 loading: false,
                 error: null,
-                isFiltered: false,
                 filterExpanded: false,
                 recentFilters: JSON.parse(localStorage.getItem('recentFilters') || '[]'),
 
@@ -234,9 +233,6 @@ function registerArchiveListComponent() {
                         query: this.archiveQuery,
                         tsFilter: this.tsFlg
                     });
-
-                    const hasQuery = this.archiveQuery.length > 0;
-                    this.$dispatch('filter-changed', hasQuery);
 
                     this.fetchData(this.firstUrl(params.toString()));
                     this.updateURL();

--- a/resources/views/channels/partials/archives-tab.blade.php
+++ b/resources/views/channels/partials/archives-tab.blade.php
@@ -5,17 +5,16 @@
         :current-page="1"
         :last-page="1"
     ></x-pagination>
-    <div id="archives" x-data="{ isFiltered : false }"
-         @filter-changed.window="isFiltered = $event.detail"
-         class="flex flex-col items-center w-[100%] gap-4">
+    <div id="archives" class="flex flex-col items-center w-[100%] gap-4">
         {{-- アーカイブリスト --}}
         <template x-for="archive in (archives.data || [])" :key="archive.id">
             <div class="channel-archive-card w-[100%] max-w-5xl">
                 {{-- ヘッダー: サムネイル + タイトル --}}
-                <div class="channel-archive-header" :class="isFiltered ? 'channel-archive-header-compact' : ''">
+                <div class="channel-archive-header">
                     <a :href="getArchiveUrl(archive.video_id || '')" target="_blank" rel="noopener noreferrer"
-                       class="channel-archive-thumb-wrap" :class="isFiltered ? 'channel-archive-thumb-compact' : ''">
+                       class="channel-archive-thumb-wrap">
                         <img :src="escapeHTML(archive.thumbnail || '')" alt="サムネイル" loading="lazy"
+                            width="320" height="180"
                             class="channel-archive-thumb"/>
                         <div class="channel-archive-thumb-overlay">
                             <svg class="w-8 h-8 text-white drop-shadow-lg" viewBox="0 0 24 24" fill="currentColor">
@@ -23,7 +22,7 @@
                             </svg>
                         </div>
                     </a>
-                    <div class="channel-archive-info" :class="isFiltered ? 'flex-1' : ''">
+                    <div class="channel-archive-info">
                         <h4 class="channel-archive-title"
                             x-data="{ expanded: false }"
                             :class="expanded ? '' : 'truncate'"

--- a/resources/views/components/search.blade.php
+++ b/resources/views/components/search.blade.php
@@ -52,7 +52,6 @@
                     params.append('visible', this.visibleFlg);
                     params.append('ts', this.tsFlg);
 
-                    this.$dispatch('filter-changed', this.query.length > 0);
                     this.$dispatch('search-results', params.toString());
 
                 } catch (error) {


### PR DESCRIPTION
## 概要

チャンネルページのアーカイブタブ（`?view=archives`）で、サムネイルが大きく表示されすぎる問題を修正しました。

## 原因

`archives-tab.blade.php` のヘッダーは、**検索中（`isFiltered`）のときだけ**横並びのコンパクト表示になる作りでした。検索していない通常表示では `.channel-archive-header` が `flex-direction: column` のため、サムネイルがカード幅（`max-w-5xl` = 1024px）いっぱいまで広がっていました。

さらに、保存しているサムネイルは `YouTubeApiService::getArchives()` が `getThumbnails()->getMedium()` を使っているため実体は **320×180（mqdefault）** です。これを1024px幅で表示すると約3.2倍の拡大となり、画質の粗さが目立っていました。

## 変更内容

### `resources/css/app.css`
- `.channel-archive-header` を常に `flex-direction: row` に変更（`-compact` 派生クラスを廃止）
- `.channel-archive-thumb-wrap` の幅を **640px未満: 120px / 640px以上: 200px** に固定。いずれも元画像の320pxを下回るため、拡大による劣化が発生しません
- `.channel-archive-thumb` に `aspect-ratio: 16 / 9` を追加
- `.channel-archive-info` に `flex: 1` を追加（従来 Alpine の `:class` で付与していたものをCSSへ移動）

### `resources/views/channels/partials/archives-tab.blade.php`
- `isFiltered` によるレイアウト分岐を削除
- `<img>` に `width="320" height="180"` を付与し、読み込み前後のレイアウトシフトを防止

### 不要になったコードの削除
レイアウト切り替えが不要になり `filter-changed` の購読者がいなくなったため、送出側も削除しました（`resources/` 全体を grep して他に購読箇所がないことを確認済み）。

- `resources/js/channels/archive-list.js`: 未使用の `isFiltered` state と `$dispatch('filter-changed', ...)`
- `resources/views/components/search.blade.php`: `$dispatch('filter-changed', ...)`（`search-results` の送出は維持）

## 表示確認

ビルド済みCSSを使った静的プレビューを Chrome headless でレンダリングして確認しました。

- **640px以上**: サムネ200px、右にタイトルと公開日、下にタイムスタンプ一覧
- **640px未満**: サムネ120px、タイトルは `truncate` で省略（`offsetWidth=288 / scrollWidth=527 / overflow=hidden` を実測して確認）

## 確認

- `php artisan test` → **627 passed (1963 assertions)**
- `./vendor/bin/pint --test` → **PASS (240 files)**
- `npm run build` → 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)