### PR TITLE
fix: アーカイブ末尾の案内と自動再抽選ONの取りこぼしを修正

### DIFF
--- a/resources/js/channels/archive-list.js
+++ b/resources/js/channels/archive-list.js
@@ -665,6 +665,8 @@ function registerArchiveListComponent() {
 
                     // 表示更新・アーカイブ末尾検知用の監視を開始
                     if (timestamp) {
+                        // 一覧からの手動選択なので連続再生ではない
+                        autoReshuffleManager.setContinuousPlayback(false);
                         autoReshuffleManager.setEndTime(autoReshuffleManager.calculateEndTime(timestamp));
                         autoReshuffleManager.startMonitor();
                     }
@@ -711,6 +713,8 @@ function registerArchiveListComponent() {
 
                     // 表示更新・アーカイブ末尾検知用の監視を開始
                     if (timestamp) {
+                        // 一覧からの手動選択なので連続再生ではない
+                        autoReshuffleManager.setContinuousPlayback(false);
                         autoReshuffleManager.setEndTime(autoReshuffleManager.calculateEndTime(timestamp));
                         autoReshuffleManager.startMonitor();
                     }
@@ -841,8 +845,12 @@ function registerArchiveListComponent() {
                     };
 
                     // 自動再抽選OFFでアーカイブ末尾に到達したとき
+                    // 案内は「いま押せる操作」に限定する。ここに到達した時点では
+                    // 動画が停止しており（ENDEDで isPlaying が false になる）、
+                    // 自動再抽選をONにしても監視を開始できないため、
+                    // 「ONにすれば続く」という案内は成立しない
                     autoReshuffleManager.onArchiveEndWithoutReshuffle = () => {
-                        toast.info('アーカイブの再生が終わりました。自動再抽選をONにすると次の曲を自動で選びます');
+                        toast.info('アーカイブの終わりに到達しました。「次の曲」ボタンかガチャで続けられます');
                     };
                 },
 
@@ -993,6 +1001,8 @@ function registerArchiveListComponent() {
                         }
 
                         // 自動再抽選用: 終了時刻を計算・設定
+                        // ガチャ由来なので連続再生として扱う
+                        autoReshuffleManager.setContinuousPlayback(true);
                         autoReshuffleManager.setEndTime(autoReshuffleManager.calculateEndTime(timestamp));
 
                         // 動画を再生
@@ -1269,6 +1279,8 @@ function registerArchiveListComponent() {
                         }
 
                         // 自動再抽選用: 終了時刻を計算・設定
+                        // 曲送り由来なので連続再生として扱う
+                        autoReshuffleManager.setContinuousPlayback(true);
                         autoReshuffleManager.setEndTime(autoReshuffleManager.calculateEndTime(timestamp));
 
                         // 動画を再生（同じアーカイブ内なのでシーク）

--- a/resources/js/channels/managers/AutoReshuffleManager.js
+++ b/resources/js/channels/managers/AutoReshuffleManager.js
@@ -34,6 +34,12 @@ export class AutoReshuffleManager {
         // 1回の再生につき1度だけ末尾処理を実行する
         this.archiveEndHandled = false;
 
+        // 連続再生（ガチャ・曲送り）由来の再生かどうか
+        // 末尾に到達したときの案内を出すかの判定に使う。一覧クリックや
+        // シェアリンク（?play=）単独の再生では案内しても続ける手段がないため、
+        // 再生の起点側で明示的に設定する（起点が分かるのは呼び出し側だけ）
+        this.continuousPlayback = false;
+
         // コールバック
         this.onSongEnd = null;          // 動画終了時に呼び出される（自動再抽選用）
         this.onStallDetected = null;    // スタック検知時に呼び出される
@@ -71,6 +77,15 @@ export class AutoReshuffleManager {
             // 終了時刻がない（＝アーカイブ内の最後の楽曲）場合も
             // 末尾検知のために監視する必要があるため条件に含めない
             if (isPlaying) {
+                // 末尾処理済みフラグを解除する。終端付近で末尾処理が走った後は
+                // 監視ループの解除条件（終端から離れたら解除）が成立しないため、
+                // 解除しないと監視を再開しても handleArchiveEnd() が空振りする。
+                //
+                // この代入は必ず isPlaying の内側に置くこと。外に出すと、
+                // プレイヤーを閉じたあと（suspend() がフラグを立てて stopVideo() 由来の
+                // ENDED を抑止している状態）にトグルを操作しただけで抑止が解け、
+                // 閉じた動画の ENDED で再抽選が走る。
+                this.archiveEndHandled = false;
                 this.startMonitor();
             }
             toast.success('自動再抽選をONにしました');
@@ -129,6 +144,18 @@ export class AutoReshuffleManager {
         this.currentSongEndTime = endTime;
         // 新しい再生位置に移ったので末尾処理フラグをリセット
         this.archiveEndHandled = false;
+    }
+
+    /**
+     * この再生が連続再生（ガチャ・曲送り）由来かどうかを設定する
+     *
+     * 末尾に到達したときに案内を出すかの判定に使う。起点が分かるのは
+     * 呼び出し側だけなので、再生を開始する各経路で明示的に設定する。
+     *
+     * @param {boolean} isContinuous
+     */
+    setContinuousPlayback(isContinuous) {
+        this.continuousPlayback = isContinuous;
     }
 
     /**
@@ -259,9 +286,12 @@ export class AutoReshuffleManager {
 
         if (!this.enabled) {
             // 自動再抽選OFFのときは何も選ばずに停止する（仕様）
-            // ただし無言で止まると不具合に見えるため呼び出し元に通知する
+            // ただし無言で止まると不具合に見えるため呼び出し元に通知する。
+            // 通知するのは連続再生（ガチャ・曲送り）由来のときだけ。一覧クリックや
+            // シェアリンク単独の再生では selectedTimestamp が無く「次の曲」も押せないため、
+            // 案内しても実行できる操作がない
             console.debug('[Monitor] archiveEnd (auto reshuffle off)');
-            if (this.onArchiveEndWithoutReshuffle) {
+            if (this.continuousPlayback && this.onArchiveEndWithoutReshuffle) {
                 this.onArchiveEndWithoutReshuffle();
             }
             return;


### PR DESCRIPTION
## 概要

cycle-review で #646 に対して裏取り済みだった残件2件に対応します。#648 のマージ時点で `9fc3612` が入りましたが、**指摘の一部しか直っていなかった**ことが独立した2つの検証で確認されたため、その続きです。

## 1. 末尾処理済みフラグが解除されず次の曲へ進まない（must）

`9fc3612` で `toggle()` の監視開始条件は `isPlaying` のみに揃いましたが、`archiveEndHandled` が立ったままなので `handleArchiveEnd()` が早期 return を続け、**監視は始まるのに次の曲へ進みません**。監視ループの解除条件（`AutoReshuffleManager.js:189`）は「終端から離れたら解除」なので、終端に留まる間は解除されません。

実測（Node ハーネス、develop 実コード）:
```
S4-b トースト後にON: 監視開始 = true , archiveEndHandled = true
S4-c ON後に監視が回った結果: songEnd = 0 , monitorAlive = true
S5  archiveEndHandled をリセットすれば進む: songEnd = 1
```

ONにしたときにフラグを解除します。**この代入は必ず `if (isPlaying)` の内側**です。外に出すと、プレイヤーを閉じたあと（`suspend()` がフラグを立てて `stopVideo()` 由来の ENDED を抑止している状態）にトグルを操作しただけで抑止が解け、閉じた動画の ENDED で再抽選が走ります。破壊実験で実証済みです。

### 効果範囲の限界（重要）

**本修正が効くのは「再生中かつ終端1.5秒以内」に限られます。** `VideoPlayerManager.js:143` は ENDED 時に `isPlaying = false` を代入してから状態変更を通知するため、再生が終わりきった後は `toggle(this.isPlaying)` に false が渡り監視自体を開始できません（実測 `S6 監視開始 = false`）。

トースト自体が終端1.5秒前に出るので、読んで押す余裕はほぼありません。**「トーストを見てONにすれば続く」というユーザー体験はこの修正では改善しません。** 停止後もONで続けられるようにする案（`archiveEndPending` を持たせる）は実測で成立を確認しましたが、再生し直して途中でONにすると即座に飛ぶ穴があり、クリア箇所が4つに散るため別Issueとします。

## 2. 末尾の案内が成立しない状態で出る（should）

案内は3点で実態と合っていませんでした。

| 症状 | 実測 |
|---|---|
| (a) 一覧クリックやシェアリンク単独の再生でも出る | `S8 一覧クリック相当（ガチャ未使用・OFF）でも通知: off=1` |
| (b) 残り1.5秒の再生中に「再生が終わりました」と出る | `currentTime=598.6/600, isPlaying=true` で発火 |
| (c) 案内どおりONにしても動かない | 上記1のとおり |

**(a) はシェアリンク `?play=` が最悪ケースです。** `selectedTimestamp` が null のまま再生するため、案内は出るのに「次の曲」ボタンも無効で、実行できる操作が一つもありません。これはサイクル1のレビューでは誰も報告していませんでした。

再生の起点を `continuousPlayback` として明示的に持たせ、連続再生（ガチャ・曲送り）由来のときだけ案内します。あわせて文言を実際に押せる操作に差し替えます。

```
- アーカイブの再生が終わりました。自動再抽選をONにすると次の曲を自動で選びます
+ アーカイブの終わりに到達しました。「次の曲」ボタンかガチャで続けられます
```

「次の曲」ボタン（`distribution-panel.blade.php`）は `:disabled` が `video_id` と `isSkippingToNext` しか見ないため **ENDED 後も有効**で、次が無ければランダム再生にフォールバックします。

### 検討して採らなかった案

- **`gachaShareData` で判別**: 代入は初期化と `playRandomTimestamp` の2箇所のみで clear されないため、一度ガチャを回すと永久に truthy になり判別子として機能しません
- **監視の起点をガチャに絞る**: ENDED 分岐は監視の有無と無関係に `handleArchiveEnd()` を呼ぶため (a) が消えません（実測: `startMonitor()` を一度も呼ばずに `notify=1`）
- **通知を ENDED 由来のみに限定 / 通知を遅延**: ENDED が届かないアーカイブの救済が #646 の目的なので衝突します

## 検証

Node ハーネスで不変条件7項目（10アサーション）を確認し、**指定した破壊方法で対応する条件だけが落ちる**ことを実測しました。

| 破壊方法 | 結果 |
|---|---|
| `archiveEndHandled = false` を削除（develop の状態に戻す） | 不変条件1 FAIL（`songEnd: 1 → 0`） |
| 同じ行を `if (isPlaying)` の外へ移す | 不変条件2 FAIL（閉じた動画の ENDED で `songEnd=1`） |
| 通知条件から `continuousPlayback` を外す | 不変条件5 FAIL（手動選択でも `notify=1`） |

- 不変条件 **10/10 passed**
- `php artisan test` → **695 passed (2158 assertions)**
- `npm run build` → 成功

**JSのテスト基盤が存在しないため、恒久的な回帰テストは置けていません**（`package.json` の scripts は dev/build のみ）。上記はすべて使い捨てハーネスでの確認です。基盤導入は別Issueとします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)