### PR TITLE
feat: 楽曲マスタクレンジング画面を追加

### DIFF
--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -13,6 +13,7 @@ use App\Models\NormalizationLog;
 use App\Models\Song;
 use App\Models\TimestampSongMapping;
 use App\Models\TsItem;
+use App\Services\SongCleansingService;
 use App\Services\SongMappingService;
 use App\Services\SongMergeService;
 use App\Services\SongSearchService;
@@ -50,6 +51,8 @@ class SongController extends Controller
 
     protected SongMergeService $songMergeService;
 
+    protected SongCleansingService $songCleansingService;
+
     protected SpotifyService $spotifyService;
 
     protected YouTubeApiService $youtubeApiService;
@@ -60,6 +63,7 @@ class SongController extends Controller
         SongSearchService $songSearchService,
         SongMappingService $songMappingService,
         SongMergeService $songMergeService,
+        SongCleansingService $songCleansingService,
         SpotifyService $spotifyService,
         YouTubeApiService $youtubeApiService,
         VideoUrlService $videoUrlService
@@ -67,6 +71,7 @@ class SongController extends Controller
         $this->songSearchService = $songSearchService;
         $this->songMappingService = $songMappingService;
         $this->songMergeService = $songMergeService;
+        $this->songCleansingService = $songCleansingService;
         $this->spotifyService = $spotifyService;
         $this->youtubeApiService = $youtubeApiService;
         $this->videoUrlService = $videoUrlService;
@@ -135,6 +140,99 @@ class SongController extends Controller
             ),
             'affected_mappings' => $result['affected_mappings'],
             'affected_ts_items' => $result['affected_ts_items'],
+        ]);
+    }
+
+    /**
+     * 楽曲マスタクレンジング画面を表示
+     */
+    public function cleansing()
+    {
+        return view('songs.cleansing');
+    }
+
+    /**
+     * アーティスト名一括変換のプレビューを取得
+     */
+    public function previewArtistRename(Request $request)
+    {
+        $validated = $request->validate([
+            'from' => 'required|string|max:255',
+            'to' => 'required|string|max:255|different:from',
+        ]);
+
+        $result = $this->songCleansingService->previewArtistRename($validated['from'], $validated['to']);
+
+        return response()->json($result);
+    }
+
+    /**
+     * アーティスト名を一括変換する
+     */
+    public function renameArtist(Request $request)
+    {
+        $validated = $request->validate([
+            'from' => 'required|string|max:255',
+            'to' => 'required|string|max:255|different:from',
+        ]);
+
+        $result = $this->songCleansingService->executeArtistRename(
+            $validated['from'],
+            $validated['to'],
+            Auth::id()
+        );
+
+        return response()->json([
+            'message' => sprintf(
+                'アーティスト名を変換しました（リネーム %d件、統合 %d件）',
+                count($result['renamed']),
+                count($result['merged'])
+            ),
+            'renamed' => $result['renamed'],
+            'merged' => $result['merged'],
+        ]);
+    }
+
+    /**
+     * 同名異表記グループ（同じタイトルで複数名義のマスタ）を取得
+     */
+    public function findTitleGroups(Request $request)
+    {
+        $validated = $request->validate([
+            'search' => 'nullable|string|max:255',
+            'filter' => 'nullable|string|in:active,pending',
+        ]);
+
+        $groups = $this->songCleansingService->findTitleGroups(
+            $validated['search'] ?? '',
+            $validated['filter'] ?? 'active'
+        );
+
+        return response()->json($groups);
+    }
+
+    /**
+     * 同名異表記グループを「別の曲」または「保留」として記録する
+     */
+    public function reviewTitleGroup(Request $request)
+    {
+        $validated = $request->validate([
+            'normalized_title' => 'required|string',
+            'song_ids' => 'required|array|min:2',
+            'song_ids.*' => 'string|exists:songs,id',
+            'decision' => 'required|string|in:distinct,pending',
+        ]);
+
+        $review = $this->songCleansingService->reviewTitleGroup(
+            $validated['normalized_title'],
+            $validated['song_ids'],
+            $validated['decision'],
+            Auth::id()
+        );
+
+        return response()->json([
+            'message' => $validated['decision'] === 'pending' ? '保留にしました' : '別の曲として記録しました',
+            'id' => $review->id,
         ]);
     }
 

--- a/app/Models/NormalizationLog.php
+++ b/app/Models/NormalizationLog.php
@@ -45,6 +45,10 @@ class NormalizationLog extends Model
 
     public const ACTION_MERGE_SONG = 'merge_song';
 
+    public const ACTION_RENAME_ARTIST = 'rename_artist';
+
+    public const ACTION_REVIEW_SONG_GROUP = 'review_song_group';
+
     /**
      * ターゲット種別
      */

--- a/app/Models/SongGroupReview.php
+++ b/app/Models/SongGroupReview.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+
+class SongGroupReview extends Model
+{
+    use HasUlids;
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'normalized_title',
+        'song_ids_hash',
+        'song_ids',
+        'decision',
+        'created_by',
+    ];
+
+    protected $casts = [
+        'song_ids' => 'array',
+    ];
+
+    /**
+     * 「別の曲」判定（今後候補として表示しない）
+     */
+    public const DECISION_DISTINCT = 'distinct';
+
+    /**
+     * 「保留」判定（一旦候補から外すが、後で見返せる）
+     */
+    public const DECISION_PENDING = 'pending';
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /**
+     * 楽曲IDの組み合わせから一意なハッシュを生成する
+     */
+    public static function hashSongIds(array $songIds): string
+    {
+        $sorted = $songIds;
+        sort($sorted);
+
+        return sha1(implode(',', $sorted));
+    }
+}

--- a/app/Services/SongCleansingService.php
+++ b/app/Services/SongCleansingService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Helpers\QueryHelper;
 use App\Models\NormalizationLog;
 use App\Models\Song;
 use App\Models\SongGroupReview;
@@ -127,7 +128,8 @@ class SongCleansingService
             ->orderBy('normalized_title');
 
         if ($search !== '') {
-            $titleQuery->where('title', 'LIKE', "%{$search}%");
+            $escaped = QueryHelper::escapeLikeString($search);
+            $titleQuery->where('title', 'LIKE', "%{$escaped}%");
         }
 
         $normalizedTitles = $titleQuery->limit(self::GROUP_LIMIT)->pluck('normalized_title');

