### PR TITLE
fix: ローカル開発用ログインを設定キャッシュに対して fail-closed にする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,20 @@ PAGINATE_NUM=50
 MAX_ARCHIVE_COUNT=100
 # ローカル開発用ログイン（/dev-login）を有効にする
 # 本番のログインはGoogle OAuthのみのため、OAuthを通せない環境でのUI確認用。
-# APP_ENV=local との両方が揃わないと動作しない（それ以外は404）。
+#
+# 動作する条件（すべて満たす必要がある）:
+#   - DEV_LOGIN_ENABLED が有効値（'true' / '1' / 'on' / 'yes' のいずれでも有効になる）
+#   - APP_ENV=local
+#   - 設定キャッシュ・ルートキャッシュがどちらも存在しない
+# ひとつでも欠ければ 404 を返す。
+#
+# 無効化するとき: この値を false にするか行を削除したうえで、
+# 設定キャッシュを使っている環境では php artisan config:clear route:clear が必要。
+# キャッシュは .env より優先されるため、.env の編集だけでは効かない
+# （本番はサーバー側で実行すること。deploy.sh 冒頭のコメント参照）。
 DEV_LOGIN_ENABLED=false
 # ログインさせるユーザーのメールアドレス（未指定なら最初のユーザー）
+# リクエストパラメータでの上書きはできない（任意ユーザーになりきれてしまうため）
 DEV_LOGIN_EMAIL=
 
 LOG_CHANNEL=stack

--- a/app/Http/Controllers/DevLoginController.php
+++ b/app/Http/Controllers/DevLoginController.php
@@ -14,17 +14,36 @@ use Illuminate\Support\Facades\Log;
  * 本番のログインはGoogle OAuthのみのため、OAuthを通せない環境では
  * 画面の動作確認ができない。その回避用の経路。
  *
