### PR TITLE
fix: linkToSong() でアーティスト空の楽曲マスタ作成を防止する

### DIFF
--- a/app/Services/TimestampDecompositionService.php
+++ b/app/Services/TimestampDecompositionService.php
@@ -721,6 +721,8 @@ class TimestampDecompositionService
         TimestampDecomposition::where('status', TimestampDecomposition::STATUS_AUTO_MATCHED)
             ->whereNull('song_id')
             ->whereNotNull('derived_title')
+            ->where('derived_artist', '!=', '')
+            ->whereNotNull('derived_artist')
             ->chunk(100, function ($decompositions) use (&$count) {
                 foreach ($decompositions as $decomposition) {
                     try {

--- a/app/Services/TimestampDecompositionService.php
+++ b/app/Services/TimestampDecompositionService.php
@@ -582,13 +582,13 @@ class TimestampDecompositionService
         $title = $decomposition->derived_title;
         $artist = $decomposition->derived_artist ?? '';
 
-        if ($artist === '') {
-            return null;
-        }
-
         // 正規化済みテキストで既存楽曲を検索（文字バリエーションによる重複を防止）
         $normalizedTitle = TextNormalizer::normalize($title);
         $normalizedArtist = TextNormalizer::normalize($artist);
+
+        if ($normalizedArtist === '') {
+            return null;
+        }
 
         $song = Song::where('normalized_title', $normalizedTitle)
             ->where('normalized_artist', $normalizedArtist)

--- a/app/Services/TimestampDecompositionService.php
+++ b/app/Services/TimestampDecompositionService.php
@@ -582,6 +582,10 @@ class TimestampDecompositionService
         $title = $decomposition->derived_title;
         $artist = $decomposition->derived_artist ?? '';
 
+        if ($artist === '') {
+            return null;
+        }
+
         // 正規化済みテキストで既存楽曲を検索（文字バリエーションによる重複を防止）
         $normalizedTitle = TextNormalizer::normalize($title);
         $normalizedArtist = TextNormalizer::normalize($artist);

--- a/resources/js/songs/decompose.js
+++ b/resources/js/songs/decompose.js
@@ -701,7 +701,9 @@ class TimestampDecomposition {
             this.updateUndoButton();
 
             const cascadedCount = response.data.cascaded_count || 0;
-            if (cascadedCount > 0) {
+            if (!response.data.song) {
+                toast.warning('保存しました（アーティスト未指定のため楽曲マスタには未登録）');
+            } else if (cascadedCount > 0) {
                 toast.success(`保存しました（同じアーティストの ${cascadedCount} 件も自動処理）`);
             } else {
                 toast.success('保存しました');
@@ -753,7 +755,7 @@ class TimestampDecomposition {
 
         try {
             this.showLoading();
-            await axios.post('/api/songs/decompose/whole-title', {
+            const response = await axios.post('/api/songs/decompose/whole-title', {
                 id: this.currentItem.id,
                 link_to_song: true
             });
@@ -766,7 +768,11 @@ class TimestampDecomposition {
             };
             this.updateUndoButton();
 
-            toast.success('全体を楽曲名として登録しました');
+            if (!response.data.song) {
+                toast.warning('登録しました（アーティスト未指定のため楽曲マスタには未登録）');
+            } else {
+                toast.success('全体を楽曲名として登録しました');
+            }
             await this.loadStatistics();
             await this.loadNext();
         } catch (error) {

--- a/tests/Unit/Services/TimestampDecompositionServiceTest.php
+++ b/tests/Unit/Services/TimestampDecompositionServiceTest.php
@@ -777,6 +777,108 @@ class TimestampDecompositionServiceTest extends TestCase
      * "Official髭男dism" の "official" が無視キーワードとして部分一致すると、
      * アーティスト名なしで自動確定され、アーティスト名が空の楽曲マスタが作られてしまう
      */
+    public function test_link_to_song_skips_when_artist_is_empty(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $decomposition = TimestampDecomposition::create([
+            'id' => (string) Str::ulid(),
+            'normalized_text' => TextNormalizer::normalize('Night of Fire'),
+            'original_text' => 'Night of Fire',
+            'parts' => ['Night of Fire'],
+            'separator_count' => 0,
+            'status' => TimestampDecomposition::STATUS_SELECTED,
+            'confidence' => 1.0,
+            'derived_title' => 'Night of Fire',
+            'derived_artist' => null,
+        ]);
+
+        $result = $this->service->linkToSong($decomposition);
+
+        $this->assertNull($result);
+        $this->assertDatabaseCount('songs', 0);
+        $this->assertDatabaseCount('timestamp_song_mappings', 0);
+        $decomposition->refresh();
+        $this->assertNull($decomposition->song_id);
+    }
+
+    public function test_link_to_song_skips_when_artist_is_empty_string(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $decomposition = TimestampDecomposition::create([
+            'id' => (string) Str::ulid(),
+            'normalized_text' => TextNormalizer::normalize('Yesterday'),
+            'original_text' => 'Yesterday',
+            'parts' => ['Yesterday'],
+            'separator_count' => 0,
+            'status' => TimestampDecomposition::STATUS_SELECTED,
+            'confidence' => 1.0,
+            'derived_title' => 'Yesterday',
+            'derived_artist' => '',
+        ]);
+
+        $result = $this->service->linkToSong($decomposition);
+
+        $this->assertNull($result);
+        $this->assertDatabaseCount('songs', 0);
+        $this->assertDatabaseCount('timestamp_song_mappings', 0);
+    }
+
+    public function test_link_to_song_works_when_artist_is_present(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $decomposition = TimestampDecomposition::create([
+            'id' => (string) Str::ulid(),
+            'normalized_text' => TextNormalizer::normalize('Night of Fire / HINOI Team'),
+            'original_text' => 'Night of Fire / HINOI Team',
+            'parts' => ['Night of Fire', 'HINOI Team'],
+            'separator_count' => 1,
+            'status' => TimestampDecomposition::STATUS_SELECTED,
+            'confidence' => 1.0,
+            'derived_title' => 'Night of Fire',
+            'derived_artist' => 'HINOI Team',
+        ]);
+
+        $result = $this->service->linkToSong($decomposition);
+
+        $this->assertNotNull($result);
+        $this->assertEquals('Night of Fire', $result->title);
+        $this->assertEquals('HINOI Team', $result->artist);
+        $this->assertDatabaseCount('songs', 1);
+        $this->assertDatabaseCount('timestamp_song_mappings', 1);
+    }
+
+    public function test_bulk_link_auto_matched_does_not_create_song_when_artist_is_empty(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // derived_title あり・derived_artist なしの AUTO_MATCHED レコード
+        TimestampDecomposition::create([
+            'id' => (string) Str::ulid(),
+            'normalized_text' => TextNormalizer::normalize('YOASOBI'),
+            'original_text' => 'cover / YOASOBI',
+            'parts' => ['cover', 'YOASOBI'],
+            'separator_count' => 1,
+            'status' => TimestampDecomposition::STATUS_AUTO_MATCHED,
+            'confidence' => 0.8,
+            'derived_title' => 'YOASOBI',
+            'derived_artist' => null,
+            'title_part_index' => 1,
+        ]);
+
+        $count = $this->service->bulkLinkAutoMatched();
+
+        $this->assertEquals(0, $count);
+        $this->assertDatabaseCount('songs', 0);
+        $this->assertDatabaseCount('timestamp_song_mappings', 0);
+    }
+
     public function test_scan_does_not_auto_match_artist_containing_ignore_keyword(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Services/TimestampDecompositionServiceTest.php
+++ b/tests/Unit/Services/TimestampDecompositionServiceTest.php
@@ -771,12 +771,6 @@ class TimestampDecompositionServiceTest extends TestCase
         $this->assertNull($saved->artist_part_index);
     }
 
-    /**
-     * 無視キーワードを語の一部に含むアーティスト名が自動判定で捨てられないことをテスト
-     *
-     * "Official髭男dism" の "official" が無視キーワードとして部分一致すると、
-     * アーティスト名なしで自動確定され、アーティスト名が空の楽曲マスタが作られてしまう
-     */
     public function test_link_to_song_skips_when_artist_is_empty(): void
     {
         $user = User::factory()->create();
@@ -818,6 +812,30 @@ class TimestampDecompositionServiceTest extends TestCase
             'confidence' => 1.0,
             'derived_title' => 'Yesterday',
             'derived_artist' => '',
+        ]);
+
+        $result = $this->service->linkToSong($decomposition);
+
+        $this->assertNull($result);
+        $this->assertDatabaseCount('songs', 0);
+        $this->assertDatabaseCount('timestamp_song_mappings', 0);
+    }
+
+    public function test_link_to_song_skips_when_artist_is_whitespace_only(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $decomposition = TimestampDecomposition::create([
+            'id' => (string) Str::ulid(),
+            'normalized_text' => TextNormalizer::normalize('Yesterday'),
+            'original_text' => 'Yesterday',
+            'parts' => ['Yesterday'],
+            'separator_count' => 0,
+            'status' => TimestampDecomposition::STATUS_SELECTED,
+            'confidence' => 1.0,
+            'derived_title' => 'Yesterday',
+            'derived_artist' => '　',
         ]);
 
         $result = $this->service->linkToSong($decomposition);
@@ -879,6 +897,12 @@ class TimestampDecompositionServiceTest extends TestCase
         $this->assertDatabaseCount('timestamp_song_mappings', 0);
     }
 
+    /**
+     * 無視キーワードを語の一部に含むアーティスト名が自動判定で捨てられないことをテスト
+     *
+     * "Official髭男dism" の "official" が無視キーワードとして部分一致すると、
+     * アーティスト名なしで自動確定され、アーティスト名が空の楽曲マスタが作られてしまう
+     */
     public function test_scan_does_not_auto_match_artist_containing_ignore_keyword(): void
     {
         $user = User::factory()->create();

--- a/tests/Unit/Services/TimestampDecompositionServiceTest.php
+++ b/tests/Unit/Services/TimestampDecompositionServiceTest.php
@@ -897,6 +897,30 @@ class TimestampDecompositionServiceTest extends TestCase
         $this->assertDatabaseCount('timestamp_song_mappings', 0);
     }
 
+    public function test_bulk_link_auto_matched_does_not_create_song_when_artist_is_empty_string(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        TimestampDecomposition::create([
+            'id' => (string) Str::ulid(),
+            'normalized_text' => TextNormalizer::normalize('夜に駆ける'),
+            'original_text' => '夜に駆ける',
+            'parts' => ['夜に駆ける'],
+            'separator_count' => 0,
+            'status' => TimestampDecomposition::STATUS_AUTO_MATCHED,
+            'confidence' => 0.8,
+            'derived_title' => '夜に駆ける',
+            'derived_artist' => '',
+            'title_part_index' => 0,
+        ]);
+
+        $count = $this->service->bulkLinkAutoMatched();
+
+        $this->assertEquals(0, $count);
+        $this->assertDatabaseCount('songs', 0);
+    }
+
     /**
      * 無視キーワードを語の一部に含むアーティスト名が自動判定で捨てられないことをテスト
      *


### PR DESCRIPTION
## Summary

- `linkToSong()` で `derived_artist` が空（null / 空文字 / 空白のみ）の場合に早期リターンし、アーティスト名が空の楽曲マスタが作成されるのを防止
- 正規化後の値（`normalizedArtist`）で判定することで、全角スペースのみなど「実質空」のケースも捕捉
- `bulkLinkAutoMatched()` でアーティスト空のレコードをクエリレベルでスキップし、無限再処理を防止
- フロントエンドで楽曲マスタに未登録の場合（song === null）に警告トーストを表示し、サイレントなデータロストを防止

Closes #639

## 対応範囲

Issue #639 の対応案のうち「空アーティストの Song 作成防止」と「フロントエンドでの警告表示」を対応。以下は未対応（Issue #639 に残存）:
- 「全体を楽曲名」で title にアーティスト名が混入するケースの扱い
- 選別画面でのアーティスト未選択時の確認ダイアログ
- 既存の空アーティストマスタのクリーンアップ

## Test plan

- [x] `test_link_to_song_skips_when_artist_is_empty` — `derived_artist = null` で楽曲マスタが作られないこと
- [x] `test_link_to_song_skips_when_artist_is_empty_string` — `derived_artist = ''` で楽曲マスタが作られないこと
- [x] `test_link_to_song_skips_when_artist_is_whitespace_only` — `derived_artist = '　'`（全角スペース）で楽曲マスタが作られないこと
- [x] `test_link_to_song_works_when_artist_is_present` — アーティストありの場合は正常に動作すること
- [x] `test_bulk_link_auto_matched_does_not_create_song_when_artist_is_empty` — 一括処理でもガードが効くこと（null）
- [x] `test_bulk_link_auto_matched_does_not_create_song_when_artist_is_empty_string` — 一括処理でもガードが効くこと（空文字列）

🤖 Generated with [Claude Code](https://claude.com/claude-code)