--- a/app/Services/SongCleansingService.php
+++ b/app/Services/SongCleansingService.php
@@ -95,8 +95,26 @@ class SongCleansingService
     {
         $songs = Song::where('artist', $from)->orderBy('title')->get();
 
-        return $songs->map(function (Song $song) use ($to) {
+        // 同一バッチ内の重複タイトルを検出するため、リネーム済みタイトルを追跡
+        $renamedByNormalizedTitle = []; // normalized_title => song_id
+
+        return $songs->map(function (Song $song) use ($to, &$renamedByNormalizedTitle) {
             $conflict = $this->findRenameConflict($song, $to);
+
+            // 既存の変換先に競合がなくても、同一バッチ内で先にリネームされた曲と
+            // normalized_title が一致する場合は、実行時にマージが発生する
+            if (! $conflict && isset($renamedByNormalizedTitle[$song->normalized_title])) {
+                return [
+                    'song_id' => $song->id,
+                    'title' => $song->title,
+                    'action' => 'merge',
+                    'conflict_song_id' => $renamedByNormalizedTitle[$song->normalized_title],
+                ];
+            }
+
+            if (! $conflict) {
+                $renamedByNormalizedTitle[$song->normalized_title] = $song->id;
+            }
 
             return [
                 'song_id' => $song->id,
@@ -109,7 +127,7 @@ class SongCleansingService
 
     private function findRenameConflict(Song $song, string $to): ?Song
     {
-        return Song::where('title', $song->title)
+        return Song::where('normalized_title', $song->normalized_title)
             ->where('artist', $to)
             ->where('id', '!=', $song->id)
             ->first();
@@ -187,10 +205,13 @@ class SongCleansingService
     {
         $hash = SongGroupReview::hashSongIds($songIds);
 
+        // クライアントから送られた normalized_title を信用せず、実際の楽曲から取得する
+        $actualNormalizedTitle = Song::whereIn('id', $songIds)->value('normalized_title') ?? $normalizedTitle;
+
         $review = SongGroupReview::updateOrCreate(
             ['song_ids_hash' => $hash],
             [
-                'normalized_title' => $normalizedTitle,
+                'normalized_title' => $actualNormalizedTitle,
                 'song_ids' => $songIds,
                 'decision' => $decision,
                 'created_by' => $userId,

--- a/app/Services/SongCleansingService.php
+++ b/app/Services/SongCleansingService.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\NormalizationLog;
+use App\Models\Song;
+use App\Models\SongGroupReview;
+use App\Models\TsItem;
+use Illuminate\Support\Facades\DB;
+
+class SongCleansingService
+{
+    /**
+     * 同名異表記グループの取得件数上限
+     */
+    private const GROUP_LIMIT = 50;
+
+    public function __construct(private SongMergeService $songMergeService) {}
+
+    /**
+     * アーティスト名一括変換のプレビューを取得する
+     *
+     * 変換対象（artist = $from）の楽曲ごとに、変換後（title, $to）に一致する
+     * 既存マスタがあるか判定し、リネームのみか統合が必要かを返す。
+     */
+    public function previewArtistRename(string $from, string $to): array
+    {
+        $plan = $this->buildArtistRenamePlan($from, $to);
+
+        return [
+            'plan' => $plan,
+            'rename_count' => count(array_filter($plan, fn ($item) => $item['action'] === 'rename')),
+            'merge_count' => count(array_filter($plan, fn ($item) => $item['action'] === 'merge')),
+        ];
+    }
+
+    /**
+     * アーティスト名を一括変換する
+     *
+     * 変換先に同一タイトルの既存マスタが存在する場合は、そちらへマージする
+     * （紐付くタイムスタンプ・個別紐付けを移行し、変換元マスタを削除する）。
+     * 存在しない場合は artist を変換後の名前に更新するだけとなる。
+     */
+    public function executeArtistRename(string $from, string $to, int $userId): array
+    {
+        return DB::transaction(function () use ($from, $to, $userId) {
+            $songs = Song::where('artist', $from)->orderBy('title')->get();
+
+            $renamed = [];
+            $merged = [];
+
+            foreach ($songs as $song) {
+                $conflict = $this->findRenameConflict($song, $to);
+
+                if ($conflict) {
+                    $result = $this->songMergeService->merge($song->id, $conflict->id, $userId);
+                    $merged[] = [
+                        'title' => $song->title,
+                        'source_song_id' => $song->id,
+                        'target_song_id' => $conflict->id,
+                        'affected_mappings' => $result['affected_mappings'],
+                        'affected_ts_items' => $result['affected_ts_items'],
+                    ];
+                } else {
+                    $song->update(['artist' => $to]);
+                    $renamed[] = [
+                        'title' => $song->title,
+                        'song_id' => $song->id,
+                    ];
+                }
+            }
+
+            NormalizationLog::log(
+                $userId,
+                NormalizationLog::ACTION_RENAME_ARTIST,
+                NormalizationLog::TARGET_SONG,
+                null,
+                [
+                    'from' => $from,
+                    'to' => $to,
+                    'renamed_count' => count($renamed),
+                    'merged_count' => count($merged),
+                ]
+            );
+
+            return [
+                'renamed' => $renamed,
+                'merged' => $merged,
+            ];
+        });
+    }
+
+    private function buildArtistRenamePlan(string $from, string $to): array
+    {
+        $songs = Song::where('artist', $from)->orderBy('title')->get();
+
+        return $songs->map(function (Song $song) use ($to) {
+            $conflict = $this->findRenameConflict($song, $to);
+
+            return [
+                'song_id' => $song->id,
+                'title' => $song->title,
+                'action' => $conflict ? 'merge' : 'rename',
+                'conflict_song_id' => $conflict?->id,
+            ];
+        })->values()->toArray();
+    }
+
+    private function findRenameConflict(Song $song, string $to): ?Song
+    {
+        return Song::where('title', $song->title)
+            ->where('artist', $to)
+            ->where('id', '!=', $song->id)
+            ->first();
+    }
+
+    /**
+     * 同名異表記グループ（同じタイトルで複数名義のマスタが存在するグループ）を検出する
+     *
+     * @param  string  $filter  'active'（未処理のみ） | 'pending'（保留のみ）
+     */
+    public function findTitleGroups(string $search = '', string $filter = 'active'): array
+    {
+        $titleQuery = Song::selectRaw('normalized_title, COUNT(DISTINCT normalized_artist) as artist_count')
+            ->groupBy('normalized_title')
+            ->having('artist_count', '>', 1)
+            ->orderBy('normalized_title');
+
+        if ($search !== '') {
+            $titleQuery->where('title', 'LIKE', "%{$search}%");
+        }
+
+        $normalizedTitles = $titleQuery->limit(self::GROUP_LIMIT)->pluck('normalized_title');
+
+        if ($normalizedTitles->isEmpty()) {
+            return [];
+        }
+
+        $songs = Song::whereIn('normalized_title', $normalizedTitles)
+            ->withCount('mappings')
+            ->orderBy('artist')
+            ->orderBy('title')
+            ->get();
+
+        $songIds = $songs->pluck('id')->toArray();
+        $tsItemCounts = TsItem::selectRaw('song_id, COUNT(*) as count')
+            ->whereIn('song_id', $songIds)
+            ->groupBy('song_id')
+            ->pluck('count', 'song_id');
+
+        $groups = $songs->groupBy('normalized_title')->map(function ($songsInGroup, $normalizedTitle) use ($tsItemCounts) {
+            $sortedIds = $songsInGroup->pluck('id')->sort()->values()->all();
+
+            return [
+                'normalized_title' => $normalizedTitle,
+                'song_ids_hash' => SongGroupReview::hashSongIds($sortedIds),
+                'songs' => $songsInGroup->map(fn (Song $song) => [
+                    'id' => $song->id,
+                    'title' => $song->title,
+                    'artist' => $song->artist,
+                    'spotify_track_id' => $song->spotify_track_id,
+                    'mappings_count' => $song->mappings_count,
+                    'ts_items_count' => $tsItemCounts->get($song->id, 0),
+                ])->values(),
+            ];
+        })->values();
+
+        $hashes = $groups->pluck('song_ids_hash')->toArray();
+        $reviewedDecisions = SongGroupReview::whereIn('song_ids_hash', $hashes)
+            ->pluck('decision', 'song_ids_hash');
+
+        return $groups->filter(function ($group) use ($reviewedDecisions, $filter) {
+            $decision = $reviewedDecisions->get($group['song_ids_hash']);
+
+            return $filter === 'pending'
+                ? $decision === SongGroupReview::DECISION_PENDING
+                : $decision === null;
+        })->values()->toArray();
+    }
+
+    /**
+     * 同名異表記グループを「別の曲」または「保留」として記録する
+     */
+    public function reviewTitleGroup(string $normalizedTitle, array $songIds, string $decision, int $userId): SongGroupReview
+    {
+        $hash = SongGroupReview::hashSongIds($songIds);
+
+        $review = SongGroupReview::updateOrCreate(
+            ['song_ids_hash' => $hash],
+            [
+                'normalized_title' => $normalizedTitle,
+                'song_ids' => $songIds,
+                'decision' => $decision,
+                'created_by' => $userId,
+            ]
+        );
+
+        NormalizationLog::log(
+            $userId,
+            NormalizationLog::ACTION_REVIEW_SONG_GROUP,
+            NormalizationLog::TARGET_SONG,
+            null,
+            [
+                'normalized_title' => $normalizedTitle,
+                'song_ids' => $songIds,
+                'decision' => $decision,
+            ]
+        );
+
+        return $review;
+    }
+}

--- a/database/migrations/2026_08_24_110923_create_song_group_reviews_table.php
+++ b/database/migrations/2026_08_24_110923_create_song_group_reviews_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // 同名異表記グループ（同じ曲名で複数名義のマスタが存在するグループ）の
+        // レビュー結果（別の曲 / 保留）を記録するテーブル
+        Schema::create('song_group_reviews', function (Blueprint $table) {
+            $table->string('id', 26)->primary();
+            $table->string('normalized_title');
+            $table->string('song_ids_hash', 40)->unique();
+            $table->json('song_ids');
+            $table->string('decision', 20);
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->timestamps();
+
+            $table->index('normalized_title');
+            $table->foreign('created_by')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('song_group_reviews');
+    }
+};

--- a/database/migrations/2026_08_24_110923_create_song_group_reviews_table.php
+++ b/database/migrations/2026_08_24_110923_create_song_group_reviews_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
         // レビュー結果（別の曲 / 保留）を記録するテーブル
         Schema::create('song_group_reviews', function (Blueprint $table) {
             $table->string('id', 26)->primary();
-            $table->string('normalized_title');
+            $table->string('normalized_title')->charset('utf8mb4')->collation('utf8mb4_bin');
             $table->string('song_ids_hash', 40)->unique();
             $table->json('song_ids');
             $table->string('decision', 20);

--- a/resources/js/songs/cleansing.js
+++ b/resources/js/songs/cleansing.js
@@ -173,6 +173,7 @@ document.addEventListener('DOMContentLoaded', () => {
             this.message = null;
 
             try {
+                let completed = 0;
                 for (const sourceId of sources) {
                     const res = await fetch('/api/songs/merge', {
                         method: 'POST',
@@ -187,17 +188,21 @@ document.addEventListener('DOMContentLoaded', () => {
                     });
                     if (!res.ok) {
                         const data = await res.json();
-                        throw new Error(data.message || 'マージに失敗しました');
+                        const base = data.message || 'マージに失敗しました';
+                        throw new Error(completed > 0
+                            ? `${base}（${completed}/${sources.length}件は統合済み）`
+                            : base);
                     }
+                    completed++;
                 }
                 this.message = `${sources.length}件の楽曲を統合しました`;
                 this.messageType = 'success';
-                await this.fetchTitleGroups();
             } catch (e) {
                 this.message = e.message;
                 this.messageType = 'error';
             } finally {
                 this.merging[groupKey] = false;
+                await this.fetchTitleGroups();
             }
         },
 

--- a/resources/js/songs/cleansing.js
+++ b/resources/js/songs/cleansing.js
@@ -1,0 +1,236 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const app = document.getElementById('cleansing-app');
+    if (!app) return;
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+
+    Alpine.data('cleansingApp', () => ({
+        tab: 'rename',
+
+        // --- アーティスト名一括変換 ---
+        renameFrom: '',
+        renameTo: '',
+        renamePlan: null,
+        renamePreviewing: false,
+        renameExecuting: false,
+
+        // --- 同名異表記グループ ---
+        groupFilter: 'active',
+        groups: [],
+        groupsLoading: false,
+        groupSearch: '',
+        selectedIds: {},
+        targetId: {},
+        merging: {},
+
+        message: null,
+        messageType: 'success',
+
+        async init() {
+            await this.fetchTitleGroups();
+        },
+
+        switchTab(tab) {
+            this.tab = tab;
+            this.message = null;
+        },
+
+        // --- アーティスト名一括変換 ---
+
+        async previewRename() {
+            if (!this.renameFrom.trim() || !this.renameTo.trim()) return;
+            this.renamePreviewing = true;
+            this.renamePlan = null;
+            this.message = null;
+            try {
+                const params = new URLSearchParams({ from: this.renameFrom, to: this.renameTo });
+                const res = await fetch(`/api/songs/cleansing/artist-rename-preview?${params}`);
+                if (!res.ok) {
+                    const data = await res.json();
+                    throw new Error(data.message || 'プレビューの取得に失敗しました');
+                }
+                this.renamePlan = await res.json();
+                if (this.renamePlan.plan.length === 0) {
+                    this.message = `「${this.renameFrom}」に一致する楽曲マスタがありません`;
+                    this.messageType = 'error';
+                }
+            } catch (e) {
+                this.message = e.message;
+                this.messageType = 'error';
+            } finally {
+                this.renamePreviewing = false;
+            }
+        },
+
+        async executeRename() {
+            if (!this.renamePlan || this.renamePlan.plan.length === 0) return;
+
+            const { rename_count, merge_count } = this.renamePlan;
+            const confirmMessage = merge_count > 0
+                ? `${rename_count}件をリネーム、${merge_count}件を統合します。統合される側の元マスタは削除されます。よろしいですか？`
+                : `${rename_count}件をリネームします。よろしいですか？`;
+
+            if (!confirm(confirmMessage)) return;
+
+            this.renameExecuting = true;
+            this.message = null;
+
+            try {
+                const res = await fetch('/api/songs/cleansing/artist-rename', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': csrfToken,
+                    },
+                    body: JSON.stringify({ from: this.renameFrom, to: this.renameTo }),
+                });
+                if (!res.ok) {
+                    const data = await res.json();
+                    throw new Error(data.message || '変換に失敗しました');
+                }
+                const data = await res.json();
+                this.message = data.message;
+                this.messageType = 'success';
+                this.renamePlan = null;
+                this.renameFrom = '';
+                this.renameTo = '';
+                await this.fetchTitleGroups();
+            } catch (e) {
+                this.message = e.message;
+                this.messageType = 'error';
+            } finally {
+                this.renameExecuting = false;
+            }
+        },
+
+        // --- 同名異表記グループ ---
+
+        async fetchTitleGroups() {
+            this.groupsLoading = true;
+            try {
+                const params = new URLSearchParams({ filter: this.groupFilter });
+                if (this.groupSearch.trim()) params.set('search', this.groupSearch);
+                const res = await fetch(`/api/songs/cleansing/title-groups?${params}`);
+                if (!res.ok) throw new Error('グループの取得に失敗しました');
+                this.groups = await res.json();
+                this.selectedIds = {};
+                this.targetId = {};
+            } catch (e) {
+                this.message = e.message;
+                this.messageType = 'error';
+            } finally {
+                this.groupsLoading = false;
+            }
+        },
+
+        setFilter(filter) {
+            this.groupFilter = filter;
+            this.fetchTitleGroups();
+        },
+
+        groupKey(group) {
+            return group.song_ids_hash;
+        },
+
+        toggleSelect(groupKey, songId) {
+            if (!this.selectedIds[groupKey]) this.selectedIds[groupKey] = [];
+            const idx = this.selectedIds[groupKey].indexOf(songId);
+            if (idx === -1) {
+                this.selectedIds[groupKey].push(songId);
+            } else {
+                this.selectedIds[groupKey].splice(idx, 1);
+                if (this.targetId[groupKey] === songId) {
+                    delete this.targetId[groupKey];
+                }
+            }
+        },
+
+        isSelected(groupKey, songId) {
+            return (this.selectedIds[groupKey] || []).includes(songId);
+        },
+
+        setTarget(groupKey, songId) {
+            this.targetId[groupKey] = songId;
+        },
+
+        canMerge(groupKey) {
+            const selected = this.selectedIds[groupKey] || [];
+            return selected.length >= 2 && this.targetId[groupKey] && selected.includes(this.targetId[groupKey]);
+        },
+
+        async mergeGroup(group) {
+            const groupKey = this.groupKey(group);
+            if (!this.canMerge(groupKey)) return;
+
+            const target = group.songs.find(s => s.id === this.targetId[groupKey]);
+            const sources = this.selectedIds[groupKey].filter(id => id !== this.targetId[groupKey]);
+
+            if (!confirm(`「${target.artist || '(アーティスト未設定)'}」に統合します。${sources.length}件の楽曲が削除されます。よろしいですか？`)) {
+                return;
+            }
+
+            this.merging[groupKey] = true;
+            this.message = null;
+
+            try {
+                for (const sourceId of sources) {
+                    const res = await fetch('/api/songs/merge', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRF-TOKEN': csrfToken,
+                        },
+                        body: JSON.stringify({
+                            source_song_id: sourceId,
+                            target_song_id: this.targetId[groupKey],
+                        }),
+                    });
+                    if (!res.ok) {
+                        const data = await res.json();
+                        throw new Error(data.message || 'マージに失敗しました');
+                    }
+                }
+                this.message = `${sources.length}件の楽曲を統合しました`;
+                this.messageType = 'success';
+                await this.fetchTitleGroups();
+            } catch (e) {
+                this.message = e.message;
+                this.messageType = 'error';
+            } finally {
+                this.merging[groupKey] = false;
+            }
+        },
+
+        async reviewGroup(group, decision) {
+            const label = decision === 'pending' ? '保留' : '別の曲';
+            if (!confirm(`このグループを「${label}」として記録します。よろしいですか？`)) return;
+
+            this.message = null;
+            try {
+                const res = await fetch('/api/songs/cleansing/title-groups/review', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': csrfToken,
+                    },
+                    body: JSON.stringify({
+                        normalized_title: group.normalized_title,
+                        song_ids: group.songs.map(s => s.id),
+                        decision,
+                    }),
+                });
+                if (!res.ok) {
+                    const data = await res.json();
+                    throw new Error(data.message || '記録に失敗しました');
+                }
+                const data = await res.json();
+                this.message = data.message;
+                this.messageType = 'success';
+                this.groups = this.groups.filter(g => this.groupKey(g) !== this.groupKey(group));
+            } catch (e) {
+                this.message = e.message;
+                this.messageType = 'error';
+            }
+        },
+    }));
+});

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -28,6 +28,12 @@
                         <x-nav-link :href="route('songs.decompose')" :active="request()->routeIs('songs.decompose')">
                             {{ __('TS分解') }}
                         </x-nav-link>
+                        <x-nav-link :href="route('songs.duplicates')" :active="request()->routeIs('songs.duplicates')">
+                            {{ __('名寄せ') }}
+                        </x-nav-link>
+                        <x-nav-link :href="route('songs.cleansing')" :active="request()->routeIs('songs.cleansing')">
+                            {{ __('クレンジング') }}
+                        </x-nav-link>
                     @endif
                     <x-nav-link :href="route('markdown.show')" :active="request()->routeIs('markdown.show')" class="text-center">
                         {{ __('利用規約・') }}<br/>
@@ -114,6 +120,12 @@
                 </x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('songs.decompose')" :active="request()->routeIs('songs.decompose')">
                     {{ __('TS分解') }}
+                </x-responsive-nav-link>
+                <x-responsive-nav-link :href="route('songs.duplicates')" :active="request()->routeIs('songs.duplicates')">
+                    {{ __('名寄せ') }}
+                </x-responsive-nav-link>
+                <x-responsive-nav-link :href="route('songs.cleansing')" :active="request()->routeIs('songs.cleansing')">
+                    {{ __('クレンジング') }}
                 </x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('markdown.show')" :active="request()->routeIs('markdown.show')">
                     {{ __('利用規約・プライバシーポリシー') }}

--- a/resources/views/songs/cleansing.blade.php
+++ b/resources/views/songs/cleansing.blade.php
@@ -1,0 +1,204 @@
+<x-app-layout>
+    <div class="py-4" id="cleansing-app" x-data="cleansingApp">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            {{-- ヘッダー --}}
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg mb-4">
+                <div class="p-4 text-gray-900 dark:text-gray-100">
+                    <div class="flex items-center justify-between">
+                        <h3 class="text-lg font-semibold">楽曲マスタクレンジング</h3>
+                        <div class="flex gap-2 text-sm">
+                            <a href="{{ route('songs.index') }}" class="text-blue-600 hover:underline">正規化画面</a>
+                            <a href="{{ route('songs.duplicates') }}" class="text-blue-600 hover:underline">名寄せ画面</a>
+                            <a href="{{ route('songs.decompose') }}" class="text-blue-600 hover:underline">分解画面</a>
+                        </div>
+                    </div>
+
+                    {{-- タブ --}}
+                    <div class="flex gap-1 mt-3 border-b border-gray-200 dark:border-gray-700">
+                        <button @click="switchTab('rename')"
+                                class="px-4 py-2 text-sm font-medium border-b-2 -mb-px"
+                                :class="tab === 'rename' ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'">
+                            アーティスト名一括変換
+                        </button>
+                        <button @click="switchTab('groups')"
+                                class="px-4 py-2 text-sm font-medium border-b-2 -mb-px"
+                                :class="tab === 'groups' ? 'border-blue-600 text-blue-600' : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'">
+                            同名異表記グループ
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            {{-- メッセージ --}}
+            <template x-if="message">
+                <div class="mb-4 p-3 rounded-md text-sm"
+                     :class="messageType === 'success' ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200' : 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'"
+                     x-text="message"></div>
+            </template>
+
+            {{-- アーティスト名一括変換 --}}
+            <div x-show="tab === 'rename'" class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-4 text-gray-900 dark:text-gray-100">
+                    <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                        変換前のアーティスト名（例: maaya sakamoto）が付いた楽曲マスタを、まとめて変換後の名前（例: 坂本真綾）に統一します。
+                        変換後の名前で既に同じ曲名のマスタが存在する場合は、そちらへタイムスタンプの紐付けを移行し、変換元のマスタを削除します。
+                    </p>
+
+                    <div class="flex flex-wrap gap-2 mb-3">
+                        <input type="text"
+                               x-model="renameFrom"
+                               placeholder="変換前のアーティスト名（完全一致）"
+                               class="flex-1 min-w-[200px] px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm">
+                        <span class="self-center text-gray-400">→</span>
+                        <input type="text"
+                               x-model="renameTo"
+                               @keydown.enter="previewRename()"
+                               placeholder="変換後のアーティスト名"
+                               class="flex-1 min-w-[200px] px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm">
+                        <button @click="previewRename()"
+                                :disabled="renamePreviewing || !renameFrom.trim() || !renameTo.trim()"
+                                class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700 disabled:opacity-50">
+                            プレビュー
+                        </button>
+                    </div>
+
+                    <template x-if="renamePreviewing">
+                        <div class="text-center py-4 text-gray-500 dark:text-gray-400 text-sm">確認中...</div>
+                    </template>
+
+                    <template x-if="renamePlan && renamePlan.plan.length > 0">
+                        <div>
+                            <div class="mb-2 text-sm text-gray-600 dark:text-gray-400">
+                                リネームのみ: <span x-text="renamePlan.rename_count"></span>件 /
+                                統合が必要: <span x-text="renamePlan.merge_count"></span>件
+                            </div>
+                            <div class="space-y-1 max-h-[50vh] overflow-y-auto mb-3">
+                                <template x-for="item in renamePlan.plan" :key="item.song_id">
+                                    <div class="flex items-center justify-between p-2 border border-gray-200 dark:border-gray-700 rounded-md text-sm">
+                                        <span x-text="item.title"></span>
+                                        <span class="text-xs px-2 py-0.5 rounded"
+                                              :class="item.action === 'merge' ? 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300' : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'"
+                                              x-text="item.action === 'merge' ? '統合' : 'リネーム'"></span>
+                                    </div>
+                                </template>
+                            </div>
+                            <button @click="executeRename()"
+                                    :disabled="renameExecuting"
+                                    class="px-4 py-2 bg-orange-600 text-white text-sm rounded-md hover:bg-orange-700 disabled:opacity-50">
+                                <span x-show="!renameExecuting">実行する</span>
+                                <span x-show="renameExecuting">実行中...</span>
+                            </button>
+                        </div>
+                    </template>
+                </div>
+            </div>
+
+            {{-- 同名異表記グループ --}}
+            <div x-show="tab === 'groups'" class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-4 text-gray-900 dark:text-gray-100">
+                    <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                        同じ曲名で複数のアーティスト表記のマスタが存在するグループです。同じ曲であれば選択してマージ、
+                        別の曲であれば「別の曲」、判断がつかない場合は「保留」を選んでください。
+                    </p>
+
+                    <div class="flex flex-wrap items-center gap-2 mb-3">
+                        <input type="text"
+                               x-model="groupSearch"
+                               @keydown.enter="fetchTitleGroups()"
+                               placeholder="タイトルで絞り込み..."
+                               class="flex-1 min-w-[200px] px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm">
+                        <button @click="fetchTitleGroups()"
+                                class="px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700">
+                            検索
+                        </button>
+                        <div class="flex gap-1 ml-auto">
+                            <button @click="setFilter('active')"
+                                    class="px-3 py-1 text-sm rounded"
+                                    :class="groupFilter === 'active' ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600'">
+                                未処理
+                            </button>
+                            <button @click="setFilter('pending')"
+                                    class="px-3 py-1 text-sm rounded"
+                                    :class="groupFilter === 'pending' ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600'">
+                                保留中
+                            </button>
+                        </div>
+                    </div>
+
+                    <template x-if="groupsLoading">
+                        <div class="text-center py-4 text-gray-500 dark:text-gray-400 text-sm">読み込み中...</div>
+                    </template>
+
+                    <template x-if="!groupsLoading && groups.length === 0">
+                        <div class="text-center py-4 text-gray-500 dark:text-gray-400 text-sm">対象のグループはありません</div>
+                    </template>
+
+                    <div class="space-y-3 max-h-[70vh] overflow-y-auto">
+                        <template x-for="group in groups" :key="groupKey(group)">
+                            <div class="border border-gray-200 dark:border-gray-700 rounded-md p-3">
+                                <div class="flex items-center justify-between mb-2">
+                                    <div class="font-medium text-sm" x-text="group.normalized_title"></div>
+                                    <div class="flex gap-2">
+                                        <button @click="mergeGroup(group)"
+                                                :disabled="!canMerge(groupKey(group)) || merging[groupKey(group)]"
+                                                class="px-3 py-1 text-xs rounded-md bg-orange-600 text-white hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed">
+                                            <span x-show="!merging[groupKey(group)]">同じ曲としてマージ</span>
+                                            <span x-show="merging[groupKey(group)]">マージ中...</span>
+                                        </button>
+                                        <button @click="reviewGroup(group, 'pending')"
+                                                class="px-3 py-1 text-xs rounded-md bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600">
+                                            保留
+                                        </button>
+                                        <button @click="reviewGroup(group, 'distinct')"
+                                                class="px-3 py-1 text-xs rounded-md bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600">
+                                            別の曲
+                                        </button>
+                                    </div>
+                                </div>
+
+                                <div class="space-y-1">
+                                    <template x-for="song in group.songs" :key="song.id">
+                                        <div class="flex items-center gap-2 p-2 border rounded-md transition-colors"
+                                             :class="{
+                                                 'border-blue-500 bg-blue-50 dark:bg-blue-900/20': isSelected(groupKey(group), song.id),
+                                                 'border-orange-500 bg-orange-50 dark:bg-orange-900/20 ring-2 ring-orange-300': targetId[groupKey(group)] === song.id,
+                                                 'border-gray-200 dark:border-gray-700': !isSelected(groupKey(group), song.id)
+                                             }">
+                                            <input type="checkbox"
+                                                   :checked="isSelected(groupKey(group), song.id)"
+                                                   @change="toggleSelect(groupKey(group), song.id)"
+                                                   class="w-4 h-4 flex-shrink-0 text-blue-600 rounded focus:ring-blue-500">
+
+                                            <div class="flex-1 min-w-0">
+                                                <div class="text-sm font-medium truncate" x-text="song.title"></div>
+                                                <div class="text-xs text-gray-500 dark:text-gray-400 truncate" x-text="song.artist || '(アーティスト未設定)'"></div>
+                                                <div class="flex gap-2 mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+                                                    <span>MP: <span x-text="song.mappings_count"></span></span>
+                                                    <span>TS: <span x-text="song.ts_items_count"></span></span>
+                                                    <template x-if="song.spotify_track_id">
+                                                        <span class="text-green-600">Spotify</span>
+                                                    </template>
+                                                </div>
+                                            </div>
+
+                                            <button x-show="isSelected(groupKey(group), song.id)"
+                                                    @click="setTarget(groupKey(group), song.id)"
+                                                    class="flex-shrink-0 px-2 py-1 text-xs rounded-md transition-colors"
+                                                    :class="targetId[groupKey(group)] === song.id
+                                                        ? 'bg-orange-600 text-white'
+                                                        : 'bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 hover:bg-orange-100 dark:hover:bg-orange-900/30'"
+                                                    x-text="targetId[groupKey(group)] === song.id ? 'マージ先' : '残す'">
+                                            </button>
+                                        </div>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @vite(['resources/js/songs/cleansing.js'])
+</x-app-layout>

--- a/resources/views/songs/duplicates.blade.php
+++ b/resources/views/songs/duplicates.blade.php
@@ -9,6 +9,7 @@
                         <div class="flex gap-2 text-sm">
                             <a href="{{ route('songs.index') }}" class="text-blue-600 hover:underline">正規化画面</a>
                             <a href="{{ route('songs.decompose') }}" class="text-blue-600 hover:underline">分解画面</a>
+                            <a href="{{ route('songs.cleansing') }}" class="text-blue-600 hover:underline">クレンジング画面</a>
                         </div>
                     </div>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,7 @@ Route::middleware(['auth', 'admin'])->group(function () {
     // 楽曲マスタ管理
     Route::get('/songs/normalize', [SongController::class, 'index'])->name('songs.index');
     Route::get('/songs/duplicates', [SongController::class, 'duplicates'])->name('songs.duplicates');
+    Route::get('/songs/cleansing', [SongController::class, 'cleansing'])->name('songs.cleansing');
 
     // タイムスタンプ分解・選別
     Route::get('/songs/decompose', [TimestampDecompositionController::class, 'index'])->name('songs.decompose');
@@ -143,6 +144,10 @@ Route::middleware(['auth', 'admin'])->group(function () {
     Route::get('api/songs/duplicates', [SongController::class, 'findDuplicates'])->name('songs.findDuplicates');
     Route::get('api/songs/search-for-merge', [SongController::class, 'searchSongsForMerge'])->name('songs.searchForMerge');
     Route::post('api/songs/merge', [SongController::class, 'mergeSongs'])->name('songs.mergeSongs');
+    Route::get('api/songs/cleansing/artist-rename-preview', [SongController::class, 'previewArtistRename'])->name('songs.previewArtistRename');
+    Route::post('api/songs/cleansing/artist-rename', [SongController::class, 'renameArtist'])->name('songs.renameArtist');
+    Route::get('api/songs/cleansing/title-groups', [SongController::class, 'findTitleGroups'])->name('songs.findTitleGroups');
+    Route::post('api/songs/cleansing/title-groups/review', [SongController::class, 'reviewTitleGroup'])->name('songs.reviewTitleGroup');
     // Parameterized route - must be last to avoid capturing specific route names
     Route::put('api/songs/{id}', [SongController::class, 'updateSong'])->name('songs.updateSong');
     Route::delete('api/songs/{id}', [SongController::class, 'deleteSong'])->name('songs.deleteSong');

--- a/tests/Feature/SongCleansingTest.php
+++ b/tests/Feature/SongCleansingTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Song;
+use App\Models\TimestampSongMapping;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SongCleansingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create([
+            'email_verified_at' => now(),
+            'role' => User::ROLE_SUPER_ADMIN,
+        ]);
+    }
+
+    public function test_preview_artist_rename_without_conflict(): void
+    {
+        Song::factory()->create(['title' => 'Yoru ni Kakeru', 'artist' => 'maaya sakamoto']);
+        Song::factory()->create(['title' => 'Loop', 'artist' => 'maaya sakamoto']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/songs/cleansing/artist-rename-preview?'.http_build_query([
+                'from' => 'maaya sakamoto',
+                'to' => '坂本真綾',
+            ]));
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertEquals(2, $data['rename_count']);
+        $this->assertEquals(0, $data['merge_count']);
+        foreach ($data['plan'] as $item) {
+            $this->assertEquals('rename', $item['action']);
+            $this->assertNull($item['conflict_song_id']);
+        }
+    }
+
+    public function test_preview_artist_rename_with_conflict(): void
+    {
+        Song::factory()->create(['title' => 'Yoru ni Kakeru', 'artist' => 'maaya sakamoto']);
+        $existing = Song::factory()->create(['title' => 'Yoru ni Kakeru', 'artist' => '坂本真綾']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/songs/cleansing/artist-rename-preview?'.http_build_query([
+                'from' => 'maaya sakamoto',
+                'to' => '坂本真綾',
+            ]));
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertEquals(0, $data['rename_count']);
+        $this->assertEquals(1, $data['merge_count']);
+        $this->assertEquals($existing->id, $data['plan'][0]['conflict_song_id']);
+    }
+
+    public function test_rename_artist_renames_without_conflict(): void
+    {
+        $song = Song::factory()->create(['title' => 'Loop', 'artist' => 'maaya sakamoto']);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/songs/cleansing/artist-rename', [
+                'from' => 'maaya sakamoto',
+                'to' => '坂本真綾',
+            ]);
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertCount(1, $data['renamed']);
+        $this->assertCount(0, $data['merged']);
+
+        $song->refresh();
+        $this->assertEquals('坂本真綾', $song->artist);
+    }
+
+    public function test_rename_artist_merges_on_conflict(): void
+    {
+        $source = Song::factory()->create(['title' => 'Yoru ni Kakeru', 'artist' => 'maaya sakamoto']);
+        $target = Song::factory()->create(['title' => 'Yoru ni Kakeru', 'artist' => '坂本真綾']);
+
+        TimestampSongMapping::factory()
+            ->withSong($source)
+            ->withText('yoru ni kakeru maaya')
+            ->create();
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/songs/cleansing/artist-rename', [
+                'from' => 'maaya sakamoto',
+                'to' => '坂本真綾',
+            ]);
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertCount(0, $data['renamed']);
+        $this->assertCount(1, $data['merged']);
+        $this->assertEquals(1, $data['merged'][0]['affected_mappings']);
+
+        $this->assertDatabaseMissing('songs', ['id' => $source->id]);
+        $this->assertEquals(1, TimestampSongMapping::where('song_id', $target->id)->count());
+
+        $this->assertDatabaseHas('normalization_logs', [
+            'action' => 'rename_artist',
+        ]);
+    }
+
+    public function test_rename_artist_rejects_same_from_and_to(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/songs/cleansing/artist-rename', [
+                'from' => 'maaya sakamoto',
+                'to' => 'maaya sakamoto',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['to']);
+    }
+
+    public function test_find_title_groups_returns_multi_artist_titles(): void
+    {
+        Song::factory()->create(['title' => '会いたかった', 'artist' => 'A']);
+        Song::factory()->create(['title' => '会いたかった', 'artist' => 'B']);
+        Song::factory()->create(['title' => 'Unique Title', 'artist' => 'C']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/songs/cleansing/title-groups');
+
+        $response->assertStatus(200);
+        $data = $response->json();
+        $this->assertCount(1, $data);
+        $this->assertCount(2, $data[0]['songs']);
+    }
+
+    public function test_review_title_group_as_distinct_hides_it_from_active_filter(): void
+    {
+        $songA = Song::factory()->create(['title' => '会いたかった', 'artist' => 'A']);
+        $songB = Song::factory()->create(['title' => '会いたかった', 'artist' => 'B']);
+
+        $reviewResponse = $this->actingAs($this->user)
+            ->postJson('/api/songs/cleansing/title-groups/review', [
+                'normalized_title' => $songA->normalized_title,
+                'song_ids' => [$songA->id, $songB->id],
+                'decision' => 'distinct',
+            ]);
+
+        $reviewResponse->assertStatus(200);
+
+        $activeResponse = $this->actingAs($this->user)
+            ->getJson('/api/songs/cleansing/title-groups?filter=active');
+        $activeResponse->assertStatus(200)->assertJsonCount(0);
+
+        $this->assertDatabaseHas('normalization_logs', [
+            'action' => 'review_song_group',
+        ]);
+    }
+
+    public function test_review_title_group_as_pending_moves_it_to_pending_filter(): void
+    {
+        $songA = Song::factory()->create(['title' => '会いたかった', 'artist' => 'A']);
+        $songB = Song::factory()->create(['title' => '会いたかった', 'artist' => 'B']);
+
+        $this->actingAs($this->user)
+            ->postJson('/api/songs/cleansing/title-groups/review', [
+                'normalized_title' => $songA->normalized_title,
+                'song_ids' => [$songA->id, $songB->id],
+                'decision' => 'pending',
+            ])->assertStatus(200);
+
+        $this->actingAs($this->user)
+            ->getJson('/api/songs/cleansing/title-groups?filter=active')
+            ->assertStatus(200)->assertJsonCount(0);
+
+        $this->actingAs($this->user)
+            ->getJson('/api/songs/cleansing/title-groups?filter=pending')
+            ->assertStatus(200)->assertJsonCount(1);
+    }
+
+    public function test_review_title_group_rejects_single_song(): void
+    {
+        $song = Song::factory()->create(['title' => 'Solo', 'artist' => 'A']);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/songs/cleansing/title-groups/review', [
+                'normalized_title' => $song->normalized_title,
+                'song_ids' => [$song->id],
+                'decision' => 'distinct',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['song_ids']);
+    }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,7 @@ export default defineConfig(() => {
                     'resources/js/songs/normalize.js',
                     'resources/js/songs/decompose.js',
                     'resources/js/songs/duplicates.js',
+                    'resources/js/songs/cleansing.js',
                 ],
                 refresh: true,
             }),