- * config/dev_login.php の enabled が true、かつ APP_ENV=local の場合のみ動作する。
- * どちらか一方でも欠ければ 404 を返すので、本番環境では有効化できない。
+ * 有効化の条件と無効化の手順は .env.example の DEV_LOGIN_ENABLED を参照。
+ *
+ * ガードは3段:
+ *   1. 設定/ルートキャッシュが存在しない（キャッシュは .env より優先されるため、
+ *      キャッシュがあると 2. と 3. の入力を信用できない）
+ *   2. config('dev_login.enabled') === true
+ *   3. APP_ENV=local
+ *
+ * 2. と 3. は同じ bootstrap/cache/config.php に固定されるため独立していない。
+ * ローカルで生成したキャッシュが配布されると2つ同時に貫通するので、
+ * 1. で無条件に閉じる（fail-closed）。
  */
 class DevLoginController extends Controller
 {
     public function __invoke(Request $request): RedirectResponse
     {
+        // キャッシュされた設定・ルートは .env を読まずに使われる。
+        // そのため下の2つのガードの入力を信用できない。キャッシュがあれば閉じる。
+        if (app()->configurationIsCached() || app()->routesAreCached()) {
+            Log::warning('[DevLogin] 設定/ルートキャッシュが有効なため無効化されています。php artisan config:clear route:clear を実行してください');
+            abort(404);
+        }
+
         abort_unless(config('dev_login.enabled') === true, 404);
         abort_unless(app()->environment('local'), 404);
 
-        $email = $request->query('email') ?: config('dev_login.email');
+        // ログイン先はサーバー側の設定のみで決める。
+        // リクエストで指定できるようにすると、この経路が到達可能な環境で
+        // 任意ユーザーになりきれてしまう（登録ユーザーは全員が管理機能を使える）
+        $email = config('dev_login.email');
 
         $user = $email
             ? User::where('email', $email)->first()

--- a/config/dev_login.php
+++ b/config/dev_login.php
@@ -9,23 +9,28 @@
 | （ブラウザ自動操作でのUI確認など）ではログインできない。
 | その回避用に、ユーザーを直接ログインさせる経路を用意する。
 |
-| 二重にガードしている:
-|   1. enabled が true であること（既定 false。.env で明示的に有効化する）
-|   2. APP_ENV=local であること（App\Http\Controllers\DevLoginController で判定）
+| 有効化の条件と無効化の手順は .env.example の DEV_LOGIN_ENABLED を参照。
+| ガードの内訳は App\Http\Controllers\DevLoginController のdocblockに書いてある。
 |
-| どちらか一方でも欠けると 404 を返す。
+| 注意: 有効化スイッチをここ以外（storage/ 配下のフラグファイル等）に置かないこと。
+| deploy.sh の rsync は .exclude-list に無いものをすべて本番へ転送するため、
+| storage/ に置いたフラグは本番に配られたうえ config:clear でも消えない。
 |
 */
 
 return [
     /*
-     * 有効にするか。無効化したい場合は .env から DEV_LOGIN_ENABLED を消すか false にする。
+     * 有効にするか。
+     *
+     * env の値が 'true' / '1' / 'on' / 'yes' のいずれでも有効になる点に注意
+     * （Laravel の env() が bool に解釈するため）。無効にしたい場合は
+     * 'false' / '0' / 空 のいずれかにするか、行ごと削除する。
      */
     'enabled' => (bool) env('DEV_LOGIN_ENABLED', false),
 
     /*
      * ログインさせるユーザーのメールアドレス。
-     * 未指定の場合は最初のユーザーを使う。クエリパラメータ ?email= でも指定できる。
+     * 未指定の場合は最初のユーザーを使う。
      */
     'email' => env('DEV_LOGIN_EMAIL'),
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,11 +29,18 @@ use Illuminate\Support\Facades\Route;
  */
 
 // ローカル開発用ログイン（Google OAuthを通せない環境でのUI確認用）
-// DEV_LOGIN_ENABLED=true かつ APP_ENV=local のときだけ動作し、それ以外は404。
-// 無効化するには .env の DEV_LOGIN_ENABLED を消すか false にする。
-Route::get('/dev-login', DevLoginController::class)
-    ->middleware('throttle:10,1')
-    ->name('dev.login');
+// 有効化の条件と無効化の手順は .env.example の DEV_LOGIN_ENABLED を参照。
+//
+// この条件は route:cache 実行時に一度だけ評価され、結果が
+// bootstrap/cache/routes-v7.php に焼き込まれる。焼いた環境が local かつ
+// 有効だった場合、配布先では条件を満たさなくてもルートが登録された状態になる。
+// したがってこれは防御ではなく攻撃面の削減であり、実際の防御は
+// DevLoginController のキャッシュガードである。
+if (app()->environment('local') && config('dev_login.enabled') === true) {
+    Route::get('/dev-login', DevLoginController::class)
+        ->middleware('throttle:10,1')
+        ->name('dev.login');
+}
 
 // 管理者（Channel Admin以上）専用機能
 Route::middleware(['auth', 'admin'])->group(function () {

--- a/tests/Feature/DevLoginRouteRegistrationTest.php
+++ b/tests/Feature/DevLoginRouteRegistrationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+/**
+ * ローカル開発用ログイン: ルート登録層
+ *
+ * routes/web.php はアプリのブート時に評価されるため、config() や app['env'] を
+ * ブート後に書き換えても登録条件には効かない。ここでは $_SERVER を
+ * parent::setUp() の前に差し替えて、登録条件そのものを検証する。
+ *
+ * コントローラ内のガードは DevLoginTest で検証する（あちらはルートを明示登録して
+ * 登録条件を迂回する）。両者を1つのクラスに混ぜると、片方のガードを削除しても
+ * もう片方の理由で404になり、テストが緑のまま通ってしまう。
+ */
+class DevLoginRouteRegistrationTest extends TestCase
+{
+    /**
+     * 環境変数を差し替えてアプリを起動する
+     *
+     * DEV_LOGIN_ENABLED は unset ではなく明示的に値を置くこと。
+     * Dotenv の safeLoad は既存の環境変数を上書きしないため、unset にすると
+     * 開発者の .env の値が読み込まれ、有効化している人の環境でだけ結果が変わる。
+     *
+     * APP_ENV / DEV_LOGIN_ENABLED 以外は触らないこと（DB_* を上書きすると
+     * phpunit.xml の sqlite ではなく mysql を掴んで落ちる）。
+     *
+     * refreshApplication() で in-memory DB が作り直されるため、
+     * RefreshDatabase ではなくここで明示的にマイグレートする。
+     */
+    private function boot(string $appEnv, string $enabled, bool $withDatabase = false): void
+    {
+        $_SERVER['APP_ENV'] = $appEnv;
+        $_SERVER['DEV_LOGIN_ENABLED'] = $enabled;
+
+        $this->refreshApplication();
+
+        if ($withDatabase) {
+            // APP_ENV=production では確認を求められて中断するため --force が必要
+            $this->artisan('migrate', ['--force' => true]);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['APP_ENV'], $_SERVER['DEV_LOGIN_ENABLED']);
+
+        parent::tearDown();
+    }
+
+    /**
+     * local かつ有効ならルートが登録され、ログインできること
+     */
+    public function test_route_is_registered_in_local_when_enabled(): void
+    {
+        $this->boot('local', 'true', withDatabase: true);
+
+        $user = User::factory()->create();
+
+        $this->assertTrue(Route::has('dev.login'), 'local かつ有効なのにルートが登録されていない');
+        $this->get('/dev-login')->assertRedirect();
+        $this->assertAuthenticatedAs($user);
+    }
+
+    /**
+     * local でも無効ならルートが登録されないこと
+     *
+     * これが「既定では無効」を検証するテスト。
+     */
+    public function test_route_is_not_registered_when_disabled(): void
+    {
+        $this->boot('local', 'false', withDatabase: true);
+
+        User::factory()->create();
+
+        $this->assertFalse(Route::has('dev.login'), '無効なのにルートが登録されている');
+        $this->get('/dev-login')->assertNotFound();
+        $this->assertGuest();
+    }
+
+    /**
+     * 有効でも local 以外ならルートが登録されないこと
+     */
+    public function test_route_is_not_registered_outside_local(): void
+    {
+        $this->boot('production', 'true', withDatabase: true);
+
+        User::factory()->create();
+
+        $this->assertFalse(Route::has('dev.login'), 'local 以外なのにルートが登録されている');
+        $this->get('/dev-login')->assertNotFound();
+        $this->assertGuest();
+    }
+
+    /**
+     * env の値がどう解釈されるかを固定する
+     *
+     * 注意: これは「truthy な文字列なら安全」という意味ではない。
+     * '1' / 'on' / 'yes' はいずれも有効化する。無効にしたいときは
+     * 'false' / '0' / 空 のいずれかにすること。
+     *
+     * @dataProvider enabledValueProvider
+     */
+    public function test_enabled_flag_interpretation(string $envValue, bool $expected): void
+    {
+        $this->boot('local', $envValue);
+
+        $this->assertSame(
+            $expected,
+            config('dev_login.enabled'),
+            "DEV_LOGIN_ENABLED='{$envValue}' の解釈が変わっている"
+        );
+        $this->assertSame($expected, Route::has('dev.login'));
+    }
+
+    public static function enabledValueProvider(): array
+    {
+        return [
+            "'true' は有効" => ['true', true],
+            "'1' は有効" => ['1', true],
+            "'on' は有効" => ['on', true],
+            "'yes' は有効" => ['yes', true],
+            "'false' は無効" => ['false', false],
+            "'0' は無効" => ['0', false],
+            '空文字は無効' => ['', false],
+        ];
+    }
+}

--- a/tests/Feature/DevLoginTest.php
+++ b/tests/Feature/DevLoginTest.php
@@ -2,13 +2,37 @@
 
 namespace Tests\Feature;
 
+use App\Http\Controllers\DevLoginController;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
+/**
+ * ローカル開発用ログイン: コントローラのガード層
+ *
+ * routes/web.php のルート登録は条件付きなので、そのままでは「ルートが無いから404」
+ * になり、コントローラ内のガードを1つも通らない。それではガードを削除しても
+ * テストが緑のまま通ってしまうため、ここではルートを明示登録して
+ * 登録条件を迂回し、ガード自体を1つずつ検証する。
+ *
+ * ルート登録条件そのものは DevLoginRouteRegistrationTest で検証する。
+ */
 class DevLoginTest extends TestCase
 {
     use RefreshDatabase;
+
+    /**
+     * 登録条件を迂回してルートを登録する
+     */
+    private function registerRoute(): void
+    {
+        // web グループを付けないとセッションが開始されず、
+        // ログイン成功時の session()->regenerate() で落ちる
+        $this->app['router']->middleware('web')
+            ->get('/dev-login', DevLoginController::class)
+            ->name('dev.login');
+        $this->app['router']->getRoutes()->refreshNameLookups();
+    }
 
     /**
      * local 環境で有効化した状態にする
@@ -20,11 +44,42 @@ class DevLoginTest extends TestCase
     }
 
     /**
-     * 既定では無効（404）であること
+     * 設定キャッシュ・ルートキャッシュがあると見せかける
+     *
+     * Application::normalizeCachePath() が呼び出しごとに Env を読むため、
+     * $_SERVER 経由で差し替えられる。実際に bootstrap/cache/config.php を
+     * 置くとテストスイート全体が焼かれた DB 設定で動いてしまうので使えない。
+     *
+     * @param  'APP_CONFIG_CACHE'|'APP_ROUTES_CACHE'  $key
      */
-    public function test_disabled_by_default(): void
+    private function withCachePresent(string $key, callable $callback): void
+    {
+        $probe = base_path('bootstrap/cache/__devlogin_probe.php');
+        file_put_contents($probe, '<?php return [];');
+        $_SERVER[$key] = 'bootstrap/cache/__devlogin_probe.php';
+
+        try {
+            $callback();
+        } finally {
+            unset($_SERVER[$key]);
+            @unlink($probe);
+        }
+    }
+
+    /**
+     * enabled が false なら 404 であること
+     *
+     * このテストは abort_unless(config('dev_login.enabled') === true) を守る。
+     * ルートを明示登録し APP_ENV も local にしているので、enabled ガードを
+     * 削除すると必ず落ちる。
+     */
+    public function test_disabled_when_flag_is_false(): void
     {
         User::factory()->create();
+
+        $this->registerRoute();
+        $this->app['env'] = 'local';
+        config()->set('dev_login.enabled', false);
 
         $this->get('/dev-login')->assertNotFound();
         $this->assertGuest();
@@ -32,16 +87,59 @@ class DevLoginTest extends TestCase
 
     /**
      * 有効化しても local 以外では 404 であること
+     *
+     * このテストは abort_unless(app()->environment('local')) を守る。
      */
     public function test_not_available_outside_local(): void
     {
         User::factory()->create();
 
+        $this->registerRoute();
         // APP_ENV は testing のまま
         config()->set('dev_login.enabled', true);
 
         $this->get('/dev-login')->assertNotFound();
         $this->assertGuest();
+    }
+
+    /**
+     * 設定キャッシュがあると 404 であること
+     *
+     * キャッシュされた設定は .env を読まずに使われるため、enabled と APP_ENV の
+     * 2つのガードは同時に貫通しうる。キャッシュの存在自体で閉じる。
+     */
+    public function test_not_available_when_configuration_is_cached(): void
+    {
+        User::factory()->create();
+
+        $this->registerRoute();
+        $this->enableInLocal();
+
+        $this->withCachePresent('APP_CONFIG_CACHE', function () {
+            $this->assertTrue($this->app->configurationIsCached(), '設定キャッシュありの状態を作れていない');
+            $this->get('/dev-login')->assertNotFound();
+            $this->assertGuest();
+        });
+    }
+
+    /**
+     * ルートキャッシュがあると 404 であること
+     *
+     * routes/web.php の条件付き登録は route:cache 実行時に一度だけ評価され
+     * 結果が焼き込まれるため、キャッシュがある環境では条件を信用できない。
+     */
+    public function test_not_available_when_routes_are_cached(): void
+    {
+        User::factory()->create();
+
+        $this->registerRoute();
+        $this->enableInLocal();
+
+        $this->withCachePresent('APP_ROUTES_CACHE', function () {
+            $this->assertTrue($this->app->routesAreCached(), 'ルートキャッシュありの状態を作れていない');
+            $this->get('/dev-login')->assertNotFound();
+            $this->assertGuest();
+        });
     }
 
     /**
@@ -51,6 +149,7 @@ class DevLoginTest extends TestCase
     {
         $user = User::factory()->create();
 
+        $this->registerRoute();
         $this->enableInLocal();
 
         $this->get('/dev-login')->assertRedirect();
@@ -65,6 +164,7 @@ class DevLoginTest extends TestCase
         User::factory()->create(['email' => 'first@example.com']);
         $target = User::factory()->create(['email' => 'target@example.com']);
 
+        $this->registerRoute();
         $this->enableInLocal();
         config()->set('dev_login.email', 'target@example.com');
 
@@ -73,17 +173,22 @@ class DevLoginTest extends TestCase
     }
 
     /**
-     * クエリパラメータでユーザーを指定できること
+     * クエリパラメータではユーザーを指定できないこと
+     *
+     * 指定できると、この経路が到達可能な環境で任意ユーザーになりきれてしまう
+     * （登録ユーザーは全員が管理機能を使えるため影響が大きい）。
      */
-    public function test_logs_in_as_query_email(): void
+    public function test_query_email_cannot_override_configured_user(): void
     {
-        User::factory()->create(['email' => 'first@example.com']);
-        $target = User::factory()->create(['email' => 'target@example.com']);
+        $configured = User::factory()->create(['email' => 'configured@example.com']);
+        User::factory()->create(['email' => 'other@example.com']);
 
+        $this->registerRoute();
         $this->enableInLocal();
+        config()->set('dev_login.email', 'configured@example.com');
 
-        $this->get('/dev-login?email=target@example.com')->assertRedirect();
-        $this->assertAuthenticatedAs($target);
+        $this->get('/dev-login?email=other@example.com')->assertRedirect();
+        $this->assertAuthenticatedAs($configured);
     }
 
     /**
@@ -91,9 +196,11 @@ class DevLoginTest extends TestCase
      */
     public function test_not_found_when_user_missing(): void
     {
+        $this->registerRoute();
         $this->enableInLocal();
+        config()->set('dev_login.email', 'nobody@example.com');
 
-        $this->get('/dev-login?email=nobody@example.com')->assertNotFound();
+        $this->get('/dev-login')->assertNotFound();
         $this->assertGuest();
     }
 
@@ -102,6 +209,7 @@ class DevLoginTest extends TestCase
      */
     public function test_not_found_when_no_users_exist(): void
     {
+        $this->registerRoute();
         $this->enableInLocal();
 
         $this->get('/dev-login')->assertNotFound();


### PR DESCRIPTION
## 概要

`/dev-login`（#644 で追加）のガードに2つの問題がありました。cycle-review の L1 と L4 が**別角度から独立に**検出し、方針レビューで実測により裏付けたものです。

この経路は認証ミドルウェアの外側にあり（`route:list -vv` で `auth` なし・`throttle:10,1` のみ）、ガードを抜けると任意ユーザーとしてログインできます。`User::isAdmin()` は常に true なので `Route::middleware(['auth','admin'])` 配下の管理機能がすべて開きます。

## 問題1: 2つのガードが独立していない

```php
abort_unless(config('dev_login.enabled') === true, 404);   // env('DEV_LOGIN_ENABLED')
abort_unless(app()->environment('local'), 404);            // config('app.env') = env('APP_ENV')
```

どちらも同じ `bootstrap/cache/config.php` に固定されます。Laravel は設定キャッシュがあると `.env` を読みません（`LoadEnvironmentVariables.php:22-24`）。実測:

```
### APP_ENV=local / DEV_LOGIN_ENABLED=true で config:cache
### .env を APP_ENV=production / DEV_LOGIN_ENABLED=false に差し替え
configCached=true | app.env='local' | environment('local')=true | dev_login.enabled=true
### DEV_LOGIN_ENABLED の行を完全に削除しても同じ
```

`config/dev_login.php` の「二重にガードしている」「どちらか一方でも欠けると404」は、この機序において成立していませんでした。

### ルート登録を条件付きにするだけでは防げません

`routes/web.php` の条件は **`route:cache` 実行時に一度だけ評価**され、結果が `bootstrap/cache/routes-v7.php` に焼き込まれます。焼いた環境（開発機 = local + 有効）の結果が配布先で使われます。実測:

```
### config:cache と route:cache を両方 local+enabled で焼いた後 .env を production/false に差し替え
configCached=true routesCached=true app.env='local' env(local)=true dev_login.enabled=true
ROUTE MATCHED: dev-login -> "App\Http\Controllers\DevLoginController"
```

**したがってルート条件化は防御ではなく攻撃面の削減**です。コメントにもそう明記しました。

### 対応

設定/ルートキャッシュの存在自体で閉じます（fail-closed）。

```php
if (app()->configurationIsCached() || app()->routesAreCached()) {
    Log::warning('[DevLogin] 設定/ルートキャッシュが有効なため無効化されています。...');
    abort(404);
}
```

**副作用はほぼありません。** `pre-commit-check.sh:12` が Issue #141 を理由に `config:clear` を明示実行しており、実際に `bootstrap/cache/config.php` がある状態で `php artisan test` を回すと焼かれた `DB_CONNECTION=mysql` で全滅します。ローカルで設定キャッシュを持ち続けることは、このリポジトリでは既にアンチパターンです。

なお `storage/` 配下のフラグファイルを有効化スイッチにする案は**採ってはいけない**と判定されました。`.exclude-list` の除外は `storage/logs` のみなので rsync で本番に配られ、しかも `config:clear` では消えません。この注意を `config/dev_login.php` に残しています。

### `?email=` の廃止

```php
$email = $request->query('email') ?: config('dev_login.email');   // 変更前
```

リクエストで上書きできました（実測 `?email=admin` → `302` / `admin@example.com` として認証）。サーバー側の設定のみで決めるようにし、あわせてメールアドレスの存在オラクル（404=未登録 / 302=登録済み）も閉じます。

## 問題2: `enabled` ガードが完全に無検証だった

`abort_unless(config('dev_login.enabled') === true, 404)` を**丸ごと削除しても既存テスト7件が全て緑**でした。`test_disabled_by_default` が `enabled=false` かつ `APP_ENV=testing` の状態を作るため、`local` ガード側だけで404になっていたためです。

### 対応: テストを2層に分離

混在させると片方のガードを削除してももう片方の理由で404になり、緑のまま通ります。

| クラス | 役割 | 手法 |
|---|---|---|
| `DevLoginRouteRegistrationTest` | ルート登録条件そのもの | `$_SERVER` を差し替えてアプリを起動 |
| `DevLoginTest` | コントローラのガード | ルートを明示登録して登録条件を迂回 |

**実装上の罠が2つありました。**

1. `DEV_LOGIN_ENABLED` は `unset` ではなく明示的に `'false'` を置く必要があります。Dotenv の `safeLoad` は既存の環境変数を上書きしないため、`unset` にすると**開発者の `.env` が読み込まれ、dev-login を有効化している人の環境でだけ落ちるテスト**になります（実測で確認）。
2. 設定キャッシュ状態は実ファイルでは作れません（スイート全体が焼かれた DB 設定で動く）。`Application::normalizeCachePath()` が呼び出しごとに Env を読むので `$_SERVER['APP_CONFIG_CACHE']` で差し替えます。

env の値の解釈もデータプロバイダで固定しました。**`'1'` / `'on'` / `'yes'` はいずれも有効化します。** 当初は「truthy な文字列は `=== true` で弾かれる」というテストを書く方針でしたが、`config/dev_login.php` は既に `(bool) env(...)` しているため事実に反しており、**嘘をテストで固定するところでした**。コメントで明示しています。

## 文言（5箇所）

「本番環境では有効化できない」はコードが強制している事実ではなく `本番 ⟹ APP_ENV≠local` という運用前提でした（`.env.example:2` は `APP_ENV=local` を出荷）。断定を削り、`.env.example` を正典として他は参照させます。キルスイッチ手順に `config:clear` が必要である旨も追記しました。

## 検証

**各ガードを1つずつ削除して、対応するテストだけが落ちることを実測しました。**

| 破壊 | 結果 |
|---|---|
| `enabled` ガード削除 | 1 failed（**従来は 0 failed** ← 元の問題） |
| `local` ガード削除 | 1 failed |
| `configurationIsCached` 削除 | 1 failed |
| `routesAreCached` 削除 | 1 failed |
| `?email=` の上書きを復活 | 1 failed |
| ルート登録条件から `enabled` を削除 | 4 failed |
| ルート登録条件から `local` を削除 | 1 failed |

- `php artisan test --filter=DevLogin` → **19 passed (51 assertions)**
- `php artisan test` → **707 passed (2189 assertions)**
- `./vendor/bin/pint --test` → **PASS (252 files)**

## 範囲外（Issue で扱います）

`.exclude-list` に `bootstrap` が無いため `bootstrap/cache/*.php` がローカルから本番へ rsync される構造自体は残ります。`deploy.sh:59,61` が `config:clear` と `route:clear` の両方を実行しているため露出は「転送直後〜ssh 実行の間」と「ssh 失敗時」に限られますが、**影響は dev-login だけでなく `APP_ENV` / `APP_DEBUG` / `DB_*` / `LOG_LEVEL` に依存する全箇所に及びます**。

`bootstrap/cache` を丸ごと除外すると `packages.php` / `services.php` が転送されず、ディレクトリ未作成のサーバで artisan が落ちる可能性があるため、**実サーバでしか検証できません**。未検証のデプロイ変更をこの認可修正に混ぜるべきではないと判断しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)