### PR DESCRIPTION
@CodiumAI-Agent /improve

## Summary

不完全な自動登録処理により、楽曲マスタに「アーティスト名が空白」「日本語名義の曲がローマ字表記で別マスタとして登録されている」といった表記ゆれ・重複が発生している問題に対応するため、既存の名寄せ画面（`/songs/duplicates`）とは別に、以下2機能を持つクレンジング画面（`/songs/cleansing`）を追加します。

- **アーティスト名一括変換**
  例: `maaya sakamoto` 名義の楽曲をまとめて `坂本真綾` に変換。変換後の名前で既に同一タイトルのマスタが存在する場合は、そちらへタイムスタンプの紐付け（`timestamp_song_mappings` / `ts_items.song_id`）を自動で移行し、変換元マスタを削除します（内部的に既存の `SongMergeService::merge()` を再利用）。プレビューで「リネームのみ」「統合が必要」の内訳を確認してから実行する2段階フローです。
- **同名異表記グループの判定**
  同じタイトルで複数のアーティスト名義のマスタが存在するグループを検出して一覧表示し、「同じ曲としてマージ」「別の曲」「保留」のいずれかを選べるようにします。「別の曲」「保留」の判定は `song_group_reviews` テーブルに記録し、以後同じ組み合わせは（保留は保留一覧として、別の曲は恒久的に）候補一覧に出さないようにします。

### スコープ外にしたもの

会話の中で出た以下のアイデアは、今回のクレンジング対応とは別軸の課題のため、Issueとして切り出しています（今回のPRには含めていません）。

- 表記統一ポリシー自体（記号統一・feat.表記・出典タイトル付与などの「軸」の是非）
- タイムスタンプの出現頻度から代表表記を候補提示する仕組み → #711

## 変更内容

- `app/Services/SongCleansingService.php` を新規追加（アーティスト名一括変換のプレビュー/実行、同名異表記グループの検出/判定）
- `app/Models/SongGroupReview.php` を新規追加、`song_group_reviews` テーブルのマイグレーションを追加
- `SongController` にクレンジング画面用のアクションを追加、`routes/web.php` にルートを追加
- `resources/views/songs/cleansing.blade.php` / `resources/js/songs/cleansing.js` を新規追加（既存の `duplicates.blade.php` / `duplicates.js` のAlpine.jsパターンを踏襲）
- `vite.config.js` の `input` に新規JSを追加
- `duplicates.blade.php` のヘッダーナビにクレンジング画面へのリンクを追加
- `NormalizationLog` に `rename_artist` / `review_song_group` アクション定数を追加

## Test plan

- [x] `php artisan test tests/Feature/SongCleansingTest.php`（新規9件）が全てパス
- [x] `php artisan test`（全体）で、このブランチ由来の新規失敗がないことを確認（`develop` ブランチと同じ37件の既存失敗のみ。環境に `.env` が無い/フロントエンドビルド成果物が無いサンドボックス起因の既存問題で、本PRの変更とは無関係）
- [x] `./vendor/bin/pint --test` パス
- [ ] 実際のブラウザでの動作確認（この環境では未実施）


---
_Generated by [Claude Code](https://claude.ai/code/session_015fQ6KkYrezF2fLaBXVXWvG)_